### PR TITLE
feat(session): prepare user databases asynchronously

### DIFF
--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -23,6 +23,8 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.services.SendPendingMessagesAfterForegroundSyncUseCase
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
@@ -69,6 +71,7 @@ class GlobalObserversManager @Inject constructor(
 ) {
     // TODO(tests): refactor so scope/dispatcher can be injected and properly stopped
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.io())
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     fun observe() {
         scope.launch { setUpNotifications() }
@@ -76,7 +79,9 @@ class GlobalObserversManager @Inject constructor(
             coreLogic.getGlobalScope().observeValidAccounts().distinctUntilChanged().collectLatest {
                 coroutineScope {
                     it.forEach {
-                        launch { coreLogic.getSessionScope(it.first.id).calls.endCallOnConversationChange() }
+                        launch {
+                            preparedSessionScope(it.first.id)?.calls?.endCallOnConversationChange()
+                        }
                     }
                 }
             }
@@ -165,7 +170,7 @@ class GlobalObserversManager @Inject constructor(
                         emptyFlow()
                     }
                 }
-                .collect { userId -> coreLogic.getSessionScope(userId).messages.deleteEphemeralMessageEndDate() }
+                .collect { userId -> preparedSessionScope(userId)?.messages?.deleteEphemeralMessageEndDate() }
         }
     }
 
@@ -200,4 +205,13 @@ class GlobalObserversManager @Inject constructor(
     private companion object {
         private const val TAG = "GlobalObserversManager"
     }
+
+    private suspend fun preparedSessionScope(userId: UserId) =
+        when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("$TAG skipping database observer for ${userId.toLogString()}: ${result.reason}")
+                null
+            }
+        }
 }

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -42,6 +42,8 @@ import com.wire.android.feature.analytics.AnonymousAnalyticsRecorderImpl
 import com.wire.android.feature.analytics.globalAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
 import com.wire.android.feature.analytics.model.AnalyticsSettings
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.AppNameUtil
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.DataDogLogger
@@ -54,6 +56,8 @@ import com.wire.kalium.common.logger.CoreLogger
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import kotlinx.coroutines.CoroutineScope
@@ -61,14 +65,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import dev.zacsweers.metro.Inject
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.collections.filter
 
@@ -112,6 +119,8 @@ class WireApplication : BaseApp() {
 
     @Inject
     lateinit var analyticsManager: Lazy<AnonymousAnalyticsManager>
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic.value) }
 
     @Inject
     lateinit var workManager: WorkManager
@@ -192,7 +201,7 @@ class WireApplication : BaseApp() {
             ::Pair
         ).collect { (isAppVisible, validSessions) ->
             validSessions.forEach {
-                coreLogic.value.getSessionScope(it.userId).calls.setBackground(!isAppVisible)
+                preparedSessionScope(it.userId)?.calls?.setBackground(!isAppVisible)
             }
         }
     }
@@ -201,7 +210,11 @@ class WireApplication : BaseApp() {
         coreLogic.value.getGlobalScope().session.currentSessionFlow().filterIsInstance(CurrentSessionResult.Success::class)
             .filter { session -> session.accountInfo.isValid() }
             .flatMapLatest { session ->
-                coreLogic.value.getSessionScope(session.accountInfo.userId).calls.observeRecentlyEndedCallMetadata()
+                flow {
+                    preparedSessionScope(session.accountInfo.userId)?.let { sessionScope ->
+                        emitAll(sessionScope.calls.observeRecentlyEndedCallMetadata())
+                    }
+                }
             }
             .collect { metadata ->
                 analyticsManager.value.sendEvent(AnalyticsEvent.RecentlyEndedCallEvent(metadata))
@@ -213,7 +226,11 @@ class WireApplication : BaseApp() {
             .filterIsInstance<CurrentSessionResult.Success>()
             .map { it.accountInfo.userId }
             .flatMapLatest {
-                coreLogic.value.getSessionScope(it).messages.observeAssetUploadState()
+                flow {
+                    preparedSessionScope(it)?.let { sessionScope ->
+                        emitAll(sessionScope.messages.observeAssetUploadState())
+                    }
+                }
             }
             .collect { uploadInProgress ->
                 if (uploadInProgress) {
@@ -360,6 +377,7 @@ class WireApplication : BaseApp() {
         initializeAnonymousAnalytics()
     }
 
+    @Suppress("LongMethod")
     private fun initializeAnonymousAnalytics() {
         if (!BuildConfig.ANALYTICS_ENABLED) return
 
@@ -370,22 +388,29 @@ class WireApplication : BaseApp() {
             enableDebugLogging = BuildConfig.DEBUG
         )
 
+        val analyticsSessionScopes = ConcurrentHashMap<UserId, UserSessionScope>()
         val analyticsResultFlow = ObserveCurrentSessionAnalyticsUseCase(
             currentSessionFlow = coreLogic.value.getGlobalScope().session.currentSessionFlow(),
             getAnalyticsContactsData = { userId ->
-                coreLogic.value.getSessionScope(userId).getAnalyticsContactsData()
+                checkNotNull(analyticsSessionScopes[userId]).getAnalyticsContactsData()
             },
             observeAnalyticsTrackingIdentifierStatusFlow = { userId ->
-                coreLogic.value.getSessionScope(userId).observeAnalyticsTrackingIdentifierStatus()
+                checkNotNull(analyticsSessionScopes[userId]).observeAnalyticsTrackingIdentifierStatus()
             },
             analyticsIdentifierManagerProvider = { userId ->
-                coreLogic.value.getSessionScope(userId).analyticsIdentifierManager
+                checkNotNull(analyticsSessionScopes[userId]).analyticsIdentifierManager
             },
             userDataStoreProvider = userDataStoreProvider.value,
             globalDataStore = globalDataStore.value,
             currentBackend = { userId ->
-                coreLogic.value.getSessionScope(userId).users.serverLinks()
-            }
+                checkNotNull(analyticsSessionScopes[userId]).users.serverLinks()
+            },
+            prepareSession = { userId ->
+                preparedSessionScope(userId)?.let { sessionScope ->
+                    analyticsSessionScopes[userId] = sessionScope
+                    true
+                } ?: false
+            },
         ).invoke()
 
         AnonymousAnalyticsManagerImpl.init(
@@ -411,7 +436,7 @@ class WireApplication : BaseApp() {
                 .collect {
                     val currentSessionResult = coreLogic.value.getGlobalScope().session.currentSessionFlow().first()
                     val isTeamMember = if (currentSessionResult is CurrentSessionResult.Success) {
-                        coreLogic.value.getSessionScope(currentSessionResult.accountInfo.userId).team.isSelfATeamMember()
+                        preparedSessionScope(currentSessionResult.accountInfo.userId)?.team?.isSelfATeamMember()
                     } else {
                         null
                     }
@@ -439,6 +464,15 @@ class WireApplication : BaseApp() {
         val elapsed = startedAt?.let { " (+${SystemClock.elapsedRealtime() - it}ms)" }.orEmpty()
         Log.i(TAG, "startup:$event$elapsed")
     }
+
+    private suspend fun preparedSessionScope(userId: UserId) =
+        when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("Skipping application database observer for ${userId.toLogString()}: ${result.reason}")
+                null
+            }
+        }
 
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)

--- a/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/analytics/ObserveCurrentSessionAnalyticsUseCase.kt
@@ -52,10 +52,11 @@ fun ObserveCurrentSessionAnalyticsUseCase(
     currentSessionFlow: Flow<CurrentSessionResult>,
     getAnalyticsContactsData: suspend (UserId) -> AnalyticsContactsData,
     observeAnalyticsTrackingIdentifierStatusFlow: suspend (UserId) -> Flow<AnalyticsIdentifierResult>,
-    analyticsIdentifierManagerProvider: (UserId) -> AnalyticsIdentifierManager,
+    analyticsIdentifierManagerProvider: suspend (UserId) -> AnalyticsIdentifierManager,
     userDataStoreProvider: UserDataStoreProvider,
     globalDataStore: GlobalDataStore,
-    currentBackend: suspend (UserId) -> SelfServerConfigUseCase.Result
+    currentBackend: suspend (UserId) -> SelfServerConfigUseCase.Result,
+    prepareSession: suspend (UserId) -> Boolean = { true },
 ) = object : ObserveCurrentSessionAnalyticsUseCase {
 
     private var previousAnalyticsResult: AnalyticsIdentifierResult? = null
@@ -89,6 +90,9 @@ fun ObserveCurrentSessionAnalyticsUseCase(
 
             if (currentSession is CurrentSessionResult.Success && currentSession.accountInfo.isValid()) {
                 val userId = currentSession.accountInfo.userId
+                if (!prepareSession(userId)) {
+                    return@flatMapLatest flowOf(disabledAnalyticsResult())
+                }
                 val analyticsIdentifierManager = analyticsIdentifierManagerProvider(userId)
                 combine(
                     observeAnalyticsTrackingIdentifierStatusFlow(userId)
@@ -131,22 +135,22 @@ fun ObserveCurrentSessionAnalyticsUseCase(
                     )
                 }
             } else {
-                flowOf(
-                    AnalyticsResult<AnalyticsIdentifierManager>(
-                        identifierResult = AnalyticsIdentifierResult.Disabled,
-                        profileProperties = {
-                            AnalyticsProfileProperties(
-                                isTeamMember = false,
-                                teamId = null,
-                                contactsAmount = null,
-                                teamMembersAmount = null,
-                                isEnterprise = null
-                            )
-                        },
-                        manager = null
-                    )
-                )
+                flowOf(disabledAnalyticsResult())
             }
         }.distinctUntilChanged()
     }
 }
+
+private fun disabledAnalyticsResult() = AnalyticsResult<AnalyticsIdentifierManager>(
+    identifierResult = AnalyticsIdentifierResult.Disabled,
+    profileProperties = {
+        AnalyticsProfileProperties(
+            isTeamMember = false,
+            teamId = null,
+            contactsAmount = null,
+            teamMembersAmount = null,
+            isEnterprise = null,
+        )
+    },
+    manager = null,
+)

--- a/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
+++ b/app/src/main/kotlin/com/wire/android/di/metro/AppSessionViewModelGraph.kt
@@ -27,6 +27,7 @@ import com.wire.android.ui.home.HomeViewModelGraph
 import com.wire.android.ui.home.sync.FeatureFlagNotificationViewModel
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.GraphExtension
@@ -48,6 +49,7 @@ interface AppSessionViewModelGraph :
     CommonViewModelGraph {
     @get:CurrentAccount
     val currentAccount: UserId
+    val userSessionScope: UserSessionScope
 
     override val viewModelScopeKey: String
         get() = currentAccount.toString()
@@ -60,10 +62,16 @@ interface AppSessionViewModelGraph :
     @ContributesTo(AppScope::class)
     @GraphExtension.Factory
     interface Factory {
-        fun createAppSessionViewModelGraph(@Provides @CurrentAccount currentAccount: UserId): AppSessionViewModelGraph
+        fun createAppSessionViewModelGraph(
+            @Provides @CurrentAccount currentAccount: UserId,
+            @Provides userSessionScope: UserSessionScope,
+        ): AppSessionViewModelGraph
     }
 }
 
-fun WireApplicationGraph.createSessionViewModelGraph(currentAccount: UserId): AppSessionViewModelGraph {
-    return asContribution<AppSessionViewModelGraph.Factory>().createAppSessionViewModelGraph(currentAccount)
+fun WireApplicationGraph.createSessionViewModelGraph(
+    currentAccount: UserId,
+    userSessionScope: UserSessionScope,
+): AppSessionViewModelGraph {
+    return asContribution<AppSessionViewModelGraph.Factory>().createAppSessionViewModelGraph(currentAccount, userSessionScope)
 }

--- a/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCase.kt
@@ -19,6 +19,8 @@ package com.wire.android.feature
 
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import kotlinx.coroutines.flow.Flow
@@ -36,13 +38,21 @@ class ObserveAppLockConfigUseCase @Inject constructor(
     private val globalDataStore: GlobalDataStore,
     @KaliumCoreLogic private val coreLogic: CoreLogic
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
+
     operator fun invoke(): Flow<AppLockConfig> = channelFlow {
         coreLogic.getGlobalScope().session.currentSessionFlow().collectLatest { sessionResult ->
             when {
                 sessionResult is CurrentSessionResult.Success && sessionResult.accountInfo.isValid() -> {
                     val userId = sessionResult.accountInfo.userId
-                    val appLockTeamFeatureConfigFlow =
-                        coreLogic.getSessionScope(userId).appLockTeamFeatureConfigObserver
+                    val sessionScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+                        is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                        is AppUserSessionPreparationResult.Failed -> {
+                            send(AppLockConfig.Disabled(DEFAULT_APP_LOCK_TIMEOUT))
+                            return@collectLatest
+                        }
+                    }
+                    val appLockTeamFeatureConfigFlow = sessionScope.appLockTeamFeatureConfigObserver
 
                     appLockTeamFeatureConfigFlow().combineTransform(
                         globalDataStore.isAppLockPasscodeSetFlow()

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
@@ -24,10 +24,13 @@ import android.net.Uri
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.services.ServicesManager
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.common.R as commonR
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.extension.intervalFlow
 import com.wire.android.util.ui.UIText
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
@@ -73,6 +76,8 @@ class ConversationAudioMessagePlayer
     @ApplicationScope private val scope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
+
     private companion object {
         const val UPDATE_POSITION_INTERVAL_IN_MS = 1000L
     }
@@ -398,13 +403,21 @@ class ConversationAudioMessagePlayer
         conversationId: ConversationId,
         messageId: String,
     ): MessageAssetResult = withContext(dispatchers.io()) {
+        val preparation = userSessionPreparationGate.prepare(userId)
+        val sessionScope = when (preparation) {
+            is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+            is AppUserSessionPreparationResult.Failed -> return@withContext MessageAssetResult.Failure(
+                CoreFailure.Unknown(IllegalStateException("User session preparation failed: ${preparation.reason}")),
+                preparation.canRetry,
+            )
+        }
         val key = GetAssetMessageKey(userId, conversationId, messageId)
         getAssetMessageMutex.withLock {
             // keep deferred in the map to prevent multiple calls to the same asset at the same time, instead just reuse the existing one
             val deferredResult = getAssetMessageDeferredMap[key]
             // if no deferred exists or the existing one is already completed with failure, create a new one
             if (deferredResult == null || (deferredResult.isCompleted && deferredResult.getCompleted() is MessageAssetResult.Failure)) {
-                coreLogic.getSessionScope(userId).messages.getAssetMessage(conversationId, messageId).also {
+                sessionScope.messages.getAssetMessage(conversationId, messageId).also {
                     getAssetMessageDeferredMap[key] = it
                 }
             } else {
@@ -415,7 +428,7 @@ class ConversationAudioMessagePlayer
             // this is to handle the case when the file has been uploaded and the file name has changed from temporary to proper one
             if (result is MessageAssetResult.Success && !result.decodedAssetPath.toFile().exists()) {
                 getAssetMessageMutex.withLock {
-                    coreLogic.getSessionScope(userId).messages.getAssetMessage(conversationId, messageId).also {
+                    sessionScope.messages.getAssetMessage(conversationId, messageId).also {
                         getAssetMessageDeferredMap[key] = it
                     }
                 }.await()
@@ -463,30 +476,37 @@ class ConversationAudioMessagePlayer
         _audioSpeed.emit(currentSpeed)
     }
 
+    @Suppress("NestedBlockDepth")
     private suspend fun tryToPlayNextAudio(currentMessageIdWrapper: MessageIdWrapper): Boolean {
         val (conversationId, currentMessageId) = currentMessageIdWrapper
 
         val currentAccountResult = coreLogic.getGlobalScope().session.currentSession()
         if (currentAccountResult is CurrentSessionResult.Success) {
-            coreLogic
-                .getSessionScope((currentAccountResult).accountInfo.userId)
-                .messages
-                .getNextAudioMessageInConversation(conversationId, currentMessageId).let { nextAudio ->
-                    if (nextAudio is GetNextAudioMessageInConversationUseCase.Result.Success) {
-                        playAudio(conversationId, nextAudio.messageId)
-                        return true
+            val preparation = userSessionPreparationGate.prepare(currentAccountResult.accountInfo.userId)
+            if (preparation is AppUserSessionPreparationResult.Ready) {
+                preparation.sessionScope
+                    .messages
+                    .getNextAudioMessageInConversation(conversationId, currentMessageId).let { nextAudio ->
+                        if (nextAudio is GetNextAudioMessageInConversationUseCase.Result.Success) {
+                            playAudio(conversationId, nextAudio.messageId)
+                            return true
+                        }
                     }
-                }
+            }
         }
         return false
     }
 
+    @Suppress("ReturnCount")
     private suspend fun getSenderNameByMessageId(conversationId: ConversationId, messageId: String): String? {
         val currentAccountResult = coreLogic.getGlobalScope().session.currentSession()
         if (currentAccountResult is CurrentSessionResult.Failure) return null
 
-        val senderNameResult = coreLogic
-            .getSessionScope((currentAccountResult as CurrentSessionResult.Success).accountInfo.userId)
+        val preparation = userSessionPreparationGate.prepare(
+            (currentAccountResult as CurrentSessionResult.Success).accountInfo.userId
+        )
+        if (preparation !is AppUserSessionPreparationResult.Ready) return null
+        val senderNameResult = preparation.sessionScope
             .messages
             .getSenderNameByMessageId(conversationId, messageId)
 

--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -25,6 +25,8 @@ import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.media.PingRinger
 import com.wire.android.services.ServicesManager
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -41,6 +43,7 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.user.E2EIRequiredResult
+import com.wire.kalium.logic.feature.UserSessionScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -91,6 +94,7 @@ class WireNotificationManager @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.default())
     private val fetchOnceMutex = Mutex()
     private val fetchOnceJobs = hashMapOf<UserId, Job>()
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
     private var observingWhileRunningJobs = ObservingJobs()
     private var observingPersistentlyJobs = ObservingJobs()
 
@@ -142,14 +146,25 @@ class WireNotificationManager @Inject constructor(
      * will join the first execution and return together.
      * @param userIdValue String value param of QualifiedID of the User that need to check Notifications for
      */
-    suspend fun fetchAndShowNotificationsOnce(userIdValue: String) {
-        val userId = checkIfUserIsAuthenticated(userIdValue) ?: return
+    @Suppress("ReturnCount")
+    suspend fun fetchAndShowNotificationsOnce(userIdValue: String): FetchNotificationsResult {
+        val userId = checkIfUserIsAuthenticated(userIdValue) ?: return FetchNotificationsResult.Failure
+        when (val preparation = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> Unit
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w(
+                    "$TAG user-session preparation failed for ${userId.toLogString()}: ${preparation.reason}"
+                )
+                return if (preparation.canRetry) FetchNotificationsResult.Retry else FetchNotificationsResult.Failure
+            }
+        }
 
         val syncAndNotificationJobForUser = fetchAndShowMessageNotificationsJob(userId)
 
         // Join the jobs for the user, waiting for its completion
         syncAndNotificationJobForUser?.start()
         syncAndNotificationJobForUser?.join()
+        return FetchNotificationsResult.Success
     }
 
     private suspend fun fetchAndShowMessageNotificationsJob(userId: UserId): Job? =
@@ -406,7 +421,7 @@ class WireNotificationManager @Inject constructor(
     ) {
         appLogger.d("$TAG observe incoming calls")
 
-        coreLogic.getSessionScope(userId).let { userSessionScope ->
+        preparedSessionScope(userId)?.let { userSessionScope ->
             userSessionScope.observeE2EIRequired()
                 .map { it is E2EIRequiredResult.NoGracePeriod }
                 .distinctUntilChanged()
@@ -439,7 +454,8 @@ class WireNotificationManager @Inject constructor(
         userId: UserId,
         currentScreenState: StateFlow<CurrentScreen>
     ) {
-        val selfUserNameState = coreLogic.getSessionScope(userId)
+        val userSessionScope = preparedSessionScope(userId) ?: return
+        val selfUserNameState = userSessionScope
             .users
             .observeSelfUser()
             .onEach { it.logIfEmptyUserName() }
@@ -447,12 +463,12 @@ class WireNotificationManager @Inject constructor(
             .distinctUntilChanged()
             .stateIn(scope)
 
-        val isBlockedByE2EIRequiredState = coreLogic.getSessionScope(userId).observeE2EIRequired()
+        val isBlockedByE2EIRequiredState = userSessionScope.observeE2EIRequired()
             .map { it is E2EIRequiredResult.NoGracePeriod }
             .distinctUntilChanged()
             .stateIn(scope)
 
-        coreLogic.getSessionScope(userId)
+        userSessionScope
             .messages
             .getNotifications()
             .cancellable()
@@ -504,17 +520,19 @@ class WireNotificationManager @Inject constructor(
         coreLogic.getGlobalScope().session.currentSessionFlow()
             .flatMapLatest {
                 if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
-                    val sessionScope = coreLogic.getSessionScope(it.accountInfo.userId)
-                    // wait for the initial cleanup of stale open calls to be completed before starting to observe the calls,
-                    // to avoid starting the service by mistake for the calls that are already stale
-                    sessionScope.calls.observeStaleOpenCallsCleanup()
-                        .dropWhile { completed -> !completed }
-                        .flatMapLatest {
-                            combine(
-                                sessionScope.calls.establishedCall(),
-                                sessionScope.calls.observeOutgoingCall()
-                            ) { establishedCalls, outgoingCalls -> (establishedCalls + outgoingCalls).isNotEmpty() }
-                        }
+                    flowOf(it.accountInfo.userId).flatMapLatest { userId ->
+                        val sessionScope = preparedSessionScope(userId) ?: return@flatMapLatest flowOf(null)
+                        // wait for the initial cleanup of stale open calls to be completed before starting to observe the calls,
+                        // to avoid starting the service by mistake for the calls that are already stale
+                        sessionScope.calls.observeStaleOpenCallsCleanup()
+                            .dropWhile { completed -> !completed }
+                            .flatMapLatest {
+                                combine(
+                                    sessionScope.calls.establishedCall(),
+                                    sessionScope.calls.observeOutgoingCall()
+                                ) { establishedCalls, outgoingCalls -> (establishedCalls + outgoingCalls).isNotEmpty() }
+                            }
+                    }
                 } else {
                     flowOf(null)
                 }
@@ -546,9 +564,9 @@ class WireNotificationManager @Inject constructor(
         val markNotified = conversationId?.let {
             MarkMessagesAsNotifiedUseCase.UpdateTarget.SingleConversation(conversationId, lastNotified)
         } ?: MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations
-        coreLogic.getSessionScope(userId)
-            .messages
-            .markMessagesAsNotified(markNotified)
+        preparedSessionScope(userId)
+            ?.messages
+            ?.markMessagesAsNotified(markNotified)
     }
 
     private suspend fun markConnectionAsNotified(
@@ -557,10 +575,25 @@ class WireNotificationManager @Inject constructor(
     ) {
         appLogger.d("$TAG markConnectionAsNotified")
         userId?.let {
-            coreLogic.getSessionScope(it)
-                .conversations
-                .markConnectionRequestAsNotified(connectionRequestUserId)
+            preparedSessionScope(it)
+                ?.conversations
+                ?.markConnectionRequestAsNotified(connectionRequestUserId)
         }
+    }
+
+    private suspend fun preparedSessionScope(userId: UserId): UserSessionScope? =
+        when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("$TAG skipping database work for ${userId.toLogString()}: ${result.reason}")
+                null
+            }
+        }
+
+    sealed interface FetchNotificationsResult {
+        data object Success : FetchNotificationsResult
+        data object Retry : FetchNotificationsResult
+        data object Failure : FetchNotificationsResult
     }
 
     private fun playPingSoundIfNeeded(

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
@@ -18,63 +18,56 @@
 
 package com.wire.android.notification.broadcastreceivers
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
-import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.di.metro.wireApplicationGraph
-import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
 
-class EndOngoingCallReceiver : BroadcastReceiver() {
+class EndOngoingCallReceiver : CoroutineReceiver() {
 
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
 
     @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    @Inject
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
 
-    @Inject
-    @ApplicationScope
-    lateinit var coroutineScope: CoroutineScope
-
-    override fun onReceive(context: Context, intent: Intent) {
+    override fun onReceive(context: Context, intent: Intent?) {
         context.wireApplicationGraph.inject(this)
+        super.onReceive(context, intent)
+    }
+
+    override suspend fun receive(context: Context, intent: Intent) {
         val conversationId: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: return
         appLogger.i("EndOngoingCallReceiver: onReceive, conversationId: $conversationId")
 
-        coroutineScope.launch {
-            val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
-            val sessionScope =
-                if (userId != null) {
-                    coreLogic.getSessionScope(userId)
-                } else {
-                    val currentSession = coreLogic.globalScope { session.currentSession() }
-                    if (currentSession is CurrentSessionResult.Success) {
-                        coreLogic.getSessionScope(currentSession.accountInfo.userId)
-                    } else {
-                        null
-                    }
+        val requestedUserId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
+        val userId = requestedUserId ?: (coreLogic.globalScope { session.currentSession() } as? CurrentSessionResult.Success)
+            ?.accountInfo
+            ?.userId
+        val sessionScope = userId?.let {
+            when (val preparation = UserSessionPreparationGate(coreLogic).prepare(it)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    appLogger.w("EndOngoingCallReceiver: session preparation failed: ${preparation.reason}")
+                    null
                 }
-
-            sessionScope?.let {
-                it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
             }
+        }
+
+        sessionScope?.let {
+            it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/IncomingCallActionReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/IncomingCallActionReceiver.kt
@@ -18,49 +18,42 @@
 
 package com.wire.android.notification.broadcastreceivers
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
-import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.notification.CallNotificationManager
-import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.data.user.UserId
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
 
-class IncomingCallActionReceiver : BroadcastReceiver() {
+class IncomingCallActionReceiver : CoroutineReceiver() {
 
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
 
     @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    @Inject
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     @Inject
-    @ApplicationScope
-    lateinit var coroutineScope: CoroutineScope
-
-    @Inject
     lateinit var callNotificationManager: CallNotificationManager
 
-    @Suppress("ReturnCount")
-    override fun onReceive(context: Context, intent: Intent) {
+    override fun onReceive(context: Context, intent: Intent?) {
         context.wireApplicationGraph.inject(this)
+        super.onReceive(context, intent)
+    }
+
+    @Suppress("ReturnCount")
+    override suspend fun receive(context: Context, intent: Intent) {
         val conversationIdString: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: run {
             appLogger.e("CallNotificationDismissReceiver: onReceive, conversation ID is missing")
             return
@@ -75,15 +68,18 @@ class IncomingCallActionReceiver : BroadcastReceiver() {
             return
         }
 
-        coroutineScope.launch(Dispatchers.Default) {
-            with(coreLogic.getSessionScope(userId)) {
+        when (val preparation = UserSessionPreparationGate(coreLogic).prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> with(preparation.sessionScope) {
                 val conversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationIdString)
                 if (action == ACTION_DECLINE_CALL) {
                     calls.rejectCall(conversationId)
                 }
             }
-            callNotificationManager.hideIncomingCallNotification(userId.toString(), conversationIdString)
+
+            is AppUserSessionPreparationResult.Failed ->
+                appLogger.w("CallNotificationDismissReceiver: session preparation failed: ${preparation.reason}")
         }
+        callNotificationManager.hideIncomingCallNotification(userId.toString(), conversationIdString)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
@@ -25,6 +25,8 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.android.util.lifecycle.AppBackgroundManager
 import com.wire.kalium.logic.CoreLogic
@@ -97,7 +99,14 @@ class NomadLogoutReceiver : CoroutineReceiver() {
             is CurrentSessionResult.Success -> {
                 val userId = session.accountInfo.userId
                 appLogger.i("$TAG Logging out user: ${userId.toLogString()}")
-                coreLogic.getSessionScope(userId).logout(LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
+                val sessionScope = when (val preparation = UserSessionPreparationGate(coreLogic).prepare(userId)) {
+                    is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                    is AppUserSessionPreparationResult.Failed -> {
+                        appLogger.e("$TAG session preparation failed: ${preparation.reason}")
+                        return
+                    }
+                }
+                sessionScope.logout(LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
                 coreLogic.getGlobalScope().deleteSession(userId)
                 accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).callAction(switchAccountObserver)
             }

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
@@ -28,7 +28,8 @@ import com.wire.android.di.NoSession
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.notification.MessageNotificationManager
 import com.wire.android.notification.NotificationConstants
-import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -41,9 +42,6 @@ class NotificationReplyReceiver : CoroutineReceiver() { // requires zero argumen
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
-
-    @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
 
     @Inject
     @NoSession
@@ -64,7 +62,14 @@ class NotificationReplyReceiver : CoroutineReceiver() { // requires zero argumen
             val qualifiedUserId = qualifiedIdMapper.fromStringToQualifiedID(userId)
             val qualifiedConversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
 
-            with(coreLogic.getSessionScope(qualifiedUserId)) {
+            val sessionScope = when (val preparation = UserSessionPreparationGate(coreLogic).prepare(qualifiedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    updateNotification(context, conversationId, qualifiedUserId, null)
+                    return
+                }
+            }
+            with(sessionScope) {
                 syncExecutor.request {
                     messages.sendTextMessage(qualifiedConversationId, replyText).toEither()
                         .fold(

--- a/app/src/main/kotlin/com/wire/android/services/CallServiceManager.kt
+++ b/app/src/main/kotlin/com/wire/android/services/CallServiceManager.kt
@@ -20,6 +20,8 @@ package com.wire.android.services
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.CallNotificationData
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.services.CallService.Action
 import com.wire.android.util.logging.logIfEmptyUserName
 import com.wire.kalium.common.functional.Either
@@ -48,6 +50,7 @@ import dev.zacsweers.metro.Inject
 
 class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: CoreLogic) {
     private val actions = Channel<Action>(capacity = Channel.BUFFERED, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     /** Handles the action by adding it to the channel for processing. */
     internal suspend fun handleAction(action: Action) = actions.send(action)
@@ -97,7 +100,7 @@ class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: Cor
         coreLogic.getGlobalScope().session.currentSessionFlow().firstOrNull().let {
             if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
                 val userId = it.accountInfo.userId
-                val userSessionScope = coreLogic.getSessionScope(userId)
+                val userSessionScope = preparedSessionScope(userId) ?: return@let
                 combine(
                     userSessionScope.calls.observeOutgoingCall(),
                     userSessionScope.calls.establishedCall(),
@@ -124,7 +127,8 @@ class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: Cor
             .flatMapLatest {
                 if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
                     val userId = it.accountInfo.userId
-                    val userSessionScope = coreLogic.getSessionScope(userId)
+                    val userSessionScope = preparedSessionScope(userId)
+                        ?: return@flatMapLatest flowOf(Either.Left(StopReason.NO_VALID_CURRENT_SESSION))
                     val userName = userSessionScope.getUserName()
                     combine(
                         userSessionScope.calls.establishedCall().mapToCallNotificationData(userId, userName),
@@ -170,9 +174,18 @@ class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: Cor
     private suspend fun getValidSessionIfExists(userId: UserId): Either<Unit, UserSessionScope> =
         coreLogic.getGlobalScope().doesValidSessionExist(userId).let { result ->
             if (result is DoesValidSessionExistResult.Success && result.doesValidSessionExist) {
-                coreLogic.getSessionScope(userId).right()
+                preparedSessionScope(userId)?.right() ?: Unit.left()
             } else {
                 Unit.left()
+            }
+        }
+
+    private suspend fun preparedSessionScope(userId: UserId): UserSessionScope? =
+        when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("$TAG: user-session preparation failed for ${userId.toLogString()}: ${result.reason}")
+                null
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/services/PendingMessagesForegroundService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PendingMessagesForegroundService.kt
@@ -39,6 +39,8 @@ import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.lifecycle.SyncLifecycleManager
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.logout.LogoutReason
@@ -310,13 +312,21 @@ class SendPendingMessagesAfterForegroundSyncUseCase @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val syncLifecycleManager: SyncLifecycleManager,
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
+
     suspend operator fun invoke(userId: UserId) {
+        val userSessionScope = when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("$TAG: user-session preparation failed for ${userId.toLogString()}: ${result.reason}")
+                return
+            }
+        }
         syncLifecycleManager.syncTemporarily(
             userId = userId,
             stayAliveExtraDuration = 3.seconds,
             waitForNextSyncState = true,
         ) {
-            val userSessionScope = coreLogic.getSessionScope(userId)
             appLogger.i(
                 "$TAG: sending pending messages for ${userId.toLogString()}, " +
                         "syncState=${userSessionScope.syncManager.syncState.value}, " +

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -38,6 +38,8 @@ import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_NA
 import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
@@ -69,6 +71,8 @@ class PersistentWebSocketService : Service() {
 
     @Inject
     lateinit var notificationChannelsManager: NotificationChannelsManager
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
@@ -120,7 +124,14 @@ class PersistentWebSocketService : Service() {
         coroutineScope {
             usersToObserve.forEach { userId ->
                 launch {
-                    coreLogic.getSessionScope(userId).syncExecutor.request {
+                    val sessionScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+                        is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                        is AppUserSessionPreparationResult.Failed -> {
+                            appLogger.w("Skipping persistent sync for ${userId.toLogString()}: ${preparation.reason}")
+                            return@launch
+                        }
+                    }
+                    sessionScope.syncExecutor.request {
                         awaitCancellation()
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/session/UserSessionPreparationGate.kt
+++ b/app/src/main/kotlin/com/wire/android/session/UserSessionPreparationGate.kt
@@ -1,0 +1,65 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.session
+
+import com.wire.android.di.KaliumCoreLogic
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
+import com.wire.kalium.logic.UserSessionPreparationState
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The Android-side boundary for every operation that needs a user database.
+ *
+ * This class intentionally does not start or cache a second migration operation. Each caller
+ * delegates to Kalium, which single-flights concurrent preparation for the physical database.
+ */
+@SingleIn(AppScope::class)
+class UserSessionPreparationGate @Inject constructor(
+    @KaliumCoreLogic private val coreLogic: CoreLogic,
+) {
+    suspend fun prepare(userId: UserId): AppUserSessionPreparationResult =
+        coreLogic.prepareUserSession(userId).toAppResult()
+
+    fun observe(userId: UserId): Flow<UserSessionPreparationState> =
+        coreLogic.observeUserSessionPreparation(userId)
+}
+
+sealed interface AppUserSessionPreparationResult {
+    data class Ready(val sessionScope: UserSessionScope) : AppUserSessionPreparationResult
+
+    data class Failed(
+        val reason: UserSessionPreparationFailure,
+        val canRetry: Boolean,
+    ) : AppUserSessionPreparationResult
+}
+
+internal fun PrepareUserSessionResult.toAppResult(): AppUserSessionPreparationResult = when (this) {
+    is PrepareUserSessionResult.Success -> AppUserSessionPreparationResult.Ready(sessionScope)
+    is PrepareUserSessionResult.Failure -> AppUserSessionPreparationResult.Failed(
+        reason = reason,
+        canRetry = reason is UserSessionPreparationFailure.InsufficientStorage ||
+                reason is UserSessionPreparationFailure.TemporarilyUnavailable,
+    )
+}

--- a/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/AppLockActivity.kt
@@ -17,13 +17,19 @@
  */
 package com.wire.android.ui
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.biometric.BiometricManager
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.lifecycleScope
 import com.ramcosta.composedestinations.generated.app.destinations.AppUnlockWithBiometricsScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.EnterLockCodeScreenDestination
 import com.ramcosta.composedestinations.generated.app.destinations.SetLockCodeScreenDestination
@@ -35,12 +41,24 @@ import com.wire.android.model.LocalWireSessionImageLoader
 import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.navigation.MainNavHost
 import com.wire.android.navigation.rememberNavigator
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.util.SupportPage
+import com.wire.android.util.SupportUrlResolver
+import com.wire.android.util.launchUpdateTheApp
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 
 class AppLockActivity : BaseActivity() {
 
@@ -48,13 +66,16 @@ class AppLockActivity : BaseActivity() {
     lateinit var loginTypeSelector: LoginTypeSelector
 
     private val qualifiedIdMapper = QualifiedIdMapper(null)
+    private var preparationState by mutableStateOf<UserSessionPreparationUiState>(
+        UserSessionPreparationUiState.ResolvingSession
+    )
+    private var preparationJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         wireApplicationGraph.inject(this)
         super.onCreate(savedInstanceState)
-        val sessionViewModelGraph = intent.getStringExtra(EXTRA_USER_ID)
+        val userId = intent.getStringExtra(EXTRA_USER_ID)
             ?.let(qualifiedIdMapper::fromStringToQualifiedID)
-            ?.let(wireApplicationGraph::createSessionViewModelGraph)
             ?: run {
                 appLogger.e("appLock: missing session user id, closing app lock activity")
                 finish()
@@ -62,6 +83,49 @@ class AppLockActivity : BaseActivity() {
             }
         setupOrientationForDevice()
         enableEdgeToEdge()
+        showPreparation(userId)
+    }
+
+    private fun showPreparation(userId: UserId) {
+        setContent {
+            WireTheme {
+                UserSessionPreparationScreen(
+                    state = preparationState,
+                    onRetry = { prepareSession(userId) },
+                    onUpdate = ::updateTheApp,
+                    onContactSupport = ::openSupport,
+                )
+            }
+        }
+        prepareSession(userId)
+    }
+
+    private fun prepareSession(userId: UserId) {
+        if (preparationJob?.isActive == true) return
+        preparationState = UserSessionPreparationUiState.ResolvingSession
+        preparationJob = lifecycleScope.launch {
+            val gate = UserSessionPreparationGate(wireApplicationGraph.coreLogic)
+            val result = coroutineScope {
+                val observer = launch(start = CoroutineStart.UNDISPATCHED) {
+                    gate.observe(userId).collect { preparationState = it.toUiState() }
+                }
+                try {
+                    gate.prepare(userId)
+                } finally {
+                    observer.cancelAndJoin()
+                }
+            }
+            when (result) {
+                is AppUserSessionPreparationResult.Ready -> showAppLock(userId, result.sessionScope)
+                is AppUserSessionPreparationResult.Failed -> {
+                    preparationState = UserSessionPreparationUiState.Failed(result.reason.toUiFailure())
+                }
+            }
+        }
+    }
+
+    private fun showAppLock(userId: UserId, userSessionScope: UserSessionScope) {
+        val sessionViewModelGraph = wireApplicationGraph.createSessionViewModelGraph(userId, userSessionScope)
         setContent {
             val snackbarHostState = remember { SnackbarHostState() }
             val rememberedSessionViewModelGraph = remember { sessionViewModelGraph }
@@ -101,6 +165,13 @@ class AppLockActivity : BaseActivity() {
             }
         }
     }
+
+    private fun openSupport() {
+        val supportUrl = SupportUrlResolver.resolve(resources, SupportPage.SUPPORT)
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(supportUrl)))
+    }
+
+    private fun updateTheApp() = launchUpdateTheApp()
 
     companion object {
         const val SET_TEAM_APP_LOCK = "set_team_app_lock"

--- a/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
@@ -36,6 +36,9 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.UserSessionPreparationState
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 internal fun UserSessionPreparationScreen(
@@ -93,13 +96,39 @@ internal sealed interface UserSessionPreparationUiState {
 /**
  * Keeps fast session opening behind the system splash. A migration earns dedicated UI only when
  * it lasts long enough to avoid a flash; failures are revealed immediately so they stay actionable.
+ *
+ * Returning `null` means the state never justifies leaving the splash on its own.
  */
-internal fun UserSessionPreparationUiState.preparationScreenRevealDelayMillis(): Long? = when (this) {
-    UserSessionPreparationUiState.MigratingDatabase -> MIGRATION_SCREEN_DEBOUNCE_MILLIS
-    is UserSessionPreparationUiState.Failed -> 0L
+internal fun UserSessionPreparationUiState.preparationScreenRevealDelay(): Duration? = when (this) {
+    UserSessionPreparationUiState.MigratingDatabase -> MIGRATION_SCREEN_REVEAL_DELAY
+    is UserSessionPreparationUiState.Failed -> Duration.ZERO
     UserSessionPreparationUiState.ResolvingSession,
     UserSessionPreparationUiState.OpeningDatabase,
     UserSessionPreparationUiState.Ready -> null
+}
+
+/**
+ * Tracks how long the migration screen has been visible so it is never replaced mid-blink.
+ *
+ * The reveal delay already skips the screen entirely for migrations that finish quickly. Once the
+ * screen does appear, a migration finishing right after would swap it out instantly, which reads as
+ * a glitch, so callers wait out [remainingVisibility] before showing the next screen.
+ */
+internal class MigrationScreenVisibility(
+    private val minimumVisibility: Duration = MIGRATION_SCREEN_MINIMUM_VISIBILITY,
+    private val elapsedRealtimeMillis: () -> Long,
+) {
+    private var revealedAtMillis: Long? = null
+
+    fun onRevealed() {
+        if (revealedAtMillis == null) revealedAtMillis = elapsedRealtimeMillis()
+    }
+
+    fun remainingVisibility(): Duration {
+        val revealedAt = revealedAtMillis ?: return Duration.ZERO
+        val visibleFor = (elapsedRealtimeMillis() - revealedAt).milliseconds
+        return (minimumVisibility - visibleFor).coerceAtLeast(Duration.ZERO)
+    }
 }
 
 internal enum class UserSessionPreparationUiFailure {
@@ -136,7 +165,11 @@ private data class UserSessionPreparationContent(
     val action: UserSessionPreparationAction? = null,
 )
 
-internal const val MIGRATION_SCREEN_DEBOUNCE_MILLIS = 500L
+/** How long a migration has to run before it is worth interrupting the splash for it. */
+internal val MIGRATION_SCREEN_REVEAL_DELAY: Duration = 500.milliseconds
+
+/** How long the migration screen stays up once revealed, even if the migration already finished. */
+internal val MIGRATION_SCREEN_MINIMUM_VISIBILITY: Duration = 1.seconds
 
 @Composable
 private fun UserSessionPreparationUiState.content(): UserSessionPreparationContent = when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
@@ -90,6 +90,18 @@ internal sealed interface UserSessionPreparationUiState {
     data class Failed(val failure: UserSessionPreparationUiFailure) : UserSessionPreparationUiState
 }
 
+/**
+ * Keeps fast session opening behind the system splash. A migration earns dedicated UI only when
+ * it lasts long enough to avoid a flash; failures are revealed immediately so they stay actionable.
+ */
+internal fun UserSessionPreparationUiState.preparationScreenRevealDelayMillis(): Long? = when (this) {
+    UserSessionPreparationUiState.MigratingDatabase -> MIGRATION_SCREEN_DEBOUNCE_MILLIS
+    is UserSessionPreparationUiState.Failed -> 0L
+    UserSessionPreparationUiState.ResolvingSession,
+    UserSessionPreparationUiState.OpeningDatabase,
+    UserSessionPreparationUiState.Ready -> null
+}
+
 internal enum class UserSessionPreparationUiFailure {
     InsufficientStorage,
     TemporarilyUnavailable,
@@ -123,6 +135,8 @@ private data class UserSessionPreparationContent(
     val message: Int,
     val action: UserSessionPreparationAction? = null,
 )
+
+internal const val MIGRATION_SCREEN_DEBOUNCE_MILLIS = 500L
 
 @Composable
 private fun UserSessionPreparationUiState.content(): UserSessionPreparationContent = when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
@@ -17,23 +17,33 @@
  */
 package com.wire.android.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
+import com.wire.android.ui.common.Logo
+import com.wire.android.ui.theme.WireTheme
 import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.UserSessionPreparationState
 import kotlinx.coroutines.channels.Channel
@@ -52,17 +62,70 @@ internal fun UserSessionPreparationScreen(
     onContactSupport: () -> Unit,
 ) {
     val content = state.content()
-    Column(
+    Box(
         modifier = Modifier
             .fillMaxSize()
+            .background(colorResource(R.color.background))
             .padding(horizontal = 32.dp),
+    ) {
+        if (content.action == null) {
+            SplashContinuationContent(content)
+        } else {
+            PreparationFailureContent(
+                content = content,
+                onRetry = onRetry,
+                onUpdate = onUpdate,
+                onContactSupport = onContactSupport,
+            )
+        }
+    }
+}
+
+/**
+ * Continues the system splash with its final, static logo frame. Keeping the logo centred means
+ * dismissing the system-owned splash does not look like a navigation event; only the explanatory
+ * copy below it becomes visible.
+ */
+@Composable
+private fun BoxScope.SplashContinuationContent(content: UserSessionPreparationContent) {
+    Logo(
+        tint = colorResource(R.color.default_icon_color),
+        modifier = Modifier
+            .size(width = SPLASH_LOGO_WIDTH, height = SPLASH_LOGO_HEIGHT)
+            .align(Alignment.Center),
+    )
+    Column(
+        modifier = Modifier
+            .align(Alignment.Center)
+            .offset(y = SPLASH_COPY_OFFSET),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(content.title),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = stringResource(content.message),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.PreparationFailureContent(
+    content: UserSessionPreparationContent,
+    onRetry: () -> Unit,
+    onUpdate: () -> Unit,
+    onContactSupport: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.align(Alignment.Center),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        if (content.action == null) {
-            CircularProgressIndicator()
-            Spacer(Modifier.height(32.dp))
-        }
         Text(
             text = stringResource(content.title),
             style = MaterialTheme.typography.headlineSmall,
@@ -86,6 +149,41 @@ internal fun UserSessionPreparationScreen(
                 Text(stringResource(action.label))
             }
         }
+    }
+}
+
+// The system splash uses a 288 dp icon canvas. Its Wire wordmark occupies roughly 174 x 55 dp.
+private val SPLASH_LOGO_WIDTH = 174.dp
+private val SPLASH_LOGO_HEIGHT = 55.dp
+private val SPLASH_COPY_OFFSET = 96.dp
+
+private class UserSessionPreparationStatePreviewProvider :
+    PreviewParameterProvider<UserSessionPreparationUiState> {
+    override val values: Sequence<UserSessionPreparationUiState> = sequenceOf(
+        UserSessionPreparationUiState.ResolvingSession,
+        UserSessionPreparationUiState.OpeningDatabase,
+        UserSessionPreparationUiState.MigratingDatabase,
+        UserSessionPreparationUiState.Ready,
+        UserSessionPreparationUiState.Failed(UserSessionPreparationUiFailure.InsufficientStorage),
+        UserSessionPreparationUiState.Failed(UserSessionPreparationUiFailure.TemporarilyUnavailable),
+        UserSessionPreparationUiState.Failed(UserSessionPreparationUiFailure.ApplicationUpdateRequired),
+        UserSessionPreparationUiState.Failed(UserSessionPreparationUiFailure.SupportRequired),
+    )
+}
+
+@Preview(name = "User session preparation", showBackground = false)
+@Composable
+private fun PreviewUserSessionPreparationScreen(
+    @PreviewParameter(UserSessionPreparationStatePreviewProvider::class)
+    state: UserSessionPreparationUiState,
+) {
+    WireTheme {
+        UserSessionPreparationScreen(
+            state = state,
+            onRetry = {},
+            onUpdate = {},
+            onContactSupport = {},
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
@@ -36,6 +36,10 @@ import androidx.compose.ui.unit.dp
 import com.wire.android.R
 import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.UserSessionPreparationState
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.map
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -137,6 +141,18 @@ internal enum class UserSessionPreparationUiFailure {
     ApplicationUpdateRequired,
     SupportRequired,
 }
+
+/**
+ * Maps Kalium's preparation states for a collector that cannot keep up with them.
+ *
+ * Kalium publishes on a conflated `StateFlow`, and the main thread is busy with the first frame
+ * during startup. Reading the states straight from the main thread lets a short
+ * [UserSessionPreparationState.MigratingDatabase] window be overwritten before it is ever seen, so
+ * the migration screen never gets a chance to appear. Buffering hands the collector every state in
+ * order instead, at the cost of observing them slightly later than they happened.
+ */
+internal fun Flow<UserSessionPreparationState>.toUiStates(): Flow<UserSessionPreparationUiState> =
+    map { it.toUiState() }.buffer(Channel.UNLIMITED)
 
 internal fun UserSessionPreparationState.toUiState(): UserSessionPreparationUiState = when (this) {
     UserSessionPreparationState.NotStarted -> UserSessionPreparationUiState.ResolvingSession

--- a/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/UserSessionPreparationScreen.kt
@@ -1,0 +1,166 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.wire.android.R
+import com.wire.kalium.logic.UserSessionPreparationFailure
+import com.wire.kalium.logic.UserSessionPreparationState
+
+@Composable
+internal fun UserSessionPreparationScreen(
+    state: UserSessionPreparationUiState,
+    onRetry: () -> Unit,
+    onUpdate: () -> Unit,
+    onContactSupport: () -> Unit,
+) {
+    val content = state.content()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        if (content.action == null) {
+            CircularProgressIndicator()
+            Spacer(Modifier.height(32.dp))
+        }
+        Text(
+            text = stringResource(content.title),
+            style = MaterialTheme.typography.headlineSmall,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(12.dp))
+        Text(
+            text = stringResource(content.message),
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+        )
+        content.action?.let { action ->
+            Spacer(Modifier.height(32.dp))
+            Button(
+                onClick = when (action) {
+                    UserSessionPreparationAction.Retry -> onRetry
+                    UserSessionPreparationAction.Update -> onUpdate
+                    UserSessionPreparationAction.ContactSupport -> onContactSupport
+                }
+            ) {
+                Text(stringResource(action.label))
+            }
+        }
+    }
+}
+
+internal sealed interface UserSessionPreparationUiState {
+    data object ResolvingSession : UserSessionPreparationUiState
+    data object OpeningDatabase : UserSessionPreparationUiState
+    data object MigratingDatabase : UserSessionPreparationUiState
+    data object Ready : UserSessionPreparationUiState
+    data class Failed(val failure: UserSessionPreparationUiFailure) : UserSessionPreparationUiState
+}
+
+internal enum class UserSessionPreparationUiFailure {
+    InsufficientStorage,
+    TemporarilyUnavailable,
+    ApplicationUpdateRequired,
+    SupportRequired,
+}
+
+internal fun UserSessionPreparationState.toUiState(): UserSessionPreparationUiState = when (this) {
+    UserSessionPreparationState.NotStarted -> UserSessionPreparationUiState.ResolvingSession
+    UserSessionPreparationState.OpeningDatabase -> UserSessionPreparationUiState.OpeningDatabase
+    UserSessionPreparationState.MigratingDatabase -> UserSessionPreparationUiState.MigratingDatabase
+    UserSessionPreparationState.Ready -> UserSessionPreparationUiState.Ready
+    is UserSessionPreparationState.Failed -> UserSessionPreparationUiState.Failed(reason.toUiFailure())
+}
+
+internal fun UserSessionPreparationFailure.toUiFailure(): UserSessionPreparationUiFailure = when (this) {
+    UserSessionPreparationFailure.InsufficientStorage -> UserSessionPreparationUiFailure.InsufficientStorage
+    UserSessionPreparationFailure.TemporarilyUnavailable -> UserSessionPreparationUiFailure.TemporarilyUnavailable
+    UserSessionPreparationFailure.ApplicationUpdateRequired -> UserSessionPreparationUiFailure.ApplicationUpdateRequired
+    UserSessionPreparationFailure.SupportRequired -> UserSessionPreparationUiFailure.SupportRequired
+}
+
+private enum class UserSessionPreparationAction(val label: Int) {
+    Retry(R.string.label_try_again),
+    Update(R.string.label_update),
+    ContactSupport(R.string.user_session_preparation_contact_support),
+}
+
+private data class UserSessionPreparationContent(
+    val title: Int,
+    val message: Int,
+    val action: UserSessionPreparationAction? = null,
+)
+
+@Composable
+private fun UserSessionPreparationUiState.content(): UserSessionPreparationContent = when (this) {
+    UserSessionPreparationUiState.ResolvingSession,
+    UserSessionPreparationUiState.OpeningDatabase,
+    UserSessionPreparationUiState.Ready -> UserSessionPreparationContent(
+        title = R.string.user_session_preparation_opening_title,
+        message = R.string.user_session_preparation_opening_message,
+    )
+
+    UserSessionPreparationUiState.MigratingDatabase -> UserSessionPreparationContent(
+        title = R.string.user_session_preparation_migrating_title,
+        message = R.string.user_session_preparation_migrating_message,
+    )
+
+    is UserSessionPreparationUiState.Failed -> when (failure) {
+        UserSessionPreparationUiFailure.InsufficientStorage -> UserSessionPreparationContent(
+            title = R.string.user_session_preparation_storage_title,
+            message = R.string.user_session_preparation_storage_message,
+            action = UserSessionPreparationAction.Retry,
+        )
+
+        UserSessionPreparationUiFailure.TemporarilyUnavailable -> UserSessionPreparationContent(
+            title = R.string.user_session_preparation_temporary_title,
+            message = R.string.user_session_preparation_temporary_message,
+            action = UserSessionPreparationAction.Retry,
+        )
+
+        UserSessionPreparationUiFailure.ApplicationUpdateRequired -> UserSessionPreparationContent(
+            title = R.string.update_app_dialog_title,
+            message = R.string.update_app_dialog_body,
+            action = UserSessionPreparationAction.Update,
+        )
+
+        UserSessionPreparationUiFailure.SupportRequired -> UserSessionPreparationContent(
+            title = R.string.user_session_preparation_support_title,
+            message = R.string.user_session_preparation_support_message,
+            action = UserSessionPreparationAction.ContactSupport,
+        )
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -239,6 +239,10 @@ class WireActivity : BaseActivity() {
     private var shouldKeepSplashOpen = true
     private var isAppLockActivityLaunching = false
     private var startupJob: Job? = null
+    private var isShowingPreparationContent = false
+    private val migrationScreenVisibility = MigrationScreenVisibility {
+        SystemClock.elapsedRealtime()
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val startupAt = SystemClock.elapsedRealtime()
@@ -333,12 +337,14 @@ class WireActivity : BaseActivity() {
     }
 
     private fun setComposableContent(startDestination: Direction) {
+        isShowingPreparationContent = false
         setContent {
             WireActivityRoot(startDestination)
         }
     }
 
     private fun setUserSessionPreparationContent(initialQueuedIntent: QueuedIntent, startupAt: Long) {
+        isShowingPreparationContent = true
         setContent {
             WireTheme(accent = viewModel.globalAppState.userAccent) {
                 UserSessionPreparationScreen(
@@ -351,13 +357,21 @@ class WireActivity : BaseActivity() {
         }
     }
 
+    /**
+     * Reveals the preparation screen only for work that outlives the reveal delay.
+     *
+     * [collectLatest] cancels the pending delay as soon as preparation moves on, so a migration that
+     * finishes quickly never leaves the splash and the screen is skipped altogether.
+     */
     private fun observePreparationScreenReveal() {
         lifecycleScope.launch {
             snapshotFlow { viewModel.userSessionPreparationState }
                 .collectLatest { state ->
-                    val revealDelayMillis = state.preparationScreenRevealDelayMillis()
-                        ?: return@collectLatest
-                    delay(revealDelayMillis)
+                    val revealDelay = state.preparationScreenRevealDelay() ?: return@collectLatest
+                    delay(revealDelay)
+                    if (isShowingPreparationContent && state == UserSessionPreparationUiState.MigratingDatabase) {
+                        migrationScreenVisibility.onRevealed()
+                    }
                     releaseSystemSplash()
                 }
         }
@@ -394,6 +408,8 @@ class WireActivity : BaseActivity() {
                 InitialAppState.SessionPreparationFailed -> error("Handled above")
             }
             traceStartup("activity.initialAppState.resolved:$startDestination", startupAt)
+            // No-op unless the migration screen was actually revealed, so fast startups pay nothing.
+            delay(migrationScreenVisibility.remainingVisibility())
             setComposableContent(startDestination)
             releaseSystemSplash()
             traceStartup("activity.setContent.done", startupAt)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -20,6 +20,7 @@ package com.wire.android.ui
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.SystemClock
@@ -164,6 +165,8 @@ import com.wire.android.ui.userprofile.self.dialog.LogoutOptionsDialogState
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.LocalSyncStateObserver
 import com.wire.android.util.ShakeDetector
+import com.wire.android.util.SupportPage
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.android.util.SyncStateObserver
 import com.wire.android.util.debug.FeatureVisibilityFlags
@@ -171,7 +174,9 @@ import com.wire.android.util.debug.LocalFeatureVisibilityFlags
 import com.wire.android.util.getProviderAuthority
 import com.wire.android.util.launchUpdateTheApp
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
@@ -228,9 +233,11 @@ class WireActivity : BaseActivity() {
     private val newIntents = Channel<QueuedIntent>(Channel.UNLIMITED)
     private lateinit var shakeDetector: ShakeDetector
 
-    // This flag is used to keep the splash screen open until the first screen is drawn.
+    // The system splash only covers the short handoff to Compose. User-session preparation has
+    // its own app screen because a SQLDelight migration can take much longer.
     private var shouldKeepSplashOpen = true
     private var isAppLockActivityLaunching = false
+    private var startupJob: Job? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val startupAt = SystemClock.elapsedRealtime()
@@ -248,55 +255,11 @@ class WireActivity : BaseActivity() {
         enableEdgeToEdge()
         setupOrientationForDevice()
         shakeDetector = ShakeDetector(this)
-
-        lifecycleScope.launch {
-            traceStartup("activity.startupCoroutine.begin", startupAt)
-
-            traceStartup("activity.observePersistentConnectionStatus.start", startupAt)
-            viewModel.observePersistentConnectionStatus()
-
-            traceStartup("activity.initialAppState.start", startupAt)
-            val initialAppState = viewModel.initialAppState()
-            val startDestination = when (initialAppState) {
-                InitialAppState.NotLoggedIn -> when (loginTypeSelector.canUseNewLogin()) {
-                    true -> NewWelcomeEmptyStartScreenDestination()
-                    false -> WelcomeScreenDestination()
-                }
-
-                is InitialAppState.EnrollE2EI -> E2EIEnrollmentScreenDestination(
-                    SessionBackedAuthenticationNavArgs.from(initialAppState.userId)
-                )
-
-                InitialAppState.LoggedIn -> HomeScreenDestination()
-            }
-            traceStartup("activity.initialAppState.resolved:$startDestination", startupAt)
-            setComposableContent(startDestination)
-            traceStartup("activity.setContent.done", startupAt)
-
-            // When the app is locked, get the app lock screen up before the splash screen is
-            // dismissed so that protected content never flashes. Waiting for the current user id
-            // is finite here because a locked app implies a logged-in session; when not logged in
-            // there is nothing to protect. Locks that happen after startup are handled by the
-            // lifecycle observer below.
-            if (initialAppState != InitialAppState.NotLoggedIn && lockCodeTimeManager.value.isAppLocked()) {
-                observeAppLockUserId(
-                    isAppLocked = lockCodeTimeManager.value.observeAppLock(),
-                    currentUserId = snapshotFlow { viewModel.globalAppState.currentUserId },
-                ).first().let { currentUserId ->
-                    startAppLockActivity(currentUserId = currentUserId)
-                }
-                traceStartup("activity.appLock.launched", startupAt)
-            }
-
-            traceStartup("activity.splash.hide", startupAt)
-            shouldKeepSplashOpen = false
-            traceStartup("activity.splash.dismissed", startupAt)
-            (application as? WireApplication)?.initializeDeferredLoggingAfterSplash()
-            traceStartup("activity.deferredLogging.triggered", startupAt)
-
-            handleNewIntent(initialQueuedIntent)
-            traceStartup("activity.initialIntent.dispatched", startupAt)
-        }
+        setUserSessionPreparationContent(initialQueuedIntent, startupAt)
+        traceStartup("activity.preparationContent.done", startupAt)
+        shouldKeepSplashOpen = false
+        (application as? WireApplication)?.initializeDeferredLoggingAfterSplash()
+        startForegroundStartup(initialQueuedIntent, startupAt)
 
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
@@ -375,6 +338,64 @@ class WireActivity : BaseActivity() {
         }
     }
 
+    private fun setUserSessionPreparationContent(initialQueuedIntent: QueuedIntent, startupAt: Long) {
+        setContent {
+            WireTheme(accent = viewModel.globalAppState.userAccent) {
+                UserSessionPreparationScreen(
+                    state = viewModel.userSessionPreparationState,
+                    onRetry = { startForegroundStartup(initialQueuedIntent, startupAt) },
+                    onUpdate = ::updateTheApp,
+                    onContactSupport = ::openSupport,
+                )
+            }
+        }
+    }
+
+    private fun startForegroundStartup(initialQueuedIntent: QueuedIntent, startupAt: Long) {
+        if (startupJob?.isActive == true) return
+        startupJob = lifecycleScope.launch {
+            traceStartup("activity.startupCoroutine.begin", startupAt)
+            traceStartup("activity.initialAppState.start", startupAt)
+            val initialAppState = viewModel.initialAppState()
+            if (initialAppState == InitialAppState.SessionPreparationFailed) {
+                traceStartup("activity.initialAppState.preparationFailed", startupAt)
+                return@launch
+            }
+            val startDestination = when (initialAppState) {
+                InitialAppState.NotLoggedIn -> when (loginTypeSelector.canUseNewLogin()) {
+                    true -> NewWelcomeEmptyStartScreenDestination()
+                    false -> WelcomeScreenDestination()
+                }
+
+                is InitialAppState.EnrollE2EI -> E2EIEnrollmentScreenDestination(
+                    SessionBackedAuthenticationNavArgs.from(initialAppState.userId)
+                )
+
+                InitialAppState.LoggedIn -> HomeScreenDestination()
+                InitialAppState.SessionPreparationFailed -> error("Handled above")
+            }
+            traceStartup("activity.initialAppState.resolved:$startDestination", startupAt)
+            setComposableContent(startDestination)
+            traceStartup("activity.setContent.done", startupAt)
+
+            traceStartup("activity.observePersistentConnectionStatus.start", startupAt)
+            viewModel.observePersistentConnectionStatus()
+
+            if (initialAppState != InitialAppState.NotLoggedIn && lockCodeTimeManager.value.isAppLocked()) {
+                observeAppLockUserId(
+                    isAppLocked = lockCodeTimeManager.value.observeAppLock(),
+                    currentUserId = snapshotFlow { viewModel.globalAppState.currentUserId },
+                ).first().let { currentUserId ->
+                    startAppLockActivity(currentUserId = currentUserId)
+                }
+                traceStartup("activity.appLock.launched", startupAt)
+            }
+
+            handleNewIntent(initialQueuedIntent)
+            traceStartup("activity.initialIntent.dispatched", startupAt)
+        }
+    }
+
     private fun traceStartup(event: String, startedAt: Long? = null) {
         val elapsed = startedAt?.let { " (+${SystemClock.elapsedRealtime() - it}ms)" }.orEmpty()
         Log.i(TAG, "startup:$event$elapsed")
@@ -421,6 +442,7 @@ class WireActivity : BaseActivity() {
     }
 
     @Composable
+    @Suppress("CyclomaticComplexMethod")
     private fun WireActivityThemedContent(
         startDestination: Direction,
         appGraph: WireApplicationGraph,
@@ -428,6 +450,15 @@ class WireActivity : BaseActivity() {
         sessionGraphStore: SessionGraphStoreViewModel,
         context: Context,
     ) {
+        if (viewModel.userSessionPreparationState !is UserSessionPreparationUiState.Ready) {
+            UserSessionPreparationScreen(
+                state = viewModel.userSessionPreparationState,
+                onRetry = viewModel::retryPendingUserSessionPreparation,
+                onUpdate = ::updateTheApp,
+                onContactSupport = ::openSupport,
+            )
+            return
+        }
         val isUserUiBlocked = viewModel.globalAppState.blockUserUI != null
         val navigator = rememberWireActivityNavigator(
             isUserUiBlocked = isUserUiBlocked,
@@ -474,6 +505,8 @@ class WireActivity : BaseActivity() {
             startDestinationBaseRoute = navHostStartDestination.baseRoute,
             isUserUiBlocked = isUserUiBlocked,
             isSessionTransitionInProgress = isSessionTransitionInProgress,
+            preparedSessionScope = sessionBackedAuthenticationUserId?.let(viewModel::preparedUserSessionScope)
+                ?: currentUserId?.let(viewModel::preparedUserSessionScope),
         )
         val lastSessionGraphContext = remember { mutableStateOf<WireActivityGraphContext?>(null) }
         if (graphContext?.sessionGraph != null) {
@@ -666,6 +699,7 @@ class WireActivity : BaseActivity() {
         startDestinationBaseRoute: String,
         isUserUiBlocked: Boolean,
         isSessionTransitionInProgress: Boolean,
+        preparedSessionScope: UserSessionScope?,
     ): WireActivityGraphContext? {
         if (isUserUiBlocked) return null
 
@@ -681,6 +715,7 @@ class WireActivity : BaseActivity() {
             usesNoSessionAuthenticationGraph,
             usesInvalidSessionBackedAuthenticationGraph,
             isSessionTransitionInProgress,
+            preparedSessionScope,
         ) {
             sessionGraphStore.resolveSessionGraph(
                 currentUserId = currentUserId,
@@ -688,6 +723,7 @@ class WireActivity : BaseActivity() {
                 usesNoSessionAuthenticationGraph = usesNoSessionAuthenticationGraph,
                 usesInvalidSessionBackedAuthenticationGraph = usesInvalidSessionBackedAuthenticationGraph,
                 isSessionTransitionInProgress = isSessionTransitionInProgress,
+                preparedSessionScope = preparedSessionScope,
             )
         }
         val sessionGraph = retainedSessionGraph?.graph
@@ -717,18 +753,21 @@ class WireActivity : BaseActivity() {
         }
     }
 
+    @Suppress("LongParameterList")
     private fun SessionGraphStoreViewModel.resolveSessionGraph(
         currentUserId: UserId?,
         sessionBackedAuthenticationUserId: UserId?,
         usesNoSessionAuthenticationGraph: Boolean,
         usesInvalidSessionBackedAuthenticationGraph: Boolean,
         isSessionTransitionInProgress: Boolean,
+        preparedSessionScope: UserSessionScope?,
     ): RetainedSessionGraph? = when {
         usesNoSessionAuthenticationGraph -> null
         usesInvalidSessionBackedAuthenticationGraph -> null
         isSessionTransitionInProgress -> null
-        sessionBackedAuthenticationUserId != null -> retainedGraphFor(sessionBackedAuthenticationUserId)
-        currentUserId != null -> retainedGraphFor(currentUserId)
+        sessionBackedAuthenticationUserId != null && preparedSessionScope != null ->
+            retainedGraphFor(sessionBackedAuthenticationUserId, preparedSessionScope)
+        currentUserId != null && preparedSessionScope != null -> retainedGraphFor(currentUserId, preparedSessionScope)
         else -> null
     }
 
@@ -1191,6 +1230,11 @@ class WireActivity : BaseActivity() {
 
     private fun updateTheApp() = this.launchUpdateTheApp()
 
+    private fun openSupport() {
+        val supportUrl = SupportUrlResolver.resolve(resources, SupportPage.SUPPORT)
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(supportUrl)))
+    }
+
     override fun onResume() {
         super.onResume()
         shakeDetector.start()
@@ -1376,16 +1420,16 @@ private data class WireActivityGraphContext(
 )
 
 internal class SessionGraphStoreViewModel(
-    private val createSessionGraph: (UserId) -> AppSessionViewModelGraph,
+    private val createSessionGraph: (UserId, UserSessionScope) -> AppSessionViewModelGraph,
 ) : ViewModel() {
     private val sessionGraphs = mutableMapOf<UserId, RetainedSessionGraph>()
     private var activeUserId: UserId? = null
 
-    fun retainedGraphFor(userId: UserId): RetainedSessionGraph {
+    fun retainedGraphFor(userId: UserId, userSessionScope: UserSessionScope): RetainedSessionGraph {
         activeUserId = userId
         return sessionGraphs.getOrPut(userId) {
             appLogger.i("WireActivity creating lifecycle-retained session graph for $userId")
-            RetainedSessionGraph(createSessionGraph(userId))
+            RetainedSessionGraph(createSessionGraph(userId, userSessionScope))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivity.kt
@@ -178,6 +178,7 @@ import com.wire.kalium.logic.feature.UserSessionScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -257,8 +258,7 @@ class WireActivity : BaseActivity() {
         shakeDetector = ShakeDetector(this)
         setUserSessionPreparationContent(initialQueuedIntent, startupAt)
         traceStartup("activity.preparationContent.done", startupAt)
-        shouldKeepSplashOpen = false
-        (application as? WireApplication)?.initializeDeferredLoggingAfterSplash()
+        observePreparationScreenReveal()
         startForegroundStartup(initialQueuedIntent, startupAt)
 
         lifecycleScope.launch {
@@ -351,6 +351,24 @@ class WireActivity : BaseActivity() {
         }
     }
 
+    private fun observePreparationScreenReveal() {
+        lifecycleScope.launch {
+            snapshotFlow { viewModel.userSessionPreparationState }
+                .collectLatest { state ->
+                    val revealDelayMillis = state.preparationScreenRevealDelayMillis()
+                        ?: return@collectLatest
+                    delay(revealDelayMillis)
+                    releaseSystemSplash()
+                }
+        }
+    }
+
+    private fun releaseSystemSplash() {
+        if (!shouldKeepSplashOpen) return
+        shouldKeepSplashOpen = false
+        (application as? WireApplication)?.initializeDeferredLoggingAfterSplash()
+    }
+
     private fun startForegroundStartup(initialQueuedIntent: QueuedIntent, startupAt: Long) {
         if (startupJob?.isActive == true) return
         startupJob = lifecycleScope.launch {
@@ -359,6 +377,7 @@ class WireActivity : BaseActivity() {
             val initialAppState = viewModel.initialAppState()
             if (initialAppState == InitialAppState.SessionPreparationFailed) {
                 traceStartup("activity.initialAppState.preparationFailed", startupAt)
+                releaseSystemSplash()
                 return@launch
             }
             val startDestination = when (initialAppState) {
@@ -376,6 +395,7 @@ class WireActivity : BaseActivity() {
             }
             traceStartup("activity.initialAppState.resolved:$startDestination", startupAt)
             setComposableContent(startDestination)
+            releaseSystemSplash()
             traceStartup("activity.setContent.done", startupAt)
 
             traceStartup("activity.observePersistentConnectionStatus.start", startupAt)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -99,7 +99,9 @@ import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSo
 import kotlinx.datetime.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -452,12 +454,15 @@ class WireActivityViewModel @Inject constructor(
         pendingPreparationUserId = userId
 
         val result = coroutineScope {
-            val observer = launch(start = CoroutineStart.UNDISPATCHED) {
-                userSessionPreparationGate.observe(userId).collect { state ->
-                    withContext(dispatchers.main()) {
-                        userSessionPreparationState = state.toUiState()
-                    }
-                }
+            // Kalium publishes preparation states on a conflated StateFlow. Hopping to the main
+            // thread per emission would let a busy first frame swallow MigratingDatabase entirely,
+            // so states are picked up off the main thread and buffered for it to drain in order.
+            val observer = launch(dispatchers.main(), start = CoroutineStart.UNDISPATCHED) {
+                userSessionPreparationGate.observe(userId)
+                    .map { it.toUiState() }
+                    .buffer(Channel.UNLIMITED)
+                    .flowOn(dispatchers.io())
+                    .collect { state -> userSessionPreparationState = state }
             }
             try {
                 userSessionPreparationGate.prepare(userId)

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -99,9 +99,7 @@ import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSo
 import kotlinx.datetime.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -109,7 +107,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -454,13 +451,11 @@ class WireActivityViewModel @Inject constructor(
         pendingPreparationUserId = userId
 
         val result = coroutineScope {
-            // Kalium publishes preparation states on a conflated StateFlow. Hopping to the main
-            // thread per emission would let a busy first frame swallow MigratingDatabase entirely,
-            // so states are picked up off the main thread and buffered for it to drain in order.
+            // States are picked up off the main thread so a busy first frame cannot swallow
+            // MigratingDatabase, then drained in order once the main thread is free again.
             val observer = launch(dispatchers.main(), start = CoroutineStart.UNDISPATCHED) {
                 userSessionPreparationGate.observe(userId)
-                    .map { it.toUiState() }
-                    .buffer(Channel.UNLIMITED)
+                    .toUiStates()
                     .flowOn(dispatchers.io())
                     .collect { state -> userSessionPreparationState = state }
             }

--- a/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/WireActivityViewModel.kt
@@ -32,10 +32,6 @@ import com.wire.android.config.NomadProfilesFeatureConfig
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.IsProfileQRCodeEnabledUseCaseProvider
 import com.wire.android.di.KaliumCoreLogic
-import com.wire.android.di.ObserveIfE2EIRequiredDuringLoginUseCaseProvider
-import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
-import com.wire.android.di.ObserveSelfUserUseCaseProvider
-import com.wire.android.di.ObserveSyncStateUseCaseProvider
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountActions
@@ -43,6 +39,8 @@ import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
 import com.wire.android.navigation.LoginTypeSelector
 import com.wire.android.services.ServicesManager
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.sync.MonitorSyncWorkUseCase
 import com.wire.android.ui.authentication.devices.model.displayName
 import com.wire.android.ui.common.ActionsViewModel
@@ -77,6 +75,7 @@ import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.IsNomadProfilesEnabledUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
 import com.wire.kalium.logic.feature.client.ClearNewClientsForUserUseCase
@@ -99,6 +98,7 @@ import com.wire.kalium.logic.feature.user.screenshotCensoring.ObserveScreenshotC
 import com.wire.kalium.logic.feature.user.webSocketStatus.ObservePersistentWebSocketConnectionStatusUseCase
 import kotlinx.datetime.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -106,20 +106,26 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import java.io.InputStream
 import java.io.InputStreamReader
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import dev.zacsweers.metro.Inject
 
 private const val AUTOMATED_NOMAD_COOKIE_LABEL = "shared-device"
@@ -137,19 +143,13 @@ class WireActivityViewModel @Inject constructor(
     private val observeSessions: Lazy<ObserveSessionsUseCase>,
     private val accountSwitch: Lazy<AccountSwitchUseCase>,
     private val servicesManager: Lazy<ServicesManager>,
-    private val observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory,
     private val observeIfAppUpdateRequired: Lazy<ObserveIfAppUpdateRequiredUseCase>,
     private val observeNewClients: Lazy<ObserveNewClientsUseCase>,
     private val clearNewClientsForUser: Lazy<ClearNewClientsForUserUseCase>,
     private val currentScreenManager: Lazy<CurrentScreenManager>,
-    private val observeScreenshotCensoringConfigUseCaseProviderFactory:
-    ObserveScreenshotCensoringConfigUseCaseProvider.Factory,
     private val globalDataStore: Lazy<GlobalDataStore>,
-    private val observeIfE2EIRequiredDuringLoginUseCaseProviderFactory:
-    ObserveIfE2EIRequiredDuringLoginUseCaseProvider.Factory,
     private val workManager: Lazy<WorkManager>,
     private val isProfileQRCodeEnabledFactory: IsProfileQRCodeEnabledUseCaseProvider.Factory,
-    private val observeSelfUserFactory: ObserveSelfUserUseCaseProvider.Factory,
     private val monitorSyncWorkUseCase: MonitorSyncWorkUseCase,
     private val managedConfigurationsManager: ManagedConfigurationsManager,
     private val defaultServerConfig: ServerConfig.Links,
@@ -162,19 +162,21 @@ class WireActivityViewModel @Inject constructor(
     var globalAppState: GlobalAppState by mutableStateOf(GlobalAppState())
         private set
 
+    internal var userSessionPreparationState: UserSessionPreparationUiState by
+        mutableStateOf(UserSessionPreparationUiState.ResolvingSession)
+        private set
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic.value) }
+    private val preparedSessionScopes = ConcurrentHashMap<UserId, UserSessionScope>()
+    private val preparedCurrentSession = MutableStateFlow<PreparedCurrentSession?>(null)
+    private val sessionObserversStarted = AtomicBoolean(false)
+    private var pendingPreparationUserId: UserId? = null
+
     private val _observeSyncFlowState: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     val observeSyncFlowState: StateFlow<SyncState?> = _observeSyncFlowState
 
     private val observeCurrentAccountInfo: SharedFlow<AccountInfo?> = currentSessionFlow.value.invoke()
         .map { (it as? CurrentSessionResult.Success)?.accountInfo }
-        .distinctUntilChanged()
-        .flowOn(dispatchers.io())
-        .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
-
-    private val observeCurrentValidUserId: SharedFlow<UserId?> = observeCurrentAccountInfo
-        .map {
-            if (it?.isValid() == true) it.userId else null
-        }
         .distinctUntilChanged()
         .flowOn(dispatchers.io())
         .shareIn(viewModelScope, SharingStarted.WhileSubscribed(), 1)
@@ -190,22 +192,29 @@ class WireActivityViewModel @Inject constructor(
     private lateinit var validSessions: StateFlow<List<AccountInfo>>
 
     init {
-        observeSyncState()
         observeUpdateAppState()
-        observeNewClientState()
-        observeScreenshotCensoringConfigState()
-        observeCurrentUserState()
         observeAppThemeState()
+        // These collectors are safe to start before foreground navigation. The current-session
+        // collector is itself the preparation gate, while the others only dereference a session
+        // after it has been published through preparedCurrentSession.
+        observeCurrentUserState()
+        observeSyncState()
+        observeScreenshotCensoringConfigState()
         observeSelectedAccent()
         observeLogoutState()
         observeBackendWebsiteUrl()
         resetNewRegistrationAnalyticsState()
-        viewModelScope.launch(dispatchers.io()) { monitorSyncWorkUseCase() }
     }
 
-    private suspend fun shouldEnrollToE2ei(userId: UserId): Boolean =
-        observeIfE2EIRequiredDuringLoginUseCaseProviderFactory.create(userId)
-            .observeIfE2EIIsRequiredDuringLogin().first() ?: false
+    private suspend fun shouldEnrollToE2ei(sessionScope: UserSessionScope): Boolean =
+        sessionScope.observeIfE2EIRequiredDuringLogin().first() ?: false
+
+    private fun startSessionDependentObservers() {
+        if (!sessionObserversStarted.compareAndSet(false, true)) return
+
+        observeNewClientState()
+        viewModelScope.launch(dispatchers.io()) { monitorSyncWorkUseCase() }
+    }
 
     private fun observeAppThemeState() {
         viewModelScope.launch(dispatchers.io()) {
@@ -219,9 +228,9 @@ class WireActivityViewModel @Inject constructor(
 
     private fun observeSelectedAccent() {
         viewModelScope.launch(dispatchers.io()) {
-            observeCurrentValidUserId.flatMapLatest {
-                it?.let {
-                    observeSelfUserFactory.create(it).observeSelfUser().map { user ->
+            preparedCurrentSession.flatMapLatest { preparedSession ->
+                preparedSession?.let {
+                    it.sessionScope.users.observeSelfUser().map { user ->
                         Accent.fromAccentId(user.accentId)
                     }
                 } ?: flowOf(Accent.Unknown)
@@ -235,10 +244,10 @@ class WireActivityViewModel @Inject constructor(
 
     private fun observeBackendWebsiteUrl() {
         viewModelScope.launch(dispatchers.io()) {
-            observeCurrentValidUserId.collectLatest { userId ->
-                val serverLinks = userId?.let {
+            preparedCurrentSession.collectLatest { preparedSession ->
+                val serverLinks = preparedSession?.let {
                     runCatching {
-                        when (val result = coreLogic.value.getSessionScope(it).users.serverLinks()) {
+                        when (val result = it.sessionScope.users.serverLinks()) {
                             is SelfServerConfigUseCase.Result.Success -> result.serverLinks.links
                             is SelfServerConfigUseCase.Result.Failure -> null
                         }
@@ -257,10 +266,10 @@ class WireActivityViewModel @Inject constructor(
 
     private fun observeSyncState() {
         viewModelScope.launch(dispatchers.io()) {
-            observeCurrentValidUserId
-                .flatMapLatest { userId ->
-                    userId?.let {
-                        observeSyncStateUseCaseProviderFactory.create(userId).observeSyncState()
+            preparedCurrentSession
+                .flatMapLatest { preparedSession ->
+                    preparedSession?.let {
+                        it.sessionScope.observeSyncState()
                     } ?: flowOf(null)
                 }
                 .distinctUntilChanged()
@@ -273,15 +282,22 @@ class WireActivityViewModel @Inject constructor(
 
     private fun observeCurrentUserState() {
         viewModelScope.launch(dispatchers.io()) {
-            observeCurrentUserId.collectLatest {
+            observeCurrentUserId.collectLatest { userId ->
+                val sessionScope = userId?.let { prepareUserSession(it) }
+                val readyUserId = userId?.takeIf { sessionScope != null }
+                preparedCurrentSession.value = if (readyUserId != null && sessionScope != null) {
+                    PreparedCurrentSession(readyUserId, sessionScope)
+                } else {
+                    null
+                }
                 globalAppState = globalAppState.copy(
-                    currentUserId = it,
-                    isSessionTransitionInProgress = if (it != null) {
+                    currentUserId = readyUserId,
+                    isSessionTransitionInProgress = if (readyUserId != null) {
                         false
                     } else {
                         globalAppState.isSessionTransitionInProgress
                     },
-                    sessionTransitionReason = if (it != null) {
+                    sessionTransitionReason = if (readyUserId != null) {
                         null
                     } else {
                         globalAppState.sessionTransitionReason
@@ -323,7 +339,13 @@ class WireActivityViewModel @Inject constructor(
             currentScreenManager.value.observeCurrentScreen(this)
                 .flatMapLatest {
                     if (it.isGlobalDialogAllowed()) {
-                        observeNewClients.value.invoke()
+                        flow<NewClientResult> {
+                            if (prepareValidSessionsForNewClientObservation()) {
+                                emitAll(observeNewClients.value.invoke())
+                            } else {
+                                emit(NewClientResult.Empty)
+                            }
+                        }
                     } else {
                         flowOf(NewClientResult.Empty)
                     }
@@ -335,13 +357,23 @@ class WireActivityViewModel @Inject constructor(
         }
     }
 
+    private suspend fun prepareValidSessionsForNewClientObservation(): Boolean {
+        val sessions = if (::validSessions.isInitialized) {
+            validSessions.value
+        } else {
+            validSessionsFlow().first()
+        }
+        return sessions
+            .filter { it.isValid() }
+            .all { prepareUserSession(it.userId) != null }
+    }
+
     private fun observeScreenshotCensoringConfigState() {
         viewModelScope.launch(dispatchers.io()) {
-            observeCurrentValidUserId
-                .flatMapLatest { currentValidUserId ->
-                    currentValidUserId?.let {
-                        observeScreenshotCensoringConfigUseCaseProviderFactory.create(it)
-                            .observeScreenshotCensoringConfig()
+            preparedCurrentSession
+                .flatMapLatest { preparedSession ->
+                    preparedSession?.let {
+                        it.sessionScope.observeScreenshotCensoringConfig()
                             .map { result ->
                                 result is ObserveScreenshotCensoringConfigResult.Enabled
                             }
@@ -364,19 +396,91 @@ class WireActivityViewModel @Inject constructor(
     }
 
     suspend fun initialAppState(): InitialAppState = withContext(dispatchers.io()) {
+        withContext(dispatchers.main()) {
+            userSessionPreparationState = UserSessionPreparationUiState.ResolvingSession
+        }
         initValidSessionsFlowIfNeeded()
         val currentValidUserId = resolveInitialCurrentUserId()
+        val preparedSessionScope = currentValidUserId?.let { prepareUserSession(it) }
+        preparedCurrentSession.value = if (currentValidUserId != null && preparedSessionScope != null) {
+            PreparedCurrentSession(currentValidUserId, preparedSessionScope)
+        } else {
+            null
+        }
         withContext(dispatchers.main()) {
             globalAppState = globalAppState.copy(
-                currentUserId = currentValidUserId,
+                currentUserId = currentValidUserId?.takeIf { preparedSessionScope != null },
                 isSessionTransitionInProgress = false,
                 sessionTransitionReason = null,
             )
         }
+        if (currentValidUserId != null && preparedSessionScope == null) {
+            return@withContext InitialAppState.SessionPreparationFailed
+        }
+        startSessionDependentObservers()
         when {
-            currentValidUserId == null -> InitialAppState.NotLoggedIn
-            shouldEnrollToE2ei(currentValidUserId) -> InitialAppState.EnrollE2EI(currentValidUserId)
+            currentValidUserId == null -> {
+                withContext(dispatchers.main()) {
+                    userSessionPreparationState = UserSessionPreparationUiState.Ready
+                }
+                InitialAppState.NotLoggedIn
+            }
+            shouldEnrollToE2ei(checkNotNull(preparedSessionScope)) -> InitialAppState.EnrollE2EI(currentValidUserId)
             else -> InitialAppState.LoggedIn
+        }
+    }
+
+    fun preparedUserSessionScope(userId: UserId): UserSessionScope? = preparedSessionScopes[userId]
+
+    fun retryPendingUserSessionPreparation() {
+        val userId = pendingPreparationUserId ?: return
+        viewModelScope.launch(dispatchers.io()) {
+            val sessionScope = prepareUserSession(userId) ?: return@launch
+            withContext(dispatchers.main()) {
+                globalAppState = globalAppState.copy(
+                    currentUserId = userId,
+                    isSessionTransitionInProgress = false,
+                    sessionTransitionReason = null,
+                )
+            }
+            preparedSessionScopes[userId] = sessionScope
+            preparedCurrentSession.value = PreparedCurrentSession(userId, sessionScope)
+        }
+    }
+
+    private suspend fun prepareUserSession(userId: UserId): UserSessionScope? {
+        pendingPreparationUserId = userId
+
+        val result = coroutineScope {
+            val observer = launch(start = CoroutineStart.UNDISPATCHED) {
+                userSessionPreparationGate.observe(userId).collect { state ->
+                    withContext(dispatchers.main()) {
+                        userSessionPreparationState = state.toUiState()
+                    }
+                }
+            }
+            try {
+                userSessionPreparationGate.prepare(userId)
+            } finally {
+                observer.cancelAndJoin()
+            }
+        }
+
+        return when (result) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope.also { sessionScope ->
+                preparedSessionScopes[userId] = sessionScope
+                pendingPreparationUserId = null
+                withContext(dispatchers.main()) {
+                    userSessionPreparationState = UserSessionPreparationUiState.Ready
+                }
+            }
+
+            is AppUserSessionPreparationResult.Failed -> {
+                withContext(dispatchers.main()) {
+                    userSessionPreparationState = UserSessionPreparationUiState.Failed(result.reason.toUiFailure())
+                }
+                null
+            }
         }
     }
 
@@ -428,8 +532,8 @@ class WireActivityViewModel @Inject constructor(
                 is CurrentSessionResult.Failure.Generic -> null
                 CurrentSessionResult.Failure.SessionNotFound -> null
                 is CurrentSessionResult.Success -> {
-                    coreLogic.value.sessionScope(currentSession.accountInfo.userId) {
-                        when (val result = debug.synchronizeExternalData(InputStreamReader(data).readText())) {
+                    prepareUserSession(currentSession.accountInfo.userId)?.let { sessionScope ->
+                        when (val result = sessionScope.debug.synchronizeExternalData(InputStreamReader(data).readText())) {
                             is SynchronizeExternalDataResult.Success -> {
                                 appLogger.d("Synchronized external data")
                             }
@@ -654,7 +758,7 @@ class WireActivityViewModel @Inject constructor(
                     }
                 }
                 val logoutReason = if (wipeData) LogoutReason.SELF_HARD_LOGOUT else LogoutReason.SELF_SOFT_LOGOUT
-                coreLogic.value.getSessionScope(currentUserId).logout(logoutReason)
+                preparedSessionScopes[currentUserId]?.logout(logoutReason)
                 if (wipeData) {
                     clearUserData(currentUserId)
                 }
@@ -765,6 +869,7 @@ class WireActivityViewModel @Inject constructor(
     private suspend fun isCrossBackendLoginBlocked(target: IsCrossBackendLoginBlockedUseCase.Target): Boolean =
         coreLogic.value.getGlobalScope().isCrossBackendLoginBlocked(target)
 
+    @Suppress("NestedBlockDepth")
     private suspend fun onConversationInviteDeepLink(
         code: String,
         key: String,
@@ -774,8 +879,8 @@ class WireActivityViewModel @Inject constructor(
         is CurrentSessionResult.Failure.Generic -> null
         CurrentSessionResult.Failure.SessionNotFound -> null
         is CurrentSessionResult.Success -> {
-            coreLogic.value.sessionScope(currentSession.accountInfo.userId) {
-                when (val result = conversations.checkIConversationInviteCode(code, key, domain)) {
+            prepareUserSession(currentSession.accountInfo.userId)?.let { sessionScope ->
+                when (val result = sessionScope.conversations.checkIConversationInviteCode(code, key, domain)) {
                     is CheckConversationInviteCodeUseCase.Result.Success -> {
                         if (result.isSelfMember) {
                             // TODO; display messsage that user is already a member and ask if they want to navigate to the conversation
@@ -825,15 +930,22 @@ class WireActivityViewModel @Inject constructor(
         val userId = withContext(dispatchers.io()) {
             currentSessionUserId()
         }
+        val sessionScope = userId?.let { prepareUserSession(it) }
+        val readyUserId = userId?.takeIf { sessionScope != null }
+        preparedCurrentSession.value = if (readyUserId != null && sessionScope != null) {
+            PreparedCurrentSession(readyUserId, sessionScope)
+        } else {
+            null
+        }
         withContext(dispatchers.main()) {
             globalAppState = globalAppState.copy(
-                currentUserId = userId,
-                isSessionTransitionInProgress = if (userId != null) {
+                currentUserId = readyUserId,
+                isSessionTransitionInProgress = if (readyUserId != null) {
                     false
                 } else {
                     globalAppState.isSessionTransitionInProgress
                 },
-                sessionTransitionReason = if (userId != null) {
+                sessionTransitionReason = if (readyUserId != null) {
                     null
                 } else {
                     globalAppState.sessionTransitionReason
@@ -910,8 +1022,8 @@ class WireActivityViewModel @Inject constructor(
     }
 
     private fun onOpenUserProfileDeepLink(result: DeepLinkResult.OpenOtherUserProfile) = viewModelScope.launch {
-        observeCurrentValidUserId.first()?.let { userId ->
-            if (isProfileQRCodeEnabledFactory.create(userId).isProfileQRCodeEnabled()) {
+        preparedCurrentSession.first()?.let { preparedSession ->
+            if (isProfileQRCodeEnabledFactory.create(preparedSession.userId).isProfileQRCodeEnabled()) {
                 sendAction(OnOpenUserProfile(result))
             } else {
                 sendAction(ShowToast(R.string.profile_deeplink_feature_unavailable_title_alert))
@@ -1016,7 +1128,13 @@ sealed interface InitialAppState {
     data object NotLoggedIn : InitialAppState
     data object LoggedIn : InitialAppState
     data class EnrollE2EI(val userId: UserId) : InitialAppState
+    data object SessionPreparationFailed : InitialAppState
 }
+
+private data class PreparedCurrentSession(
+    val userId: UserId,
+    val sessionScope: UserSessionScope,
+)
 
 sealed interface WireActivityViewAction
 internal data class OpenConversation(val result: DeepLinkResult.OpenConversation) : WireActivityViewAction

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
@@ -27,9 +27,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.BuildConfig
-import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.authentication.create.common.CreateAccountFlowType
 import com.wire.android.ui.authentication.create.common.CreateAccountNavArgs
 import com.wire.android.ui.authentication.login.email.LoginEmailViewModel.Companion.RESEND_TIMER_DELAY
@@ -37,12 +38,14 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.registration.code.CreateAccountCodeResult
 import com.wire.android.util.WillNeverOccurError
 import com.wire.android.util.ui.CountdownTimer
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.session.StoreSessionParam
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.client.RegisterClientParam
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.register.RegisterParam
@@ -59,7 +62,6 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
     @Assisted savedStateHandle: SavedStateHandle,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
-    private val clientScopeProviderFactory: ClientScopeProvider.Factory,
     defaultServerConfig: ServerConfig.Links,
     @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean
 ) : ViewModel() {
@@ -67,6 +69,8 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
     interface Factory {
         fun create(savedStateHandle: SavedStateHandle): CreateAccountCodeViewModel
     }
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     val createAccountNavArgs: CreateAccountNavArgs = savedStateHandle.navArgs()
 
@@ -205,7 +209,18 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
                     is AddAuthenticatedUserUseCase.Result.Success -> it.userId
                 }
             }
-            registerClient(storedUserId, registerParam.password).let {
+            val sessionScope = when (val preparation = userSessionPreparationGate.prepare(storedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    updateCodeErrorState(
+                        CreateAccountCodeResult.Error.DialogError.GenericError(
+                            CoreFailure.Unknown(IllegalStateException("User session preparation failed: ${preparation.reason}"))
+                        )
+                    )
+                    return@launch
+                }
+            }
+            registerClient(sessionScope, registerParam.password).let {
                 when (it) {
                     is RegisterClientResult.Failure -> {
                         updateCodeErrorState(it.toCodeError(storedUserId))
@@ -229,8 +244,8 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
         codeState = codeState.copy(loading = false, result = codeError)
     }
 
-    private suspend fun registerClient(userId: UserId, password: String) =
-        clientScopeProviderFactory.create(userId).clientScope.getOrRegister(
+    private suspend fun registerClient(sessionScope: UserSessionScope, password: String) =
+        sessionScope.client.getOrRegister(
             RegisterClientParam(
                 password = password,
                 capabilities = null,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
 import com.wire.kalium.logic.feature.auth.DomainLookupUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 
 @Suppress("TooManyFunctions")
@@ -59,6 +60,13 @@ open class LoginViewModel(
         secondFactorVerificationCode: String? = null,
         capabilities: List<ClientCapability>? = null,
     ): RegisterClientResult = loginExtension.registerClient(userId, password, secondFactorVerificationCode, capabilities)
+
+    suspend fun registerClient(
+        sessionScope: UserSessionScope,
+        password: String?,
+        secondFactorVerificationCode: String? = null,
+        capabilities: List<ClientCapability>? = null,
+    ): RegisterClientResult = loginExtension.registerClient(sessionScope, password, secondFactorVerificationCode, capabilities)
 
     internal suspend fun isInitialSyncCompleted(userId: UserId): Boolean = loginExtension.isInitialSyncCompleted(userId)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModelExtension.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModelExtension.kt
@@ -22,6 +22,8 @@ import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
 import com.wire.kalium.logic.data.client.ClientCapability
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientParam
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import kotlinx.coroutines.flow.first
@@ -38,15 +40,34 @@ class LoginViewModelExtension(
         capabilities: List<ClientCapability>? = null,
     ): RegisterClientResult {
         val clientScope = clientScopeProviderFactory.create(userId).clientScope
-        return clientScope.getOrRegister(
-            RegisterClientParam(
-                password = password,
-                capabilities = capabilities,
-                secondFactorVerificationCode = secondFactorVerificationCode,
-                modelPostfix = if (BuildConfig.PRIVATE_BUILD) " [${BuildConfig.FLAVOR}_${BuildConfig.BUILD_TYPE}]" else null
-            )
-        )
+        return registerClient(clientScope.getOrRegister, password, secondFactorVerificationCode, capabilities)
     }
+
+    suspend fun registerClient(
+        sessionScope: UserSessionScope,
+        password: String?,
+        secondFactorVerificationCode: String? = null,
+        capabilities: List<ClientCapability>? = null,
+    ): RegisterClientResult = registerClient(
+        sessionScope.client.getOrRegister,
+        password,
+        secondFactorVerificationCode,
+        capabilities,
+    )
+
+    private suspend fun registerClient(
+        getOrRegister: GetOrRegisterClientUseCase,
+        password: String?,
+        secondFactorVerificationCode: String?,
+        capabilities: List<ClientCapability>?,
+    ): RegisterClientResult = getOrRegister(
+        RegisterClientParam(
+            password = password,
+            capabilities = capabilities,
+            secondFactorVerificationCode = secondFactorVerificationCode,
+            modelPostfix = if (BuildConfig.PRIVATE_BUILD) " [${BuildConfig.FLAVOR}_${BuildConfig.BUILD_TYPE}]" else null
+        )
+    )
 
     internal suspend fun isInitialSyncCompleted(userId: UserId): Boolean =
         userDataStoreProvider.getOrCreate(userId).initialSyncCompleted.first()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -27,11 +27,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.authentication.toBackendConfigUrl
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.LoginSavedInputStore
@@ -137,6 +140,7 @@ class LoginEmailViewModel(
     )
 
     private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle ?: PreFilledUserIdentifierType.None
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     val userIdentifierTextState: TextFieldState = TextFieldState()
     val passwordTextState: TextFieldState = TextFieldState()
@@ -327,9 +331,24 @@ class LoginEmailViewModel(
                 }
             }
 
+            val preparedSessionScope = when (val preparation = userSessionPreparationGate.prepare(storedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    restorePreviousSession()
+                    updateEmailFlowState(
+                        LoginState.Error.DialogError.GenericError(
+                            com.wire.kalium.common.error.CoreFailure.Unknown(
+                                IllegalStateException("User session preparation failed: ${preparation.reason}")
+                            )
+                        )
+                    )
+                    return@launch
+                }
+            }
+
             withContext(dispatchers.io()) {
                 if (coreLogic.getGlobalScope().validateEmailUseCase(userIdentifierTextState.text.toString())) {
-                    coreLogic.getSessionScope(storedUserId).users.persistSelfUserEmail(userIdentifierTextState.text.toString())
+                    preparedSessionScope.users.persistSelfUserEmail(userIdentifierTextState.text.toString())
                 } else {
                     null
                 }
@@ -343,7 +362,7 @@ class LoginEmailViewModel(
 
             withContext(dispatchers.io()) {
                 registerClient(
-                    userId = storedUserId,
+                    sessionScope = preparedSessionScope,
                     password = passwordTextState.text.toString(),
                 )
             }.let {
@@ -370,14 +389,28 @@ class LoginEmailViewModel(
     }
 
     private suspend fun revertNewSession() {
-        loginJobData.value?.newSessionUserId?.let { newSessionUserId ->
-            // logout to cancel all session-related actions, remove all sensitive data and free up resources
-            coreLogic.getSessionScope(newSessionUserId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
-            // delete the session to make it seem like the session was never logged in
-            coreLogic.getGlobalScope().deleteSession(newSessionUserId)
+        val jobData = loginJobData.value
+        jobData?.newSessionUserId?.let { newSessionUserId ->
+            when (val preparation = userSessionPreparationGate.prepare(newSessionUserId)) {
+                is AppUserSessionPreparationResult.Ready -> {
+                    // logout to cancel session actions and remove sensitive data before deleting the session
+                    preparation.sessionScope.logout(
+                        reason = LogoutReason.SELF_HARD_LOGOUT,
+                        waitUntilCompletes = true,
+                    )
+                    coreLogic.getGlobalScope().deleteSession(newSessionUserId)
+                }
+
+                is AppUserSessionPreparationResult.Failed -> appLogger.w(
+                    "Login rollback skipped database deletion because session preparation failed: ${preparation.reason}"
+                )
+            }
         }
-        // set the previous session back
-        coreLogic.getGlobalScope().session.updateCurrentSession(loginJobData.value?.previousSessionUserId)
+        restorePreviousSession(jobData)
+    }
+
+    private suspend fun restorePreviousSession(jobData: LoginJobData? = loginJobData.value) {
+        coreLogic.getGlobalScope().session.updateCurrentSession(jobData?.previousSessionUserId)
     }
 
     private suspend fun revertLogin() {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
@@ -18,6 +18,8 @@
 package com.wire.android.ui.authentication.login.sso
 
 import com.wire.android.appLogger
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -48,6 +50,7 @@ class LoginSSOViewModelExtension(
     private val coreLogic: CoreLogic,
     private val defaultWebSocketEnabledByDefault: Boolean,
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
     suspend fun withAuthenticationScope(
         serverConfig: ServerConfig.Links,
         onAuthScopeFailure: (AutoVersionAuthScopeUseCase.Result.Failure) -> Unit,
@@ -149,15 +152,27 @@ class LoginSSOViewModelExtension(
         when (authenticatedUserResult) {
             AddAuthenticatedUserUseCase.Result.Failure.SsoIdentityChanged -> onSsoIdentityChanged(session)
             is AddAuthenticatedUserUseCase.Result.Failure -> onAddAuthenticatedUserFailure(authenticatedUserResult)
-            is AddAuthenticatedUserUseCase.Result.Success -> onSuccess(authenticatedUserResult.userId)
+            is AddAuthenticatedUserUseCase.Result.Success ->
+                when (val preparation = userSessionPreparationGate.prepare(authenticatedUserResult.userId)) {
+                    is AppUserSessionPreparationResult.Ready -> onSuccess(authenticatedUserResult.userId)
+                    is AppUserSessionPreparationResult.Failed -> onAddAuthenticatedUserFailure(
+                        AddAuthenticatedUserUseCase.Result.Failure.Generic(preparation.toCoreFailure())
+                    )
+                }
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
     suspend fun replaceRetainedSsoSession(session: StoreSessionParam): ReplaceRetainedSsoSessionResult =
         try {
             val userId = session.accountTokens.userId
-            coreLogic.getSessionScope(userId).logout(
+            val retainedScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> return ReplaceRetainedSsoSessionResult.Failure(
+                    AddAuthenticatedUserUseCase.Result.Failure.Generic(preparation.toCoreFailure())
+                )
+            }
+            retainedScope.logout(
                 reason = LogoutReason.SELF_HARD_LOGOUT,
                 waitUntilCompletes = true
             )
@@ -167,8 +182,16 @@ class LoginSSOViewModelExtension(
                     ReplaceRetainedSsoSessionResult.Failure(
                         AddAuthenticatedUserUseCase.Result.Failure.Generic(deleteResult.cause)
                     )
-                DeleteSessionUseCase.Result.Success ->
-                    addAuthenticatedUser(session, replace = false).toReplaceRetainedSsoSessionResult()
+                DeleteSessionUseCase.Result.Success -> when (val addResult = addAuthenticatedUser(session, replace = false)) {
+                    is AddAuthenticatedUserUseCase.Result.Failure -> ReplaceRetainedSsoSessionResult.Failure(addResult)
+                    is AddAuthenticatedUserUseCase.Result.Success ->
+                        when (val preparation = userSessionPreparationGate.prepare(addResult.userId)) {
+                            is AppUserSessionPreparationResult.Ready -> ReplaceRetainedSsoSessionResult.Success(addResult.userId)
+                            is AppUserSessionPreparationResult.Failed -> ReplaceRetainedSsoSessionResult.Failure(
+                                AddAuthenticatedUserUseCase.Result.Failure.Generic(preparation.toCoreFailure())
+                            )
+                        }
+                }
             }
         } catch (exception: CancellationException) {
             throw exception
@@ -178,6 +201,9 @@ class LoginSSOViewModelExtension(
             )
         }
 }
+
+private fun AppUserSessionPreparationResult.Failed.toCoreFailure(): CoreFailure =
+    CoreFailure.Unknown(IllegalStateException("User session preparation failed: $reason"))
 
 private fun AddAuthenticatedUserUseCase.Result.toReplaceRetainedSsoSessionResult(): ReplaceRetainedSsoSessionResult =
     when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/CallActivity.kt
@@ -18,6 +18,7 @@
 package com.wire.android.ui.calling
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
@@ -32,7 +33,10 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
@@ -41,13 +45,16 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.wire.android.appLogger
 import com.wire.android.di.metro.LocalWireViewModelScopeKey
-import com.wire.android.di.metro.AppSessionViewModelGraph
 import com.wire.android.di.metro.createSessionViewModelGraph
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.model.LocalWireSessionImageLoader
 import com.wire.android.ui.AppLockActivity
 import com.wire.android.ui.BaseActivity
 import com.wire.android.ui.LocalActivity
+import com.wire.android.ui.UserSessionPreparationScreen
+import com.wire.android.ui.UserSessionPreparationUiState
+import com.wire.android.ui.toUiFailure
+import com.wire.android.ui.toUiState
 import com.wire.android.ui.calling.common.ProximitySensorManager
 import com.wire.android.ui.common.setupOrientationForDevice
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
@@ -55,15 +62,28 @@ import com.wire.android.ui.common.topappbar.CommonTopAppBarParams
 import com.wire.android.ui.common.topappbar.CommonTopAppBarViewModel
 import com.wire.android.ui.common.topappbar.WireTopAppBar
 import com.wire.android.ui.theme.WireTheme
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
+import com.wire.android.util.SupportPage
+import com.wire.android.util.SupportUrlResolver
 import com.wire.android.util.SwitchAccountObserver
+import com.wire.android.util.launchUpdateTheApp
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
 import dev.zacsweers.metro.HasMemberInjections
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.Provider
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 import kotlinx.coroutines.launch
 
 @HasMemberInjections
+@Suppress("TooManyFunctions")
 abstract class CallActivity : BaseActivity() {
 
     @Inject
@@ -101,6 +121,10 @@ abstract class CallActivity : BaseActivity() {
         }
     }
     protected val qualifiedIdMapper = QualifiedIdMapper(null)
+    private var preparationState by mutableStateOf<UserSessionPreparationUiState>(
+        UserSessionPreparationUiState.ResolvingSession
+    )
+    private var preparationJob: Job? = null
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
@@ -112,18 +136,65 @@ abstract class CallActivity : BaseActivity() {
         wireApplicationGraph.inject(this)
         super.onCreate(savedInstanceState)
         setupOrientationForDevice()
-        setUpScreenshotPreventionFlag()
         setUpCallingFlags()
 
         enableEdgeToEdge()
 
-        val sessionViewModelGraph = createCallSessionViewModelGraph(intent) ?: run {
+        val userId = intent.getStringExtra(EXTRA_USER_ID)
+            ?.let(qualifiedIdMapper::fromStringToQualifiedID)
+            ?: run {
             appLogger.e("$TAG missing call session user id, closing call activity")
             finish()
             return
         }
 
+        showPreparation(userId)
+    }
+
+    private fun showPreparation(userId: UserId) {
+        setContent {
+            WireTheme {
+                UserSessionPreparationScreen(
+                    state = preparationState,
+                    onRetry = { prepareSession(userId) },
+                    onUpdate = ::updateTheApp,
+                    onContactSupport = ::openSupport,
+                )
+            }
+        }
+        prepareSession(userId)
+    }
+
+    private fun prepareSession(userId: UserId) {
+        if (preparationJob?.isActive == true) return
+        preparationState = UserSessionPreparationUiState.ResolvingSession
+        preparationJob = lifecycleScope.launch {
+            val gate = UserSessionPreparationGate(wireApplicationGraph.coreLogic)
+            val result = coroutineScope {
+                val observer = launch(start = CoroutineStart.UNDISPATCHED) {
+                    gate.observe(userId).collect { preparationState = it.toUiState() }
+                }
+                try {
+                    gate.prepare(userId)
+                } finally {
+                    observer.cancelAndJoin()
+                }
+            }
+            when (result) {
+                is AppUserSessionPreparationResult.Ready -> showCall(userId, result.sessionScope)
+                is AppUserSessionPreparationResult.Failed -> {
+                    preparationState = UserSessionPreparationUiState.Failed(result.reason.toUiFailure())
+                }
+            }
+        }
+    }
+
+    private fun showCall(userId: UserId, userSessionScope: UserSessionScope) {
+        val sessionViewModelGraph = wireApplicationGraph.createSessionViewModelGraph(userId, userSessionScope)
+
         handleNewIntent(intent)
+        onSessionPrepared()
+        setUpScreenshotPreventionFlag()
 
         appLogger.i("$TAG Initializing proximity sensor..")
         proximitySensorManager.initialize()
@@ -159,13 +230,17 @@ abstract class CallActivity : BaseActivity() {
 
     protected abstract fun handleNewIntent(intent: Intent)
 
+    protected open fun onSessionPrepared() = Unit
+
     @Composable
     protected abstract fun Content()
 
-    private fun createCallSessionViewModelGraph(intent: Intent): AppSessionViewModelGraph? =
-        intent.getStringExtra(EXTRA_USER_ID)
-            ?.let(qualifiedIdMapper::fromStringToQualifiedID)
-            ?.let(wireApplicationGraph::createSessionViewModelGraph)
+    private fun updateTheApp() = launchUpdateTheApp()
+
+    private fun openSupport() {
+        val supportUrl = SupportUrlResolver.resolve(resources, SupportPage.SUPPORT)
+        startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(supportUrl)))
+    }
 
     fun switchAccountIfNeeded(userId: String?) {
         userId?.let {

--- a/app/src/main/kotlin/com/wire/android/ui/calling/common/ProximitySensorManager.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/common/ProximitySensorManager.kt
@@ -28,6 +28,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.wire.android.appLogger
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
@@ -44,6 +46,7 @@ class ProximitySensorManager @Inject constructor(
     @KaliumCoreLogic private val coreLogic: Lazy<CoreLogic>,
     @ApplicationScope private val appCoroutineScope: CoroutineScope
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic.value) }
 
     private lateinit var sensorManager: SensorManager
     private var proximity: Sensor? = null
@@ -78,7 +81,14 @@ class ProximitySensorManager @Inject constructor(
                     when {
                         currentSession is CurrentSessionResult.Success && currentSession.accountInfo.isValid() -> {
                             val userId = currentSession.accountInfo.userId
-                            val isCallRunning = coreLogic.value.getSessionScope(userId).calls.isCallRunning()
+                            val sessionScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+                                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                                is AppUserSessionPreparationResult.Failed -> {
+                                    if (wakeLock.isHeld) wakeLock.release()
+                                    return@launch
+                                }
+                            }
+                            val isCallRunning = sessionScope.calls.isCallRunning()
                             val distance = event.values.first()
                             val shouldTurnOffScreen = distance == NEAR_DISTANCE && isCallRunning
                             appLogger.i(

--- a/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/calling/ongoing/OngoingCallActivity.kt
@@ -71,11 +71,12 @@ class OngoingCallActivity : CallActivity() {
         switchAccountIfNeeded(userId)
     }
 
-    @SuppressLint("UnusedContentLambdaTargetStateParameter")
     override fun onCreate(savedInstanceState: Bundle?) {
         wireApplicationGraph.inject(this)
         super.onCreate(savedInstanceState)
+    }
 
+    override fun onSessionPrepared() {
         if (shouldAnswerCall && userId != null && conversationId != null) {
             callNotificationManager.hideIncomingCallNotification(userId!!, conversationId!!)
             servicesManager.startCallServiceToAnswer(

--- a/app/src/main/kotlin/com/wire/android/ui/common/Logo.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/common/Logo.kt
@@ -21,18 +21,22 @@ package com.wire.android.ui.common
 import androidx.compose.foundation.Image
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import com.wire.android.R
 
 @Composable
-fun Logo(modifier: Modifier = Modifier) {
+fun Logo(
+    modifier: Modifier = Modifier,
+    tint: Color = colorsScheme().onSurface,
+) {
     Image(
         painter = painterResource(id = R.drawable.ic_wire_logo),
         contentDescription = null,
         contentScale = ContentScale.Fit,
         modifier = modifier,
-        colorFilter = ColorFilter.tint(colorsScheme().onSurface)
+        colorFilter = ColorFilter.tint(tint)
     )
 }

--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
@@ -28,19 +28,22 @@ import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.BuildConfig
 import com.wire.android.analytics.RegistrationAnalyticsManagerUseCase
-import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.analytics.model.AnalyticsEvent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.WillNeverOccurError
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.session.StoreSessionParam
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.client.RegisterClientParam
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.register.RegisterParam
@@ -57,7 +60,6 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
     private val registrationAnalyticsManager: RegistrationAnalyticsManagerUseCase,
-    private val clientScopeProviderFactory: ClientScopeProvider.Factory,
     defaultServerConfig: ServerConfig.Links,
     @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean,
 ) : ViewModel() {
@@ -65,6 +67,8 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
     interface Factory {
         fun create(savedStateHandle: SavedStateHandle): CreateAccountVerificationCodeViewModel
     }
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     val createAccountNavArgs: CreateAccountDataNavArgs = savedStateHandle.navArgs()
 
@@ -123,7 +127,7 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
         codeTextState.clearText()
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "LongMethod")
     private fun onCodeContinue() {
         codeState = codeState.copy(loading = true)
         viewModelScope.launch {
@@ -185,15 +189,27 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
                     is AddAuthenticatedUserUseCase.Result.Success -> it.userId
                 }
             }
-            registerClient(storedUserId, registerParam)
+            val sessionScope = when (val preparation = userSessionPreparationGate.prepare(storedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    updateCodeErrorState(
+                        CreateAccountCodeResult.Error.DialogError.GenericError(
+                            CoreFailure.Unknown(IllegalStateException("User session preparation failed: ${preparation.reason}"))
+                        )
+                    )
+                    return@launch
+                }
+            }
+            registerClient(storedUserId, sessionScope, registerParam)
         }
     }
 
     private suspend fun registerClient(
         storedUserId: UserId,
+        sessionScope: UserSessionScope,
         registerParam: RegisterParam.PersonalAccount
     ) {
-        registerClient(storedUserId, registerParam.password).let {
+        registerClient(sessionScope, registerParam.password).let {
             when (it) {
                 is RegisterClientResult.Failure -> {
                     updateCodeErrorState(it.toCodeError(storedUserId))
@@ -217,8 +233,8 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
         codeState = codeState.copy(loading = false, result = codeError)
     }
 
-    private suspend fun registerClient(userId: UserId, password: String) =
-        clientScopeProviderFactory.create(userId).clientScope.getOrRegister(
+    private suspend fun registerClient(sessionScope: UserSessionScope, password: String) =
+        sessionScope.client.getOrRegister(
             RegisterClientParam(
                 password = password,
                 capabilities = null,

--- a/app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt
+++ b/app/src/main/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManager.kt
@@ -20,6 +20,8 @@ package com.wire.android.util.lifecycle
 
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.logger.KaliumLogLevel
 import com.wire.kalium.logger.KaliumLogger.Companion.ApplicationFlow.SYNC
@@ -51,6 +53,7 @@ class SyncLifecycleManager @Inject constructor(
     private val currentScreenManager: CurrentScreenManager,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     private val logger by lazy { appLogger.withFeatureId(SYNC).withTextTag("SyncLifecycleManager") }
 
@@ -91,7 +94,8 @@ class SyncLifecycleManager @Inject constructor(
                             )
                             logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED, requestData)
                             try {
-                                coreLogic.getSessionScope(userId).syncExecutor.request {
+                                val sessionScope = preparedSessionScope(userId) ?: return@launch
+                                sessionScope.syncExecutor.request {
                                     awaitCancellation()
                                 }
                             } finally {
@@ -136,7 +140,7 @@ class SyncLifecycleManager @Inject constructor(
         )
         logger.logAppSyncTelemetry(AppSyncTelemetryEvent.APP_SYNC_REQUEST_STARTED, requestData)
         try {
-            coreLogic.getSessionScope(userId).run {
+            preparedSessionScope(userId)?.run {
                 syncExecutor.request {
                     logger.d("Waiting until live")
                     val syncRequestResult = if (waitForNextSyncState) {
@@ -172,4 +176,13 @@ class SyncLifecycleManager @Inject constructor(
 
     private fun UserId.toTelemetryString(): String =
         "${value.obfuscateId()}@${domain.obfuscateDomain()}"
+
+    private suspend fun preparedSessionScope(userId: UserId) =
+        when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                logger.w("Skipping sync because user-session preparation failed: ${result.reason}")
+                null
+            }
+        }
 }

--- a/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
@@ -26,9 +26,11 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.StartPersistentWebsocketIfNecessaryUseCase
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.sync.InitialSyncWorker
 import com.wire.android.workmanager.worker.DeleteConversationLocallyWorker
 import com.wire.android.workmanager.worker.NotificationFetchWorker
+import com.wire.android.workmanager.worker.NotificationTokenRegistrationWorker
 import com.wire.android.workmanager.worker.PersistentWebsocketCheckWorker
 import com.wire.android.workmanager.worker.AssetUploadObserverWorker
 import com.wire.kalium.logic.CoreLogic
@@ -40,6 +42,7 @@ class WireWorkerFactory @Inject constructor(
     private val wireNotificationManager: WireNotificationManager,
     private val notificationChannelsManager: NotificationChannelsManager,
     private val startPersistentWebsocketIfNecessary: StartPersistentWebsocketIfNecessaryUseCase,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
     @KaliumCoreLogic
     private val coreLogic: CoreLogic
 ) : WorkerFactory() {
@@ -53,6 +56,9 @@ class WireWorkerFactory @Inject constructor(
             NotificationFetchWorker::class.java.canonicalName ->
                 NotificationFetchWorker(appContext, workerParameters, wireNotificationManager, notificationChannelsManager)
 
+            NotificationTokenRegistrationWorker::class.java.canonicalName ->
+                NotificationTokenRegistrationWorker(appContext, workerParameters, coreLogic, userSessionPreparationGate)
+
             PersistentWebsocketCheckWorker::class.java.canonicalName ->
                 PersistentWebsocketCheckWorker(
                     appContext,
@@ -62,10 +68,22 @@ class WireWorkerFactory @Inject constructor(
                 )
 
             DeleteConversationLocallyWorker::class.java.canonicalName ->
-                DeleteConversationLocallyWorker(appContext, workerParameters, coreLogic, notificationChannelsManager)
+                DeleteConversationLocallyWorker(
+                    appContext,
+                    workerParameters,
+                    coreLogic,
+                    notificationChannelsManager,
+                    userSessionPreparationGate,
+                )
 
             AssetUploadObserverWorker::class.java.canonicalName ->
-                AssetUploadObserverWorker(appContext, workerParameters, coreLogic, notificationChannelsManager)
+                AssetUploadObserverWorker(
+                    appContext,
+                    workerParameters,
+                    coreLogic,
+                    notificationChannelsManager,
+                    userSessionPreparationGate,
+                )
 
             InitialSyncWorker::class.java.canonicalName ->
                 InitialSyncWorker(appContext, workerParameters, coreLogic, notificationChannelsManager)

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/AssetUploadObserverWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/AssetUploadObserverWorker.kt
@@ -31,6 +31,8 @@ import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
@@ -51,26 +53,50 @@ class AssetUploadObserverWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val coreLogic: CoreLogic,
     private val notificationChannelsManager: NotificationChannelsManager,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
 
         // Wait until there are no uploads in progress
         // switching to other user will cancel the observer and stop the worker
-        coreLogic.getGlobalScope().session.currentSessionFlow()
-            .filterIsInstance<CurrentSessionResult.Success>()
-            .map { it.accountInfo.userId }
-            .waitForUploadCompletion()
-
-        return Result.success()
+        return when (
+            coreLogic.getGlobalScope().session.currentSessionFlow()
+                .filterIsInstance<CurrentSessionResult.Success>()
+                .map { it.accountInfo.userId }
+                .waitForUploadCompletion()
+        ) {
+            UploadWaitResult.Complete -> Result.success()
+            UploadWaitResult.Retry -> Result.retry()
+            UploadWaitResult.Failure -> Result.failure()
+        }
     }
 
-    private suspend fun Flow<UserId>.waitForUploadCompletion() =
+    private suspend fun Flow<UserId>.waitForUploadCompletion(): UploadWaitResult =
         flatMapLatest { userId ->
-            coreLogic.getSessionScope(userId).messages.observeAssetUploadState()
-        }.first { uploadInProgress ->
-            uploadInProgress == false
-        }
+            when (
+                val preparation = userSessionPreparationGate.prepare(userId)
+            ) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope.messages.observeAssetUploadState()
+                    .map { uploadInProgress -> UploadState.InProgress(uploadInProgress) }
+                is AppUserSessionPreparationResult.Failed -> kotlinx.coroutines.flow.flowOf(
+                    UploadState.PreparationFailed(preparation.canRetry)
+                )
+            }
+        }.first { state -> state !is UploadState.InProgress || !state.value }
+            .let { state ->
+                when (state) {
+                    is UploadState.InProgress -> UploadWaitResult.Complete
+                    is UploadState.PreparationFailed -> if (state.canRetry) UploadWaitResult.Retry else UploadWaitResult.Failure
+                }
+            }
+
+    private sealed interface UploadState {
+        data class InProgress(val value: Boolean) : UploadState
+        data class PreparationFailed(val canRetry: Boolean) : UploadState
+    }
+
+    private enum class UploadWaitResult { Complete, Retry, Failure }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         notificationChannelsManager.createRegularChannel(

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/DeleteConversationLocallyWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/DeleteConversationLocallyWorker.kt
@@ -35,6 +35,8 @@ import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -64,6 +66,7 @@ class DeleteConversationLocallyWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val coreLogic: CoreLogic,
     private val notificationChannelsManager: NotificationChannelsManager,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
 ) : CoroutineWorker(appContext, workerParams) {
     override suspend fun doWork(): Result = coroutineScope {
         val userIdString = inputData.getString(USER_ID)
@@ -80,7 +83,12 @@ class DeleteConversationLocallyWorker @AssistedInject constructor(
                 return@coroutineScope Result.failure() // If no valid session exists, fail the work
             }
         }
-        when (coreLogic.getSessionScope(userId).conversations.deleteConversationLocallyUseCase(conversationId)) {
+        val sessionScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+            is AppUserSessionPreparationResult.Failed ->
+                return@coroutineScope if (preparation.canRetry) Result.retry() else Result.failure()
+        }
+        when (sessionScope.conversations.deleteConversationLocallyUseCase(conversationId)) {
             is ClearConversationContentUseCase.Result.Failure -> Result.retry()
             ClearConversationContentUseCase.Result.Success -> Result.success()
         }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -44,11 +44,12 @@ class NotificationFetchWorker
     }
 
     override suspend fun doWork(): Result {
-        inputData.getString(USER_ID_INPUT_DATA)?.let { userId ->
-            wireNotificationManager.fetchAndShowNotificationsOnce(userId)
+        val userId = inputData.getString(USER_ID_INPUT_DATA) ?: return Result.failure()
+        return when (wireNotificationManager.fetchAndShowNotificationsOnce(userId)) {
+            WireNotificationManager.FetchNotificationsResult.Success -> Result.success()
+            WireNotificationManager.FetchNotificationsResult.Retry -> Result.retry()
+            WireNotificationManager.FetchNotificationsResult.Failure -> Result.failure()
         }
-
-        return Result.success()
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationTokenRegistrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationTokenRegistrationWorker.kt
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.workmanager.worker
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.wire.android.appLogger
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.session.GetAllSessionsResult
+
+class NotificationTokenRegistrationWorker(
+    appContext: Context,
+    workerParameters: WorkerParameters,
+    private val coreLogic: CoreLogic,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
+) : CoroutineWorker(appContext, workerParameters) {
+
+    @Suppress("ReturnCount")
+    override suspend fun doWork(): Result {
+        val token = inputData.getString(INPUT_TOKEN) ?: return Result.failure()
+        val senderId = inputData.getString(INPUT_SENDER_ID) ?: return Result.failure()
+        val sessions = when (val result = coreLogic.globalScope { getSessions() }) {
+            is GetAllSessionsResult.Success -> result.sessions
+            GetAllSessionsResult.Failure.NoSessionFound -> emptyList()
+            is GetAllSessionsResult.Failure.Generic -> {
+                appLogger.w("$TAG unable to read sessions: ${result.genericFailure}")
+                return Result.retry()
+            }
+        }
+
+        val preparationFailures = sessions.filter { it.isValid() }.mapNotNull { session ->
+            when (val preparation = userSessionPreparationGate.prepare(session.userId)) {
+                is AppUserSessionPreparationResult.Ready -> null
+                is AppUserSessionPreparationResult.Failed -> preparation
+            }
+        }
+        if (preparationFailures.any { it.canRetry }) return Result.retry()
+        if (preparationFailures.isNotEmpty()) return Result.failure()
+
+        return when (val result = coreLogic.globalScope { saveNotificationToken(token, TRANSPORT, senderId) }) {
+            com.wire.kalium.logic.feature.notificationToken.Result.Success -> Result.success()
+            is com.wire.kalium.logic.feature.notificationToken.Result.Failure.Generic -> {
+                appLogger.w("$TAG token registration failed: ${result.failure}")
+                Result.retry()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "NotificationTokenRegistrationWorker"
+        private const val WORK_NAME = "notification_token_registration"
+        private const val INPUT_TOKEN = "token"
+        private const val INPUT_SENDER_ID = "sender_id"
+        private const val TRANSPORT = "GCM"
+
+        fun enqueue(workManager: WorkManager, token: String, senderId: String) {
+            val request = OneTimeWorkRequestBuilder<NotificationTokenRegistrationWorker>()
+                .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+                .setInputData(workDataOf(INPUT_TOKEN to token, INPUT_SENDER_ID to senderId))
+                .build()
+            workManager.enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,17 @@
     <string name="label_removing">Removing…</string>
     <string name="label_logging_in">Logging in…</string>
     <string name="label_try_again">Try Again</string>
+    <string name="user_session_preparation_opening_title">Preparing Wire</string>
+    <string name="user_session_preparation_opening_message">Opening your secure data. This may take a moment.</string>
+    <string name="user_session_preparation_migrating_title">Updating your secure data</string>
+    <string name="user_session_preparation_migrating_message">Keep Wire open while your messages are prepared for this version.</string>
+    <string name="user_session_preparation_storage_title">Free up storage</string>
+    <string name="user_session_preparation_storage_message">Wire needs more free space to safely update your secure data. Free up storage, then try again.</string>
+    <string name="user_session_preparation_temporary_title">Wire is temporarily unavailable</string>
+    <string name="user_session_preparation_temporary_message">Your secure data is busy right now. Wait a moment, then try again.</string>
+    <string name="user_session_preparation_support_title">Contact Wire support</string>
+    <string name="user_session_preparation_support_message">Wire could not safely open your secure data. Your data was not deleted or recreated.</string>
+    <string name="user_session_preparation_contact_support">Contact support</string>
     <string name="label_done">Done</string>
     <string name="label_message_sent_failure">Message could not be sent due to connectivity issues.</string>
     <string name="label_message_edit_sent_failure">The edited message could not be sent due to connectivity issues.</string>

--- a/app/src/nonfree/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
+++ b/app/src/nonfree/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
@@ -29,42 +29,21 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.wire.android.BuildConfig
 import com.wire.android.appLogger
-import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.util.NetworkUtil
-import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.workmanager.worker.NotificationFetchWorker
-import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.feature.notificationToken.Result
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
+import com.wire.android.workmanager.worker.NotificationTokenRegistrationWorker
 import java.util.Locale
 import dev.zacsweers.metro.Inject
 
 class WireFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject
-    @KaliumCoreLogic
-    lateinit var coreLogic: CoreLogic
-
-    @Inject
     lateinit var networkUtil: NetworkUtil
-
-    @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    private val scope by lazy {
-        // There's no UI, no need to run anything using the Main/UI Dispatcher
-        CoroutineScope(SupervisorJob() + dispatcherProvider.default())
-    }
 
     override fun onCreate() {
         val graph = wireApplicationGraph
-        coreLogic = graph.coreLogic
         networkUtil = graph.networkUtil
-        dispatcherProvider = graph.dispatcherProvider
         super.onCreate()
     }
 
@@ -127,24 +106,11 @@ class WireFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        scope.launch {
-            coreLogic.globalScope {
-                saveNotificationToken(token, "GCM", BuildConfig.FIREBASE_PUSH_SENDER_ID)
-            }.let { result ->
-                when (result) {
-                    is Result.Failure.Generic ->
-                        appLogger.e("$TAG: token registration has an issue : ${result.failure} ")
-                    Result.Success ->
-                        appLogger.i("$TAG: token registered successfully")
-                }
-            }
-        }
-    }
-
-    override fun onDestroy() {
-        scope.cancel()
-        appLogger.i("$TAG: onDestroy")
-        super.onDestroy()
+        NotificationTokenRegistrationWorker.enqueue(
+            WorkManager.getInstance(applicationContext),
+            token,
+            BuildConfig.FIREBASE_PUSH_SENDER_ID,
+        )
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -29,6 +29,7 @@ import com.wire.android.services.SendPendingMessagesAfterForegroundSyncUseCase
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.auth.PersistentWebSocketStatus
 import com.wire.kalium.logic.data.logout.LogoutReason
@@ -48,6 +49,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -386,6 +388,7 @@ class GlobalObserversManagerTest {
             every { notificationChannelsManager.createUserNotificationChannels(any()) } returns Unit
             every { coreLogic.getGlobalScope().logoutCallbackManager } returns logoutCallbackManager
             every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess(userSessionScope)
             every { callsScope.endCallOnConversationChange } returns endCallOnConversationChangeUseCase
             coEvery { endCallOnConversationChangeUseCase.invoke() } returns Unit
             every { userSessionScope.calls } returns callsScope
@@ -399,6 +402,11 @@ class GlobalObserversManagerTest {
             withAppVisibleFlow(true)
             withNetworkState(NetworkState.ConnectedWithInternet)
         }
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
 
         fun withValidAccounts(list: List<Pair<SelfUser, Team?>>): Arrangement = apply {
             coEvery { coreLogic.getGlobalScope().observeValidAccounts() } returns flowOf(list)

--- a/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/feature/ObserveAppLockConfigUseCaseTest.kt
@@ -20,6 +20,8 @@ package com.wire.android.feature
 import app.cash.turbine.test
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.configuration.AppLockTeamConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.logout.LogoutReason
@@ -31,6 +33,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -127,6 +130,19 @@ class ObserveAppLockConfigUseCaseTest {
             }
         }
 
+    @Test
+    fun givenSessionPreparationFails_whenObservingAppLock_thenSendSafeDisabledStatus() = runTest {
+        val (_, useCase) = Arrangement()
+            .withValidSession()
+            .withPreparationFailure()
+            .arrange()
+
+        useCase().test {
+            assertEquals(AppLockConfig.Disabled(timeout), awaitItem())
+            awaitComplete()
+        }
+    }
+
     inner class Arrangement {
 
         @MockK
@@ -150,6 +166,7 @@ class ObserveAppLockConfigUseCaseTest {
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess()
         }
 
         fun arrange() = this to useCase
@@ -170,7 +187,6 @@ class ObserveAppLockConfigUseCaseTest {
         }
 
         fun withTeamAppLockEnabled() = apply {
-            every { coreLogic.getSessionScope(any()) } returns userSessionScope
             every {
                 userSessionScope.appLockTeamFeatureConfigObserver
             } returns appLockTeamFeatureConfigObserver
@@ -180,7 +196,6 @@ class ObserveAppLockConfigUseCaseTest {
         }
 
         fun withTeamAppLockDisabled() = apply {
-            every { coreLogic.getSessionScope(any()) } returns userSessionScope
             every {
                 userSessionScope.appLockTeamFeatureConfigObserver
             } returns appLockTeamFeatureConfigObserver
@@ -196,6 +211,17 @@ class ObserveAppLockConfigUseCaseTest {
         fun withAppNonLockedByCurrentUser() = apply {
             every { globalDataStore.isAppLockPasscodeSetFlow() } returns flowOf(false)
         }
+
+        fun withPreparationFailure() = apply {
+            val failure = mockk<PrepareUserSessionResult.Failure>()
+            every { failure.reason } returns UserSessionPreparationFailure.TemporarilyUnavailable
+            coEvery { coreLogic.prepareUserSession(any()) } returns failure
+        }
+
+        private fun preparationSuccess(): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns userSessionScope
+            }
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
@@ -27,11 +27,13 @@ import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.Messag
 import com.wire.android.services.ServicesManager
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import io.mockk.MockKAnnotations
@@ -39,6 +41,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -630,6 +633,9 @@ class Arrangement(private val tempDir: File) {
     lateinit var coreLogic: CoreLogic
 
     @MockK
+    lateinit var userSessionScope: UserSessionScope
+
+    @MockK
     lateinit var mediaPlayer: MediaPlayer
 
     @MockK
@@ -661,8 +667,9 @@ class Arrangement(private val tempDir: File) {
     init {
         MockKAnnotations.init(this, relaxed = true)
 
-        every { coreLogic.getSessionScope(any()).messages.getAssetMessage } returns getAssetMessage
-        every { coreLogic.getSessionScope(any()).messages.getMessageById } returns getMessageById
+        coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess(userSessionScope)
+        every { userSessionScope.messages.getAssetMessage } returns getAssetMessage
+        every { userSessionScope.messages.getMessageById } returns getMessageById
         every { mediaPlayer.currentPosition } returns 100
 
         every { servicesManager.stopPlayingAudioMessageService() } returns Unit
@@ -672,6 +679,11 @@ class Arrangement(private val tempDir: File) {
         every { audioFocusHelper.abandon() } returns Unit
         every { audioFocusHelper.request() } returns true
     }
+
+    private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+        mockk<PrepareUserSessionResult.Success>().also { result ->
+            every { result.sessionScope } returns sessionScope
+        }
 
     fun withCurrentSession() = apply {
         coEvery { coreLogic.getGlobalScope().session.currentSession.invoke() } returns CurrentSessionResult.Success(

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -29,6 +29,8 @@ import com.wire.android.util.lifecycle.SyncLifecycleManager
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.GlobalKaliumScope
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.call.Call
@@ -69,6 +71,7 @@ import io.mockk.MockKMatcherScope
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
@@ -130,6 +133,24 @@ class WireNotificationManagerTest {
             advanceUntilIdle()
 
             coVerify(exactly = 1) { arrangement.syncLifecycleManager.syncTemporarily(TEST_AUTH_TOKEN.userId, any()) }
+            coVerifyOrder {
+                arrangement.coreLogic.prepareUserSession(TEST_AUTH_TOKEN.userId)
+                arrangement.syncLifecycleManager.syncTemporarily(TEST_AUTH_TOKEN.userId, any())
+            }
+        }
+
+    @Test
+    fun givenBackgroundFirstOpenIsTemporarilyUnavailable_whenFetchingNotifications_thenWorkerCanRetry() =
+        runTest(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement()
+                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
+                .withPreparationFailure(UserSessionPreparationFailure.TemporarilyUnavailable)
+                .arrange()
+
+            val result = manager.fetchAndShowNotificationsOnce(TEST_AUTH_TOKEN.userId.value)
+
+            assertEquals(WireNotificationManager.FetchNotificationsResult.Retry, result)
+            coVerify(exactly = 0) { arrangement.syncLifecycleManager.syncTemporarily(any(), any()) }
         }
 
     @Test
@@ -1229,6 +1250,7 @@ class WireNotificationManagerTest {
             coEvery { syncManager.waitUntilLive() } returns Unit
             coEvery { globalKaliumScope.getSessions } returns getSessionsUseCase
             coEvery { coreLogic.getSessionScope(any()) } returns userSessionScope
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess(userSessionScope)
             coEvery { coreLogic.getGlobalScope() } returns globalKaliumScope
             coEvery { messageNotificationManager.handleNotification(any(), any(), any()) } returns Unit
             coEvery { callsScope.getIncomingCalls } returns getIncomingCallsUseCase
@@ -1261,7 +1283,7 @@ class WireNotificationManagerTest {
             selfUser: SelfUser = TestUser.SELF_USER,
             userId: MockKMatcherScope.() -> UserId
         ) {
-            coEvery { coreLogic.getSessionScope(userId()) } returns mockk {
+            val specificSessionScope = mockk<UserSessionScope> {
                 coEvery { syncManager } returns this@Arrangement.syncManager
                 coEvery { conversations } returns mockk {
                     coEvery { markConnectionRequestAsNotified } returns this@Arrangement.markConnectionRequestAsNotified
@@ -1281,11 +1303,24 @@ class WireNotificationManagerTest {
                 }
                 coEvery { observeE2EIRequired } returns this@Arrangement.observeE2EIRequired
             }
+            coEvery { coreLogic.getSessionScope(userId()) } returns specificSessionScope
+            coEvery { coreLogic.prepareUserSession(userId()) } returns preparationSuccess(specificSessionScope)
         }
+
+        private fun preparationSuccess(scope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns scope
+            }
 
         fun withSession(session: GetAllSessionsResult): Arrangement {
             coEvery { getSessionsUseCase() } returns session
             return this
+        }
+
+        fun withPreparationFailure(reason: UserSessionPreparationFailure): Arrangement = apply {
+            val result = mockk<PrepareUserSessionResult.Failure>()
+            every { result.reason } returns reason
+            coEvery { coreLogic.prepareUserSession(any()) } returns result
         }
 
         suspend fun withCurrentUserSession(session: CurrentSessionResult): Arrangement {

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
@@ -26,6 +26,7 @@ import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.UserId
@@ -63,7 +64,7 @@ class NomadLogoutReceiverTest {
         val intent = mockk<Intent> { every { action } returns NomadLogoutReceiver.ACTION_LOGOUT }
         arrangement.receiver.receive(arrangement.context, intent)
 
-        verify(exactly = 1) { arrangement.coreLogic.getSessionScope(userId) }
+        coVerify(exactly = 1) { arrangement.coreLogic.prepareUserSession(userId) }
         coVerifyOrder {
             arrangement.currentSession()
             arrangement.logoutUseCase(LogoutReason.SELF_HARD_LOGOUT, true)
@@ -89,8 +90,10 @@ class NomadLogoutReceiverTest {
             arrangement.deleteSession(any())
             arrangement.accountSwitch(any())
         }
+        coVerify(exactly = 0) {
+            arrangement.coreLogic.prepareUserSession(any())
+        }
         verify(exactly = 0) {
-            arrangement.coreLogic.getSessionScope(any())
             arrangement.context.startActivity(any())
         }
     }
@@ -106,7 +109,7 @@ class NomadLogoutReceiverTest {
         advanceUntilIdle()
 
         coVerify(exactly = 1) { arrangement.currentSession() }
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+        coVerify(exactly = 0) { arrangement.coreLogic.prepareUserSession(any()) }
         coVerify(exactly = 0) {
             arrangement.logoutUseCase(any(), any())
             arrangement.deleteSession(any())
@@ -181,7 +184,7 @@ class NomadLogoutReceiverTest {
             every { coreLogic.getGlobalScope().isCurrentSessionNomadAccount } returns isCurrentSessionNomadAccount
             coEvery { isCurrentSessionNomadAccount() } returns true
             coEvery { accountSwitch(any()) } returns SwitchAccountResult.NoOtherAccountToSwitch
-            every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess()
             every { nomadProfilesFeatureConfig.isEnabled() } returns true
         }
 
@@ -205,5 +208,10 @@ class NomadLogoutReceiverTest {
         fun withCurrentSessionNomadAccount(isNomad: Boolean) = apply {
             coEvery { isCurrentSessionNomadAccount() } returns isNomad
         }
+
+        private fun preparationSuccess(): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns userSessionScope
+            }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/services/CallServiceManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/services/CallServiceManagerTest.kt
@@ -24,6 +24,7 @@ import com.wire.android.framework.TestUser
 import com.wire.android.notification.CallNotificationData
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
@@ -33,11 +34,13 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
@@ -320,14 +323,21 @@ class CallServiceManagerTest {
             outgoing: Flow<List<Call>> = flowOf(emptyList()),
             established: Flow<List<Call>> = flowOf(emptyList()),
         ) = apply {
+            val sessionScope = mockk<UserSessionScope>(relaxed = true)
             withValidSessionExists(selfUser.id, DoesValidSessionExistResult.Success(true))
-            coEvery { coreLogic.getSessionScope(selfUser.id).users.observeSelfUser() } returns flowOf(selfUser)
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.getIncomingCalls() } returns incoming
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.observeOutgoingCall() } returns outgoing
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.establishedCall() } returns established
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.answerCall } returns answerCallForUser(selfUser.id)
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.endCall } returns endCallForUser(selfUser.id)
+            coEvery { coreLogic.prepareUserSession(selfUser.id) } returns preparationSuccess(sessionScope)
+            coEvery { sessionScope.users.observeSelfUser() } returns flowOf(selfUser)
+            coEvery { sessionScope.calls.getIncomingCalls() } returns incoming
+            coEvery { sessionScope.calls.observeOutgoingCall() } returns outgoing
+            coEvery { sessionScope.calls.establishedCall() } returns established
+            coEvery { sessionScope.calls.answerCall } returns answerCallForUser(selfUser.id)
+            coEvery { sessionScope.calls.endCall } returns endCallForUser(selfUser.id)
         }
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/services/SendPendingMessagesAfterForegroundSyncUseCaseTest.kt
+++ b/app/src/test/kotlin/com/wire/android/services/SendPendingMessagesAfterForegroundSyncUseCaseTest.kt
@@ -22,6 +22,7 @@ import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.lifecycle.SyncLifecycleManager
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
@@ -33,6 +34,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -90,11 +92,17 @@ class SendPendingMessagesAfterForegroundSyncUseCaseTest {
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
             every { coreLogic.getSessionScope(USER_ID) } returns userSessionScope
+            coEvery { coreLogic.prepareUserSession(USER_ID) } returns preparationSuccess(userSessionScope)
             every { userSessionScope.syncManager } returns syncStateObserver
             every { syncStateObserver.syncState } returns MutableStateFlow(SyncState.Live)
             every { userSessionScope.sendPendingMessages } returns sendPendingMessages
             coEvery { sendPendingMessages() } returns SendPendingMessagesUseCase.Result.Success
         }
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
 
         fun withNextSyncRequestResult(syncRequestResult: SyncRequestResult) = apply {
             syncExecutor = object : FakeSyncExecutor() {

--- a/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
+++ b/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.session
+
+import com.wire.android.ui.UserSessionPreparationUiFailure
+import com.wire.android.ui.toUiFailure
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
+import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class UserSessionPreparationGateTest {
+
+    @Test
+    fun givenKaliumReturnsReadySession_whenPreparing_thenReturnedScopeIsReused() = runTest {
+        val coreLogic = mockk<CoreLogic>()
+        val sessionScope = mockk<UserSessionScope>()
+        coEvery { coreLogic.prepareUserSession(USER_ID) } returns success(sessionScope)
+
+        val result = UserSessionPreparationGate(coreLogic).prepare(USER_ID)
+
+        assertSame(sessionScope, (result as AppUserSessionPreparationResult.Ready).sessionScope)
+    }
+
+    @Test
+    fun givenConcurrentAppCallers_whenPreparing_thenBothAwaitKaliumSharedResult() = runTest {
+        val coreLogic = mockk<CoreLogic>()
+        val sessionScope = mockk<UserSessionScope>()
+        val kaliumResult = CompletableDeferred<PrepareUserSessionResult>()
+        coEvery { coreLogic.prepareUserSession(USER_ID) } coAnswers { kaliumResult.await() }
+        val gate = UserSessionPreparationGate(coreLogic)
+
+        val foreground = async { gate.prepare(USER_ID) }
+        val background = async { gate.prepare(USER_ID) }
+        runCurrent()
+        coVerify(exactly = 2) { coreLogic.prepareUserSession(USER_ID) }
+
+        kaliumResult.complete(success(sessionScope))
+
+        assertSame(
+            sessionScope,
+            (foreground.await() as AppUserSessionPreparationResult.Ready).sessionScope,
+        )
+        assertSame(
+            sessionScope,
+            (background.await() as AppUserSessionPreparationResult.Ready).sessionScope,
+        )
+    }
+
+    @Test
+    fun givenPublicPreparationFailures_whenMapping_thenRetryabilityIsExplicit() {
+        val failures = listOf(
+            UserSessionPreparationFailure.InsufficientStorage to true,
+            UserSessionPreparationFailure.TemporarilyUnavailable to true,
+            UserSessionPreparationFailure.ApplicationUpdateRequired to false,
+            UserSessionPreparationFailure.SupportRequired to false,
+        )
+
+        failures.forEach { (reason, expectedCanRetry) ->
+            val result = failure(reason).toAppResult() as AppUserSessionPreparationResult.Failed
+            assertEquals(reason, result.reason)
+            if (expectedCanRetry) assertTrue(result.canRetry) else assertFalse(result.canRetry)
+        }
+    }
+
+    @Test
+    fun givenPublicPreparationFailures_whenMappingForForeground_thenEveryActionableStateIsPreserved() {
+        val mappings = mapOf(
+            UserSessionPreparationFailure.InsufficientStorage to UserSessionPreparationUiFailure.InsufficientStorage,
+            UserSessionPreparationFailure.TemporarilyUnavailable to UserSessionPreparationUiFailure.TemporarilyUnavailable,
+            UserSessionPreparationFailure.ApplicationUpdateRequired to
+                    UserSessionPreparationUiFailure.ApplicationUpdateRequired,
+            UserSessionPreparationFailure.SupportRequired to UserSessionPreparationUiFailure.SupportRequired,
+        )
+
+        mappings.forEach { (failure, expected) ->
+            assertEquals(expected, failure.toUiFailure())
+        }
+    }
+
+    private fun success(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+        mockk<PrepareUserSessionResult.Success>().also {
+            every { it.sessionScope } returns sessionScope
+        }
+
+    private fun failure(reason: UserSessionPreparationFailure): PrepareUserSessionResult.Failure =
+        mockk<PrepareUserSessionResult.Failure>().also {
+            every { it.reason } returns reason
+        }
+
+    private companion object {
+        val USER_ID = UserId("user", "wire.test")
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
+++ b/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
@@ -17,10 +17,12 @@
  */
 package com.wire.android.session
 
-import com.wire.android.ui.MIGRATION_SCREEN_DEBOUNCE_MILLIS
+import com.wire.android.ui.MIGRATION_SCREEN_MINIMUM_VISIBILITY
+import com.wire.android.ui.MIGRATION_SCREEN_REVEAL_DELAY
+import com.wire.android.ui.MigrationScreenVisibility
 import com.wire.android.ui.UserSessionPreparationUiFailure
 import com.wire.android.ui.UserSessionPreparationUiState
-import com.wire.android.ui.preparationScreenRevealDelayMillis
+import com.wire.android.ui.preparationScreenRevealDelay
 import com.wire.android.ui.toUiFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.PrepareUserSessionResult
@@ -40,6 +42,8 @@ import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
 class UserSessionPreparationGateTest {
 
@@ -119,15 +123,15 @@ class UserSessionPreparationGateTest {
         )
 
         hiddenStates.forEach { state ->
-            assertEquals(null, state.preparationScreenRevealDelayMillis())
+            assertEquals(null, state.preparationScreenRevealDelay())
         }
     }
 
     @Test
     fun givenMigrationState_whenChoosingVisibility_thenPreparationScreenIsDebounced() {
         assertEquals(
-            MIGRATION_SCREEN_DEBOUNCE_MILLIS,
-            UserSessionPreparationUiState.MigratingDatabase.preparationScreenRevealDelayMillis(),
+            MIGRATION_SCREEN_REVEAL_DELAY,
+            UserSessionPreparationUiState.MigratingDatabase.preparationScreenRevealDelay(),
         )
     }
 
@@ -135,7 +139,48 @@ class UserSessionPreparationGateTest {
     fun givenFailureState_whenChoosingVisibility_thenPreparationScreenIsRevealedImmediately() {
         val state = UserSessionPreparationUiState.Failed(UserSessionPreparationUiFailure.SupportRequired)
 
-        assertEquals(0L, state.preparationScreenRevealDelayMillis())
+        assertEquals(Duration.ZERO, state.preparationScreenRevealDelay())
+    }
+
+    @Test
+    fun givenMigrationScreenWasNeverRevealed_whenLeavingPreparation_thenNothingIsWaitedFor() {
+        val visibility = MigrationScreenVisibility(elapsedRealtimeMillis = { 0L })
+
+        assertEquals(Duration.ZERO, visibility.remainingVisibility())
+    }
+
+    @Test
+    fun givenMigrationFinishedRightAfterReveal_whenLeavingPreparation_thenRemainderOfMinimumIsWaitedFor() {
+        var now = 1_000L
+        val visibility = MigrationScreenVisibility(elapsedRealtimeMillis = { now })
+
+        visibility.onRevealed()
+        now += 200L
+
+        assertEquals(MIGRATION_SCREEN_MINIMUM_VISIBILITY - 200.milliseconds, visibility.remainingVisibility())
+    }
+
+    @Test
+    fun givenMigrationOutlivedTheMinimum_whenLeavingPreparation_thenNothingIsWaitedFor() {
+        var now = 1_000L
+        val visibility = MigrationScreenVisibility(elapsedRealtimeMillis = { now })
+
+        visibility.onRevealed()
+        now += MIGRATION_SCREEN_MINIMUM_VISIBILITY.inWholeMilliseconds + 1L
+
+        assertEquals(Duration.ZERO, visibility.remainingVisibility())
+    }
+
+    @Test
+    fun givenScreenAlreadyRevealed_whenRevealedAgain_thenMinimumStillCountsFromFirstReveal() {
+        var now = 1_000L
+        val visibility = MigrationScreenVisibility(elapsedRealtimeMillis = { now })
+
+        visibility.onRevealed()
+        now += 400L
+        visibility.onRevealed()
+
+        assertEquals(MIGRATION_SCREEN_MINIMUM_VISIBILITY - 400.milliseconds, visibility.remainingVisibility())
     }
 
     private fun success(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =

--- a/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
+++ b/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
@@ -17,7 +17,10 @@
  */
 package com.wire.android.session
 
+import com.wire.android.ui.MIGRATION_SCREEN_DEBOUNCE_MILLIS
 import com.wire.android.ui.UserSessionPreparationUiFailure
+import com.wire.android.ui.UserSessionPreparationUiState
+import com.wire.android.ui.preparationScreenRevealDelayMillis
 import com.wire.android.ui.toUiFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.PrepareUserSessionResult
@@ -105,6 +108,34 @@ class UserSessionPreparationGateTest {
         mappings.forEach { (failure, expected) ->
             assertEquals(expected, failure.toUiFailure())
         }
+    }
+
+    @Test
+    fun givenFastPreparationStates_whenChoosingVisibility_thenPreparationScreenStaysBehindSystemSplash() {
+        val hiddenStates = listOf(
+            UserSessionPreparationUiState.ResolvingSession,
+            UserSessionPreparationUiState.OpeningDatabase,
+            UserSessionPreparationUiState.Ready,
+        )
+
+        hiddenStates.forEach { state ->
+            assertEquals(null, state.preparationScreenRevealDelayMillis())
+        }
+    }
+
+    @Test
+    fun givenMigrationState_whenChoosingVisibility_thenPreparationScreenIsDebounced() {
+        assertEquals(
+            MIGRATION_SCREEN_DEBOUNCE_MILLIS,
+            UserSessionPreparationUiState.MigratingDatabase.preparationScreenRevealDelayMillis(),
+        )
+    }
+
+    @Test
+    fun givenFailureState_whenChoosingVisibility_thenPreparationScreenIsRevealedImmediately() {
+        val state = UserSessionPreparationUiState.Failed(UserSessionPreparationUiFailure.SupportRequired)
+
+        assertEquals(0L, state.preparationScreenRevealDelayMillis())
     }
 
     private fun success(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =

--- a/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
+++ b/app/src/test/kotlin/com/wire/android/session/UserSessionPreparationGateTest.kt
@@ -24,9 +24,11 @@ import com.wire.android.ui.UserSessionPreparationUiFailure
 import com.wire.android.ui.UserSessionPreparationUiState
 import com.wire.android.ui.preparationScreenRevealDelay
 import com.wire.android.ui.toUiFailure
+import com.wire.android.ui.toUiStates
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.UserSessionPreparationFailure
+import com.wire.kalium.logic.UserSessionPreparationState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.UserSessionScope
 import io.mockk.coEvery
@@ -35,6 +37,11 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -142,6 +149,36 @@ class UserSessionPreparationGateTest {
         assertEquals(Duration.ZERO, state.preparationScreenRevealDelay())
     }
 
+    /** Preserves a short migration state after observation starts while the main collector is busy. */
+    @Test
+    fun givenStatesChangeWhileTheCollectorIsBusy_whenMappingForForeground_thenMigrationIsStillDelivered() = runTest {
+        val states = MutableStateFlow<UserSessionPreparationState>(UserSessionPreparationState.NotStarted)
+        val observed = mutableListOf<UserSessionPreparationUiState>()
+        val collector = launch(UnconfinedTestDispatcher(testScheduler)) {
+            states.toUiStates().collect { state ->
+                observed += state
+                delay(BUSY_COLLECTOR_DELAY) // stands in for a main thread stuck on the first frame
+            }
+        }
+        runCurrent()
+
+        states.value = UserSessionPreparationState.OpeningDatabase
+        states.value = UserSessionPreparationState.MigratingDatabase
+        states.value = UserSessionPreparationState.Ready
+        advanceTimeBy(BUSY_COLLECTOR_DELAY * OBSERVED_STATE_COUNT)
+        collector.cancel()
+
+        assertEquals(
+            listOf(
+                UserSessionPreparationUiState.ResolvingSession,
+                UserSessionPreparationUiState.OpeningDatabase,
+                UserSessionPreparationUiState.MigratingDatabase,
+                UserSessionPreparationUiState.Ready,
+            ),
+            observed,
+        )
+    }
+
     @Test
     fun givenMigrationScreenWasNeverRevealed_whenLeavingPreparation_thenNothingIsWaitedFor() {
         val visibility = MigrationScreenVisibility(elapsedRealtimeMillis = { 0L })
@@ -195,5 +232,7 @@ class UserSessionPreparationGateTest {
 
     private companion object {
         val USER_ID = UserId("user", "wire.test")
+        const val BUSY_COLLECTOR_DELAY = 1_000L
+        const val OBSERVED_STATE_COUNT = 4
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/SessionGraphStoreViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/SessionGraphStoreViewModelTest.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.wire.android.di.metro.AppSessionViewModelGraph
 import com.wire.android.util.ui.WireSessionImageLoader
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -41,8 +42,8 @@ class SessionGraphStoreViewModelTest {
         val oldGraph = graphWith(oldImageLoader)
         val newGraph = graphWith(mockk(relaxed = true))
         val graphs = ArrayDeque(listOf(oldGraph, newGraph))
-        val store = SessionGraphStoreViewModel { graphs.removeFirst() }
-        val oldRetainedGraph = store.retainedGraphFor(USER_ID)
+        val store = SessionGraphStoreViewModel { _, _ -> graphs.removeFirst() }
+        val oldRetainedGraph = store.retainedGraphFor(USER_ID, SESSION_SCOPE)
         val oldViewModel = TrackingViewModel()
         ViewModelProvider(
             oldRetainedGraph,
@@ -50,7 +51,7 @@ class SessionGraphStoreViewModelTest {
         )[TrackingViewModel::class.java]
 
         store.invalidate(USER_ID)
-        val newRetainedGraph = store.retainedGraphFor(USER_ID)
+        val newRetainedGraph = store.retainedGraphFor(USER_ID, SESSION_SCOPE)
 
         assertNotSame(oldRetainedGraph, newRetainedGraph)
         assertSame(newGraph, newRetainedGraph.graph)
@@ -64,11 +65,11 @@ class SessionGraphStoreViewModelTest {
         val oldGraph = graphWith(oldImageLoader)
         val newGraph = graphWith(mockk(relaxed = true))
         val graphs = ArrayDeque(listOf(oldGraph, newGraph))
-        val store = SessionGraphStoreViewModel { graphs.removeFirst() }
-        val oldRetainedGraph = store.retainedGraphFor(USER_ID)
+        val store = SessionGraphStoreViewModel { _, _ -> graphs.removeFirst() }
+        val oldRetainedGraph = store.retainedGraphFor(USER_ID, SESSION_SCOPE)
 
         store.invalidateActive()
-        val newRetainedGraph = store.retainedGraphFor(USER_ID)
+        val newRetainedGraph = store.retainedGraphFor(USER_ID, SESSION_SCOPE)
 
         assertNotSame(oldRetainedGraph, newRetainedGraph)
         assertSame(newGraph, newRetainedGraph.graph)
@@ -78,10 +79,10 @@ class SessionGraphStoreViewModelTest {
     @Test
     fun givenSessionGraphIsStillValid_whenRequestedAgain_thenGraphIsReused() {
         val graph = graphWith(mockk(relaxed = true))
-        val store = SessionGraphStoreViewModel { graph }
+        val store = SessionGraphStoreViewModel { _, _ -> graph }
 
-        val first = store.retainedGraphFor(USER_ID)
-        val second = store.retainedGraphFor(USER_ID)
+        val first = store.retainedGraphFor(USER_ID, SESSION_SCOPE)
+        val second = store.retainedGraphFor(USER_ID, SESSION_SCOPE)
 
         assertSame(first, second)
     }
@@ -90,11 +91,11 @@ class SessionGraphStoreViewModelTest {
     fun givenSameUserIsRemovedAndLogsInRepeatedly_whenGraphsAreInvalidated_thenEveryLoginGetsAFreshGraph() {
         val imageLoaders = List(RELOGIN_COUNT) { mockk<WireSessionImageLoader>(relaxed = true) }
         val graphs = ArrayDeque(imageLoaders.map(::graphWith))
-        val store = SessionGraphStoreViewModel { graphs.removeFirst() }
+        val store = SessionGraphStoreViewModel { _, _ -> graphs.removeFirst() }
 
         val retainedGraphs = buildList {
             repeat(RELOGIN_COUNT) { index ->
-                add(store.retainedGraphFor(USER_ID))
+                add(store.retainedGraphFor(USER_ID, SESSION_SCOPE))
                 if (index < RELOGIN_COUNT - 1) {
                     store.invalidate(USER_ID)
                 }
@@ -119,14 +120,14 @@ class SessionGraphStoreViewModelTest {
             USER_ID to graphWith(removedUserImageLoader),
             OTHER_USER_ID to graphWith(otherUserImageLoader),
         )
-        val store = SessionGraphStoreViewModel { userId -> graphsByUser.getValue(userId) }
-        val otherUsersGraph = store.retainedGraphFor(OTHER_USER_ID)
-        val removedUsersGraph = store.retainedGraphFor(USER_ID)
+        val store = SessionGraphStoreViewModel { userId, _ -> graphsByUser.getValue(userId) }
+        val otherUsersGraph = store.retainedGraphFor(OTHER_USER_ID, OTHER_SESSION_SCOPE)
+        val removedUsersGraph = store.retainedGraphFor(USER_ID, SESSION_SCOPE)
 
         store.invalidateActive()
 
-        assertSame(otherUsersGraph, store.retainedGraphFor(OTHER_USER_ID))
-        assertNotSame(removedUsersGraph, store.retainedGraphFor(USER_ID))
+        assertSame(otherUsersGraph, store.retainedGraphFor(OTHER_USER_ID, OTHER_SESSION_SCOPE))
+        assertNotSame(removedUsersGraph, store.retainedGraphFor(USER_ID, SESSION_SCOPE))
         verify(exactly = 1) { removedUserImageLoader.shutdown() }
         verify(exactly = 0) { otherUserImageLoader.shutdown() }
     }
@@ -148,5 +149,7 @@ class SessionGraphStoreViewModelTest {
         const val RELOGIN_COUNT = 3
         val USER_ID = UserId("user", "domain")
         val OTHER_USER_ID = UserId("other-user", "domain")
+        val SESSION_SCOPE = mockk<UserSessionScope>()
+        val OTHER_SESSION_SCOPE = mockk<UserSessionScope>()
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/WireActivityViewModelTest.kt
@@ -35,10 +35,6 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.IsProfileQRCodeEnabledUseCaseProvider
-import com.wire.android.di.ObserveIfE2EIRequiredDuringLoginUseCaseProvider
-import com.wire.android.di.ObserveScreenshotCensoringConfigUseCaseProvider
-import com.wire.android.di.ObserveSelfUserUseCaseProvider
-import com.wire.android.di.ObserveSyncStateUseCaseProvider
 import com.wire.android.emm.ManagedConfigurationsManager
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
@@ -67,6 +63,9 @@ import com.wire.android.util.lifecycle.IntentsProcessor
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
+import com.wire.kalium.logic.UserSessionPreparationState
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.auth.PersistentWebSocketStatus
@@ -80,6 +79,7 @@ import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.sync.SyncState
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.appVersioning.ObserveIfAppUpdateRequiredUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.auth.AuthenticationScope
 import com.wire.kalium.logic.feature.auth.IsNomadProfilesEnabledUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
@@ -112,6 +112,8 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -120,10 +122,12 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -181,6 +185,42 @@ class WireActivityViewModelTest {
 
         assertEquals(InitialAppState.EnrollE2EI(TEST_ACCOUNT_INFO.userId), viewModel.initialAppState())
         assertEquals(TEST_ACCOUNT_INFO.userId, viewModel.globalAppState.currentUserId)
+    }
+
+    @Test
+    fun givenUserDatabaseIsStillPreparing_whenForegroundStarts_thenSessionStateIsNotPublishedUntilReady() = runTest {
+        val preparation = CompletableDeferred<PrepareUserSessionResult>()
+        val (arrangement, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withDeferredPreparation(preparation)
+            .arrange()
+
+        val initialState = async { viewModel.initialAppState() }
+        runCurrent()
+
+        assertNull(viewModel.globalAppState.currentUserId)
+        assertEquals(UserSessionPreparationUiState.ResolvingSession, viewModel.userSessionPreparationState)
+
+        preparation.complete(arrangement.preparationSuccess())
+
+        assertEquals(InitialAppState.LoggedIn, initialState.await())
+        assertEquals(TEST_ACCOUNT_INFO.userId, viewModel.globalAppState.currentUserId)
+        assertEquals(UserSessionPreparationUiState.Ready, viewModel.userSessionPreparationState)
+    }
+
+    @Test
+    fun givenPreparationNeedsApplicationUpdate_whenForegroundStarts_thenActionableFailureIsExposed() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withSomeCurrentSession()
+            .withPreparationFailure(UserSessionPreparationFailure.ApplicationUpdateRequired)
+            .arrange()
+
+        assertEquals(InitialAppState.SessionPreparationFailed, viewModel.initialAppState())
+        assertEquals(
+            UserSessionPreparationUiState.Failed(UserSessionPreparationUiFailure.ApplicationUpdateRequired),
+            viewModel.userSessionPreparationState,
+        )
+        assertNull(viewModel.globalAppState.currentUserId)
     }
 
     @Test
@@ -633,6 +673,8 @@ class WireActivityViewModelTest {
             .withNewClient(NewClientResult.InCurrentAccount(listOf(TestClient.CLIENT), USER_ID))
             .withCurrentScreen(MutableStateFlow<CurrentScreen>(CurrentScreen.SomeOther()))
             .arrange()
+        viewModel.initialAppState()
+        advanceUntilIdle()
 
         assertEquals(
             NewClientsData.CurrentUser(listOf(NewClientInfo.fromClient(TestClient.CLIENT)), USER_ID),
@@ -647,6 +689,8 @@ class WireActivityViewModelTest {
             .withNewClient(NewClientResult.InOtherAccount(listOf(TestClient.CLIENT), USER_ID, "name", "handle"))
             .withCurrentScreen(MutableStateFlow<CurrentScreen>(CurrentScreen.SomeOther()))
             .arrange()
+        viewModel.initialAppState()
+        advanceUntilIdle()
 
         assertEquals(
             NewClientsData.OtherUser(
@@ -668,6 +712,7 @@ class WireActivityViewModelTest {
             .withNewClient(newClientFlow)
             .withCurrentScreen(currentScreenFlow)
             .arrange()
+        viewModel.initialAppState()
 
         currentScreenFlow.value = CurrentScreen.ImportMedia
         newClientFlow.emit(NewClientResult.InCurrentAccount(listOf(TestClient.CLIENT), USER_ID))
@@ -685,6 +730,7 @@ class WireActivityViewModelTest {
             .withNewClient(NewClientResult.InCurrentAccount(listOf(TestClient.CLIENT), USER_ID))
             .withCurrentScreen(currentScreenFlow)
             .arrange()
+        viewModel.initialAppState()
 
         currentScreenFlow.value = CurrentScreen.ImportMedia
 
@@ -1225,6 +1271,7 @@ class WireActivityViewModelTest {
 
         val managedConfigurationsManager: ManagedConfigurationsManager = mockk(relaxed = true)
         private val persistentWebSocketEnforcedByMDMFlow = MutableStateFlow(false)
+        private val sessionScopes = mutableMapOf<UserId, UserSessionScope>()
         private var defaultServerConfig = newServerConfig(0).links
         val automatedLoginManager = AutomatedLoginManager()
 
@@ -1236,29 +1283,27 @@ class WireActivityViewModelTest {
             mockUri()
             coEvery { monitorSyncWorkUseCase() } returns Unit
             coEvery { currentSessionFlow() } returns flowOf()
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess()
+            every { coreLogic.observeUserSessionPreparation(any()) } returns flowOf(UserSessionPreparationState.NotStarted)
+            coEvery { userSessionScope.observeIfE2EIRequiredDuringLogin() } returns flowOf(false)
             coEvery { coreLogic.getGlobalScope().session.currentSession() } returns CurrentSessionResult.Failure.SessionNotFound
             coEvery { getServerConfigUseCase(any()) } returns GetServerConfigResult.Success(newServerConfig(1).links)
             coEvery { deepLinkProcessor(any(), any()) } returns DeepLinkResult.Unknown
             coEvery { intentsProcessor(any()) } returns null
             coEvery { observeSessionsUseCase.invoke() } returns flowOf(GetAllSessionsResult.Failure.NoSessionFound)
-            every { observeSyncStateUseCaseProviderFactory.create(any()).observeSyncState } returns observeSyncStateUseCase
+            every { userSessionScope.observeSyncState } returns observeSyncStateUseCase
             every { observeSyncStateUseCase() } returns emptyFlow()
             coEvery { observeIfAppUpdateRequired(any()) } returns flowOf(false)
             coEvery { observeNewClients() } returns flowOf()
-            every { observeScreenshotCensoringConfigUseCaseProviderFactory.create(any()).observeScreenshotCensoringConfig } returns
-                    observeScreenshotCensoringConfigUseCase
+            every { userSessionScope.observeScreenshotCensoringConfig } returns observeScreenshotCensoringConfigUseCase
             every { observeScreenshotCensoringConfigUseCase.invoke() } returns
                     flowOf(ObserveScreenshotCensoringConfigResult.Disabled)
             coEvery { currentScreenManager.observeCurrentScreen(any()) } returns MutableStateFlow(CurrentScreen.SomeOther())
             coEvery { globalDataStore.selectedThemeOptionFlow() } returns flowOf(ThemeOption.LIGHT)
-            coEvery {
-                observeIfE2EIRequiredDuringLoginUseCaseProviderFactory.create(any()).observeIfE2EIIsRequiredDuringLogin()
-            } returns
-                    flowOf(false)
             every { workManager.cancelAllWorkByTag(any()) } returns mockk<Operation>()
             every { workManager.enqueueUniquePeriodicWork(any(), any(), any()) } returns mockk<Operation>()
             val observeSelfUserUseCase = mockk<ObserveSelfUserUseCase>()
-            every { observeSelfUserFactory.create(any()).observeSelfUser } returns observeSelfUserUseCase
+            every { userSessionScope.users.observeSelfUser } returns observeSelfUserUseCase
             coEvery { observeSelfUserUseCase() } returns flowOf(SELF_USER)
             every { managedConfigurationsManager.persistentWebSocketEnforcedByMDM } returns persistentWebSocketEnforcedByMDMFlow
             every { managedConfigurationsManager.currentServerConfig } returns null
@@ -1299,10 +1344,10 @@ class WireActivityViewModelTest {
         private lateinit var observeSyncStateUseCase: ObserveSyncStateUseCase
 
         @MockK
-        private lateinit var observeSyncStateUseCaseProviderFactory: ObserveSyncStateUseCaseProvider.Factory
+        private lateinit var coreLogic: CoreLogic
 
         @MockK
-        private lateinit var coreLogic: CoreLogic
+        lateinit var userSessionScope: UserSessionScope
 
         @MockK
         private lateinit var autoVersionAuthScopeUseCase: AutoVersionAuthScopeUseCase
@@ -1332,12 +1377,6 @@ class WireActivityViewModelTest {
         lateinit var observeScreenshotCensoringConfigUseCase: ObserveScreenshotCensoringConfigUseCase
 
         @MockK
-        private lateinit var observeScreenshotCensoringConfigUseCaseProviderFactory: ObserveScreenshotCensoringConfigUseCaseProvider.Factory
-
-        @MockK
-        private lateinit var observeIfE2EIRequiredDuringLoginUseCaseProviderFactory: ObserveIfE2EIRequiredDuringLoginUseCaseProvider.Factory
-
-        @MockK
         lateinit var globalDataStore: GlobalDataStore
 
         @MockK
@@ -1348,9 +1387,6 @@ class WireActivityViewModelTest {
 
         @MockK
         lateinit var isProfileQRCodeEnabledFactory: IsProfileQRCodeEnabledUseCaseProvider.Factory
-
-        @MockK
-        lateinit var observeSelfUserFactory: ObserveSelfUserUseCaseProvider.Factory
 
         @MockK
         lateinit var monitorSyncWorkUseCase: MonitorSyncWorkUseCase
@@ -1376,17 +1412,13 @@ class WireActivityViewModelTest {
                 observeSessions = lazyOf(observeSessionsUseCase),
                 accountSwitch = lazyOf(switchAccount),
                 servicesManager = lazyOf(servicesManager),
-                observeSyncStateUseCaseProviderFactory = observeSyncStateUseCaseProviderFactory,
                 observeIfAppUpdateRequired = lazyOf(observeIfAppUpdateRequired),
                 observeNewClients = lazyOf(observeNewClients),
                 clearNewClientsForUser = lazyOf(clearNewClientsForUser),
                 currentScreenManager = lazyOf(currentScreenManager),
-                observeScreenshotCensoringConfigUseCaseProviderFactory = observeScreenshotCensoringConfigUseCaseProviderFactory,
                 globalDataStore = lazyOf(globalDataStore),
-                observeIfE2EIRequiredDuringLoginUseCaseProviderFactory = observeIfE2EIRequiredDuringLoginUseCaseProviderFactory,
                 workManager = lazyOf(workManager),
                 isProfileQRCodeEnabledFactory = isProfileQRCodeEnabledFactory,
-                observeSelfUserFactory = observeSelfUserFactory,
                 monitorSyncWorkUseCase = monitorSyncWorkUseCase,
                 managedConfigurationsManager = managedConfigurationsManager,
                 defaultServerConfig = defaultServerConfig,
@@ -1402,6 +1434,21 @@ class WireActivityViewModelTest {
             coEvery { coreLogic.getGlobalScope().session.currentSession() } returns CurrentSessionResult.Success(TEST_ACCOUNT_INFO)
             coEvery { doesValidSessionExist(any()) } returns DoesValidSessionExistResult.Success(true)
         }
+
+        fun withDeferredPreparation(result: CompletableDeferred<PrepareUserSessionResult>): Arrangement = apply {
+            coEvery { coreLogic.prepareUserSession(any()) } coAnswers { result.await() }
+        }
+
+        fun withPreparationFailure(reason: UserSessionPreparationFailure): Arrangement = apply {
+            val result = mockk<PrepareUserSessionResult.Failure>()
+            every { result.reason } returns reason
+            coEvery { coreLogic.prepareUserSession(any()) } returns result
+        }
+
+        fun preparationSuccess(sessionScope: UserSessionScope = userSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
 
         fun withInvalidCurrentSession(logoutReason: LogoutReason): Arrangement = apply {
             coEvery { currentSessionFlow() } returns flowOf(CurrentSessionResult.Success(invalidAccountInfo(logoutReason)))
@@ -1437,7 +1484,8 @@ class WireActivityViewModelTest {
         }
 
         fun withServerConfigForUser(userId: UserId, serverConfig: ServerConfig): Arrangement = apply {
-            coEvery { coreLogic.getSessionScope(userId).users.serverLinks() } returns
+            val sessionScope = sessionScopeFor(userId)
+            coEvery { sessionScope.users.serverLinks() } returns
                     SelfServerConfigUseCase.Result.Success(serverConfig)
         }
 
@@ -1450,9 +1498,7 @@ class WireActivityViewModelTest {
         }
 
         fun withE2EIRequiredDuringLogin(required: Boolean): Arrangement = apply {
-            coEvery {
-                observeIfE2EIRequiredDuringLoginUseCaseProviderFactory.create(any()).observeIfE2EIIsRequiredDuringLogin()
-            } returns flowOf(required)
+            coEvery { userSessionScope.observeIfE2EIRequiredDuringLogin() } returns flowOf(required)
         }
 
         fun withObserveSessionsFlow(result: Flow<GetAllSessionsResult>): Arrangement = apply {
@@ -1486,8 +1532,9 @@ class WireActivityViewModelTest {
             domain: String,
             result: CheckConversationInviteCodeUseCase.Result
         ): Arrangement = apply {
+            val sessionScope = sessionScopeFor(TEST_ACCOUNT_INFO.userId)
             coEvery {
-                coreLogic.getSessionScope(TEST_ACCOUNT_INFO.userId).conversations.checkIConversationInviteCode(
+                sessionScope.conversations.checkIConversationInviteCode(
                     code,
                     key,
                     domain
@@ -1518,7 +1565,7 @@ class WireActivityViewModelTest {
 
         fun withCurrentScreen(currentScreenFlow: StateFlow<CurrentScreen>) = apply {
             coEvery { currentScreenManager.observeCurrentScreen(any()) } returns currentScreenFlow
-            coEvery { coreLogic.getSessionScope(TEST_ACCOUNT_INFO.userId).observeIfE2EIRequiredDuringLogin() } returns flowOf(false)
+            coEvery { userSessionScope.observeIfE2EIRequiredDuringLogin() } returns flowOf(false)
         }
 
         fun withNoNetworkConnectionWhenGettingServerConfig() = apply {
@@ -1531,17 +1578,29 @@ class WireActivityViewModelTest {
         }
 
         suspend fun withScreenshotCensoringConfigForUser(id: UserId, result: ObserveScreenshotCensoringConfigResult) = apply {
+            val sessionScope = sessionScopeFor(id)
             val useCase = mockk<ObserveScreenshotCensoringConfigUseCase>()
-            coEvery {
-                observeScreenshotCensoringConfigUseCaseProviderFactory.create(id).observeScreenshotCensoringConfig
-            } returns useCase
+            every { sessionScope.observeScreenshotCensoringConfig } returns useCase
             coEvery { useCase() } returns flowOf(result)
         }
 
         fun withSyncStateForUser(id: UserId, result: SyncState) = apply {
+            val sessionScope = sessionScopeFor(id)
             val useCase = mockk<ObserveSyncStateUseCase>()
-            coEvery { observeSyncStateUseCaseProviderFactory.create(id).observeSyncState } returns useCase
+            every { sessionScope.observeSyncState } returns useCase
             coEvery { useCase() } returns flowOf(result)
+        }
+
+        private fun sessionScopeFor(userId: UserId): UserSessionScope = sessionScopes.getOrPut(userId) {
+            mockk<UserSessionScope>(relaxed = true).also { sessionScope ->
+                coEvery { coreLogic.prepareUserSession(userId) } returns preparationSuccess(sessionScope)
+                coEvery { sessionScope.observeIfE2EIRequiredDuringLogin() } returns flowOf(false)
+                every { sessionScope.observeSyncState } returns observeSyncStateUseCase
+                every { sessionScope.observeScreenshotCensoringConfig } returns observeScreenshotCensoringConfigUseCase
+                val observeSelfUser = mockk<ObserveSelfUserUseCase>()
+                every { sessionScope.users.observeSelfUser } returns observeSelfUser
+                coEvery { observeSelfUser() } returns flowOf(SELF_USER)
+            }
         }
 
         suspend fun withThemeOption(themeOption: ThemeOption) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -16,7 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-@file:Suppress("MaxLineLength")
+@file:Suppress("MaxLineLength", "LargeClass")
 
 package com.wire.android.ui.authentication.login.email
 
@@ -44,6 +44,8 @@ import com.wire.android.util.ui.CountdownTimer
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.configuration.server.CommonApiVersionType
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
@@ -69,6 +71,7 @@ import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerifi
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
@@ -625,6 +628,30 @@ class LoginEmailViewModelTest {
     }
 
     @Test
+    fun `given new session preparation fails, when canceling login, then preserve database and restore previous session`() = runTest {
+        val newUserId = UserId("newUserId", "domain")
+        val previousUserId = UserId("previousUserId", "domain")
+        val (arrangement, viewModel) = Arrangement()
+            .withPreparationFailure(UserSessionPreparationFailure.SupportRequired)
+            .withUpdateCurrentSessionReturning(UpdateCurrentSessionUseCase.Result.Success)
+            .arrange()
+        viewModel.loginJobData.value = LoginJobData(
+            job = mockk(relaxUnitFun = true),
+            previousSessionUserId = previousUserId,
+            newSessionUserId = newUserId,
+        )
+
+        viewModel.cancelLogin()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            arrangement.logoutUseCase(any(), any())
+            arrangement.deleteSessionUseCase(any())
+        }
+        coVerify(exactly = 1) { arrangement.updateCurrentSessionUseCase(previousUserId) }
+    }
+
+    @Test
     fun `given no previous session, when canceling login, then update current session to null`() = runTest {
         // given
         val (arrangement, viewModel) = Arrangement()
@@ -832,6 +859,9 @@ class LoginEmailViewModelTest {
         internal lateinit var coreLogic: CoreLogic
 
         @MockK
+        internal lateinit var userSessionScope: UserSessionScope
+
+        @MockK
         internal lateinit var requestSecondFactorCodeUseCase: RequestSecondFactorVerificationCodeUseCase
 
         @MockK
@@ -862,6 +892,9 @@ class LoginEmailViewModelTest {
             every { qualifiedIdMapper.fromStringToQualifiedID(any()) } returns USER_ID
             every { savedInputStore.userIdentifier = any<String>() } returns Unit
             every { coreLogic.getGlobalScope().validateEmailUseCase } returns validateEmailUseCase
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess(userSessionScope)
+            every { userSessionScope.users } returns userScope
+            every { userSessionScope.client } returns clientScope
             every { coreLogic.getSessionScope(any()).users } returns userScope
             every { userScope.persistSelfUserEmail } returns persistSelfUserEmailUseCase
             every { clientScopeProviderFactory.create(any()).clientScope } returns clientScope
@@ -870,6 +903,7 @@ class LoginEmailViewModelTest {
             every { authenticationScope.login } returns loginUseCase
             every { authenticationScope.requestSecondFactorVerificationCode } returns requestSecondFactorCodeUseCase
             every { coreLogic.versionedAuthenticationScope(any()) } returns autoVersionAuthScopeUseCase
+            every { userSessionScope.logout } returns logoutUseCase
             every { coreLogic.getSessionScope(any()).logout } returns logoutUseCase
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSessionUseCase
             every { coreLogic.getGlobalScope().session.updateCurrentSession } returns updateCurrentSessionUseCase
@@ -877,6 +911,11 @@ class LoginEmailViewModelTest {
             coEvery { currentSessionUseCase() } returns CurrentSessionResult.Success(AccountInfo.Valid(USER_ID))
             coEvery { countdownTimer.start(any(), any(), any()) } returns Unit
         }
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
 
         fun arrange() = this to LoginEmailViewModel(
             LoginNavArgs(loginPasswordPath = LoginPasswordPath(newServerConfig(1).links)),
@@ -937,6 +976,12 @@ class LoginEmailViewModelTest {
             coEvery {
                 currentSessionUseCase()
             } returns result
+        }
+
+        fun withPreparationFailure(reason: UserSessionPreparationFailure) = apply {
+            val result = mockk<PrepareUserSessionResult.Failure>()
+            every { result.reason } returns reason
+            coEvery { coreLogic.prepareUserSession(any()) } returns result
         }
 
         fun withDeleteSessionReturning(result: DeleteSessionUseCase.Result) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtensionTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtensionTest.kt
@@ -21,12 +21,14 @@ package com.wire.android.ui.authentication.login.sso
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountTokens
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.session.StoreSessionParam
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import io.mockk.coEvery
 import io.mockk.coVerifyOrder
@@ -117,8 +119,11 @@ class LoginSSOViewModelExtensionTest {
         val coreLogic = mockk<CoreLogic>()
         val logout = mockk<LogoutUseCase>()
         val deleteSession = mockk<DeleteSessionUseCase>()
+        val userSessionScope = mockk<UserSessionScope>()
 
         init {
+            coEvery { coreLogic.prepareUserSession(userId) } returns preparationSuccess(userSessionScope)
+            every { userSessionScope.logout } returns logout
             every { coreLogic.getSessionScope(userId).logout } returns logout
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSession
             coEvery { logout(LogoutReason.SELF_HARD_LOGOUT, true) } returns Unit
@@ -137,5 +142,10 @@ class LoginSSOViewModelExtensionTest {
         }
 
         fun arrange() = this to LoginSSOViewModelExtension(addAuthenticatedUser, coreLogic, false)
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -840,7 +840,7 @@ class NewLoginViewModelTest {
 
         fun withRegisterClientReturning(result: RegisterClientResult) = apply {
             coEvery {
-                loginViewModelExtension.registerClient(any(), any(), any(), any())
+                loginViewModelExtension.registerClient(any<UserId>(), any(), any(), any())
             } returns result
         }
 

--- a/app/src/test/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/lifecycle/SyncLifecycleManagerTest.kt
@@ -23,6 +23,7 @@ import com.wire.android.framework.fake.FakeSyncExecutor
 import com.wire.android.util.CurrentScreenManager
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
@@ -32,6 +33,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
@@ -274,6 +276,7 @@ class SyncLifecycleManagerTest {
             MockKAnnotations.init(this, relaxUnitFun = true)
             every { coreLogic.getGlobalScope().observeAllValidSessionsFlow } returns observeValidAccountsUseCase
             every { coreLogic.getSessionScope(TestUser.SELF_USER_ID) } returns userSessionScope
+            coEvery { coreLogic.prepareUserSession(TestUser.SELF_USER_ID) } returns preparationSuccess(userSessionScope)
             every { currentScreenManager.isAppVisibleFlow() } returns appVisibility
             coEvery { observeValidAccountsUseCase.invoke() } returns flowOf(
                 GetAllSessionsResult.Success(
@@ -283,6 +286,11 @@ class SyncLifecycleManagerTest {
                 )
             )
         }
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
 
         fun withAppInTheBackground() = apply {
             updateAppVisibility(false)

--- a/features/sync/src/main/kotlin/com/wire/android/sync/InitialSyncWorker.kt
+++ b/features/sync/src/main/kotlin/com/wire/android/sync/InitialSyncWorker.kt
@@ -30,15 +30,18 @@ import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.NotificationIds
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.work.Work
 import com.wire.kalium.work.WorkId
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.takeWhile
-import kotlinx.coroutines.launch
 import com.wire.android.feature.notification.R as NR
 
 class InitialSyncWorker @AssistedInject constructor(
@@ -62,23 +65,34 @@ class InitialSyncWorker @AssistedInject constructor(
             Log.e("InitialSyncWorker", "Failure to get active sessions. Not waiting for Sync.")
             Result.failure()
         } else {
-            coroutineScope {
-                result.sessions.forEach { session ->
-                    launch {
-                        coreLogic.sessionScope(session.userId) {
-                            syncExecutor.request {
-                                Log.i("InitialSyncWorker", "Waiting for Initial Sync for user '${session.userId}' to finish.")
-                                longWork.observeWorkStatus(workId).takeWhile {
-                                    it !is Work.Status.Complete
-                                }.collect()
-                                Log.i("InitialSyncWorker", "Initial Sync for user '${session.userId}' complete.")
+            val preparationFailures = coroutineScope {
+                result.sessions.map { session ->
+                    async {
+                        when (val preparation = coreLogic.prepareUserSession(session.userId)) {
+                            is PrepareUserSessionResult.Success -> {
+                                preparation.sessionScope.syncExecutor.request {
+                                    Log.i("InitialSyncWorker", "Waiting for Initial Sync for user '${session.userId}' to finish.")
+                                    preparation.sessionScope.longWork.observeWorkStatus(workId).takeWhile {
+                                        it !is Work.Status.Complete
+                                    }.collect()
+                                    Log.i("InitialSyncWorker", "Initial Sync for user '${session.userId}' complete.")
+                                }
+                                null
                             }
+
+                            is PrepareUserSessionResult.Failure -> preparation.reason
                         }
                     }
+                }.awaitAll().filterNotNull()
+            }
+            when {
+                preparationFailures.any { it.isRetryable() } -> Result.retry()
+                preparationFailures.isNotEmpty() -> Result.failure()
+                else -> {
+                    Log.i("InitialSyncWorker", "Initial Sync complete for all users")
+                    Result.success()
                 }
             }
-            Log.i("InitialSyncWorker", "Initial Sync complete for all users")
-            Result.success()
         }
     }
 
@@ -110,3 +124,7 @@ class InitialSyncWorker @AssistedInject constructor(
             .build()
     }
 }
+
+private fun UserSessionPreparationFailure.isRetryable(): Boolean =
+    this is UserSessionPreparationFailure.InsufficientStorage ||
+            this is UserSessionPreparationFailure.TemporarilyUnavailable

--- a/features/sync/src/main/kotlin/com/wire/android/sync/MonitorSyncWorkUseCase.kt
+++ b/features/sync/src/main/kotlin/com/wire/android/sync/MonitorSyncWorkUseCase.kt
@@ -24,6 +24,7 @@ import androidx.work.WorkManager
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.ObserveSessionsUseCase
 import com.wire.kalium.work.Work
@@ -51,8 +52,11 @@ class MonitorSyncWorkUseCase @Inject constructor(
      */
     suspend operator fun invoke() {
         allSessionsUseCase().filterIsInstance<GetAllSessionsResult.Success>().map { result ->
-            result.sessions.map { session ->
-                coreLogic.sessionScope(session.userId) { longWork }
+            result.sessions.mapNotNull { session ->
+                when (val preparation = coreLogic.prepareUserSession(session.userId)) {
+                    is PrepareUserSessionResult.Success -> preparation.sessionScope.longWork
+                    is PrepareUserSessionResult.Failure -> null
+                }
             }
         }.flatMapLatest { scopes ->
             scopes.map { scope ->


### PR DESCRIPTION
## Goal

Move user-database preparation behind an explicit lifecycle so database opening and SQLDelight migrations do not block or race session-dependent Android components.

## Changes

- Introduce a single user-session preparation gate and reuse the prepared session scope across startup, authentication, calls, app lock, services, workers, notifications, and observers.
- Keep fast preparation behind the system splash while showing longer migrations on an app-owned screen that visually continues the splash and explains what Wire is doing.
- Provide actionable retry, update, and support states when preparation fails.
- Delay session-dependent work until storage is ready and add coverage for the preparation lifecycle, screen visibility, and affected consumers.

## User impact

Normal launches continue directly into Wire. During a longer database upgrade, users now see a stable branded explanation instead of an apparently stuck splash or partially initialized UI. Recoverable failures provide a clear next action.

## Validation

- Dev debug Kotlin compilation passes.
- Preparation lifecycle and integration behavior are covered by new and updated tests.
