### PR TITLE
feat(auth): prepare sessions after authentication PR 4

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/create/code/CreateAccountCodeViewModel.kt
@@ -27,9 +27,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.BuildConfig
-import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.authentication.create.common.CreateAccountFlowType
 import com.wire.android.ui.authentication.create.common.CreateAccountNavArgs
 import com.wire.android.ui.authentication.login.email.LoginEmailViewModel.Companion.RESEND_TIMER_DELAY
@@ -37,12 +38,14 @@ import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.ui.registration.code.CreateAccountCodeResult
 import com.wire.android.util.WillNeverOccurError
 import com.wire.android.util.ui.CountdownTimer
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.session.StoreSessionParam
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.client.RegisterClientParam
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.register.RegisterParam
@@ -59,7 +62,6 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
     @Assisted savedStateHandle: SavedStateHandle,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
-    private val clientScopeProviderFactory: ClientScopeProvider.Factory,
     defaultServerConfig: ServerConfig.Links,
     @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean
 ) : ViewModel() {
@@ -67,6 +69,8 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
     interface Factory {
         fun create(savedStateHandle: SavedStateHandle): CreateAccountCodeViewModel
     }
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     val createAccountNavArgs: CreateAccountNavArgs = savedStateHandle.navArgs()
 
@@ -205,7 +209,18 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
                     is AddAuthenticatedUserUseCase.Result.Success -> it.userId
                 }
             }
-            registerClient(storedUserId, registerParam.password).let {
+            val sessionScope = when (val preparation = userSessionPreparationGate.prepare(storedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    updateCodeErrorState(
+                        CreateAccountCodeResult.Error.DialogError.GenericError(
+                            CoreFailure.Unknown(IllegalStateException("User session preparation failed: ${preparation.reason}"))
+                        )
+                    )
+                    return@launch
+                }
+            }
+            registerClient(sessionScope, registerParam.password).let {
                 when (it) {
                     is RegisterClientResult.Failure -> {
                         updateCodeErrorState(it.toCodeError(storedUserId))
@@ -229,8 +244,8 @@ class CreateAccountCodeViewModel @AssistedInject constructor(
         codeState = codeState.copy(loading = false, result = codeError)
     }
 
-    private suspend fun registerClient(userId: UserId, password: String) =
-        clientScopeProviderFactory.create(userId).clientScope.getOrRegister(
+    private suspend fun registerClient(sessionScope: UserSessionScope, password: String) =
+        sessionScope.client.getOrRegister(
             RegisterClientParam(
                 password = password,
                 capabilities = null,

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModel.kt
@@ -32,6 +32,7 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.AuthenticationResult
 import com.wire.kalium.logic.feature.auth.DomainLookupUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 
 @Suppress("TooManyFunctions")
@@ -59,6 +60,13 @@ open class LoginViewModel(
         secondFactorVerificationCode: String? = null,
         capabilities: List<ClientCapability>? = null,
     ): RegisterClientResult = loginExtension.registerClient(userId, password, secondFactorVerificationCode, capabilities)
+
+    suspend fun registerClient(
+        sessionScope: UserSessionScope,
+        password: String?,
+        secondFactorVerificationCode: String? = null,
+        capabilities: List<ClientCapability>? = null,
+    ): RegisterClientResult = loginExtension.registerClient(sessionScope, password, secondFactorVerificationCode, capabilities)
 
     internal suspend fun isInitialSyncCompleted(userId: UserId): Boolean = loginExtension.isInitialSyncCompleted(userId)
 }

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModelExtension.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/LoginViewModelExtension.kt
@@ -22,6 +22,8 @@ import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.di.ClientScopeProvider
 import com.wire.kalium.logic.data.client.ClientCapability
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.kalium.logic.feature.UserSessionScope
+import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientParam
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import kotlinx.coroutines.flow.first
@@ -38,15 +40,34 @@ class LoginViewModelExtension(
         capabilities: List<ClientCapability>? = null,
     ): RegisterClientResult {
         val clientScope = clientScopeProviderFactory.create(userId).clientScope
-        return clientScope.getOrRegister(
-            RegisterClientParam(
-                password = password,
-                capabilities = capabilities,
-                secondFactorVerificationCode = secondFactorVerificationCode,
-                modelPostfix = if (BuildConfig.PRIVATE_BUILD) " [${BuildConfig.FLAVOR}_${BuildConfig.BUILD_TYPE}]" else null
-            )
-        )
+        return registerClient(clientScope.getOrRegister, password, secondFactorVerificationCode, capabilities)
     }
+
+    suspend fun registerClient(
+        sessionScope: UserSessionScope,
+        password: String?,
+        secondFactorVerificationCode: String? = null,
+        capabilities: List<ClientCapability>? = null,
+    ): RegisterClientResult = registerClient(
+        sessionScope.client.getOrRegister,
+        password,
+        secondFactorVerificationCode,
+        capabilities,
+    )
+
+    private suspend fun registerClient(
+        getOrRegister: GetOrRegisterClientUseCase,
+        password: String?,
+        secondFactorVerificationCode: String?,
+        capabilities: List<ClientCapability>?,
+    ): RegisterClientResult = getOrRegister(
+        RegisterClientParam(
+            password = password,
+            capabilities = capabilities,
+            secondFactorVerificationCode = secondFactorVerificationCode,
+            modelPostfix = if (BuildConfig.PRIVATE_BUILD) " [${BuildConfig.FLAVOR}_${BuildConfig.BUILD_TYPE}]" else null
+        )
+    )
 
     internal suspend fun isInitialSyncCompleted(userId: UserId): Boolean =
         userDataStoreProvider.getOrCreate(userId).initialSyncCompleted.first()

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModel.kt
@@ -27,11 +27,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import com.wire.android.appLogger
 import com.wire.android.datastore.UserDataStoreProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.authentication.toBackendConfigUrl
 import com.wire.android.ui.authentication.login.LoginNavArgs
 import com.wire.android.ui.authentication.login.LoginSavedInputStore
@@ -137,6 +140,7 @@ class LoginEmailViewModel(
     )
 
     private val preFilledUserIdentifier: PreFilledUserIdentifierType = loginNavArgs.userHandle ?: PreFilledUserIdentifierType.None
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     val userIdentifierTextState: TextFieldState = TextFieldState()
     val passwordTextState: TextFieldState = TextFieldState()
@@ -327,9 +331,24 @@ class LoginEmailViewModel(
                 }
             }
 
+            val preparedSessionScope = when (val preparation = userSessionPreparationGate.prepare(storedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    restorePreviousSession()
+                    updateEmailFlowState(
+                        LoginState.Error.DialogError.GenericError(
+                            com.wire.kalium.common.error.CoreFailure.Unknown(
+                                IllegalStateException("User session preparation failed: ${preparation.reason}")
+                            )
+                        )
+                    )
+                    return@launch
+                }
+            }
+
             withContext(dispatchers.io()) {
                 if (coreLogic.getGlobalScope().validateEmailUseCase(userIdentifierTextState.text.toString())) {
-                    coreLogic.getSessionScope(storedUserId).users.persistSelfUserEmail(userIdentifierTextState.text.toString())
+                    preparedSessionScope.users.persistSelfUserEmail(userIdentifierTextState.text.toString())
                 } else {
                     null
                 }
@@ -343,7 +362,7 @@ class LoginEmailViewModel(
 
             withContext(dispatchers.io()) {
                 registerClient(
-                    userId = storedUserId,
+                    sessionScope = preparedSessionScope,
                     password = passwordTextState.text.toString(),
                 )
             }.let {
@@ -370,14 +389,28 @@ class LoginEmailViewModel(
     }
 
     private suspend fun revertNewSession() {
-        loginJobData.value?.newSessionUserId?.let { newSessionUserId ->
-            // logout to cancel all session-related actions, remove all sensitive data and free up resources
-            coreLogic.getSessionScope(newSessionUserId).logout(reason = LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
-            // delete the session to make it seem like the session was never logged in
-            coreLogic.getGlobalScope().deleteSession(newSessionUserId)
+        val jobData = loginJobData.value
+        jobData?.newSessionUserId?.let { newSessionUserId ->
+            when (val preparation = userSessionPreparationGate.prepare(newSessionUserId)) {
+                is AppUserSessionPreparationResult.Ready -> {
+                    // logout to cancel session actions and remove sensitive data before deleting the session
+                    preparation.sessionScope.logout(
+                        reason = LogoutReason.SELF_HARD_LOGOUT,
+                        waitUntilCompletes = true,
+                    )
+                    coreLogic.getGlobalScope().deleteSession(newSessionUserId)
+                }
+
+                is AppUserSessionPreparationResult.Failed -> appLogger.w(
+                    "Login rollback skipped database deletion because session preparation failed: ${preparation.reason}"
+                )
+            }
         }
-        // set the previous session back
-        coreLogic.getGlobalScope().session.updateCurrentSession(loginJobData.value?.previousSessionUserId)
+        restorePreviousSession(jobData)
+    }
+
+    private suspend fun restorePreviousSession(jobData: LoginJobData? = loginJobData.value) {
+        coreLogic.getGlobalScope().session.updateCurrentSession(jobData?.previousSessionUserId)
     }
 
     private suspend fun revertLogin() {

--- a/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtension.kt
@@ -18,6 +18,8 @@
 package com.wire.android.ui.authentication.login.sso
 
 import com.wire.android.appLogger
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
@@ -48,6 +50,7 @@ class LoginSSOViewModelExtension(
     private val coreLogic: CoreLogic,
     private val defaultWebSocketEnabledByDefault: Boolean,
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
     suspend fun withAuthenticationScope(
         serverConfig: ServerConfig.Links,
         onAuthScopeFailure: (AutoVersionAuthScopeUseCase.Result.Failure) -> Unit,
@@ -149,15 +152,27 @@ class LoginSSOViewModelExtension(
         when (authenticatedUserResult) {
             AddAuthenticatedUserUseCase.Result.Failure.SsoIdentityChanged -> onSsoIdentityChanged(session)
             is AddAuthenticatedUserUseCase.Result.Failure -> onAddAuthenticatedUserFailure(authenticatedUserResult)
-            is AddAuthenticatedUserUseCase.Result.Success -> onSuccess(authenticatedUserResult.userId)
+            is AddAuthenticatedUserUseCase.Result.Success ->
+                when (val preparation = userSessionPreparationGate.prepare(authenticatedUserResult.userId)) {
+                    is AppUserSessionPreparationResult.Ready -> onSuccess(authenticatedUserResult.userId)
+                    is AppUserSessionPreparationResult.Failed -> onAddAuthenticatedUserFailure(
+                        AddAuthenticatedUserUseCase.Result.Failure.Generic(preparation.toCoreFailure())
+                    )
+                }
         }
     }
 
-    @Suppress("TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught", "NestedBlockDepth")
     suspend fun replaceRetainedSsoSession(session: StoreSessionParam): ReplaceRetainedSsoSessionResult =
         try {
             val userId = session.accountTokens.userId
-            coreLogic.getSessionScope(userId).logout(
+            val retainedScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> return ReplaceRetainedSsoSessionResult.Failure(
+                    AddAuthenticatedUserUseCase.Result.Failure.Generic(preparation.toCoreFailure())
+                )
+            }
+            retainedScope.logout(
                 reason = LogoutReason.SELF_HARD_LOGOUT,
                 waitUntilCompletes = true
             )
@@ -167,8 +182,16 @@ class LoginSSOViewModelExtension(
                     ReplaceRetainedSsoSessionResult.Failure(
                         AddAuthenticatedUserUseCase.Result.Failure.Generic(deleteResult.cause)
                     )
-                DeleteSessionUseCase.Result.Success ->
-                    addAuthenticatedUser(session, replace = false).toReplaceRetainedSsoSessionResult()
+                DeleteSessionUseCase.Result.Success -> when (val addResult = addAuthenticatedUser(session, replace = false)) {
+                    is AddAuthenticatedUserUseCase.Result.Failure -> ReplaceRetainedSsoSessionResult.Failure(addResult)
+                    is AddAuthenticatedUserUseCase.Result.Success ->
+                        when (val preparation = userSessionPreparationGate.prepare(addResult.userId)) {
+                            is AppUserSessionPreparationResult.Ready -> ReplaceRetainedSsoSessionResult.Success(addResult.userId)
+                            is AppUserSessionPreparationResult.Failed -> ReplaceRetainedSsoSessionResult.Failure(
+                                AddAuthenticatedUserUseCase.Result.Failure.Generic(preparation.toCoreFailure())
+                            )
+                        }
+                }
             }
         } catch (exception: CancellationException) {
             throw exception
@@ -178,6 +201,9 @@ class LoginSSOViewModelExtension(
             )
         }
 }
+
+private fun AppUserSessionPreparationResult.Failed.toCoreFailure(): CoreFailure =
+    CoreFailure.Unknown(IllegalStateException("User session preparation failed: $reason"))
 
 private fun AddAuthenticatedUserUseCase.Result.toReplaceRetainedSsoSessionResult(): ReplaceRetainedSsoSessionResult =
     when (this) {

--- a/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/registration/code/CreateAccountVerificationCodeViewModel.kt
@@ -28,19 +28,22 @@ import androidx.lifecycle.viewModelScope
 import com.ramcosta.composedestinations.generated.app.navArgs
 import com.wire.android.BuildConfig
 import com.wire.android.analytics.RegistrationAnalyticsManagerUseCase
-import com.wire.android.di.ClientScopeProvider
 import com.wire.android.di.DefaultWebSocketEnabledByDefault
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.analytics.model.AnalyticsEvent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.ui.authentication.create.common.CreateAccountDataNavArgs
 import com.wire.android.ui.common.textfield.textAsFlow
 import com.wire.android.util.WillNeverOccurError
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.session.StoreSessionParam
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.autoVersioningAuth.AutoVersionAuthScopeUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.client.RegisterClientParam
 import com.wire.kalium.logic.feature.client.RegisterClientResult
 import com.wire.kalium.logic.feature.register.RegisterParam
@@ -57,7 +60,6 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val addAuthenticatedUser: AddAuthenticatedUserUseCase,
     private val registrationAnalyticsManager: RegistrationAnalyticsManagerUseCase,
-    private val clientScopeProviderFactory: ClientScopeProvider.Factory,
     defaultServerConfig: ServerConfig.Links,
     @DefaultWebSocketEnabledByDefault private val defaultWebSocketEnabledByDefault: Boolean,
 ) : ViewModel() {
@@ -65,6 +67,8 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
     interface Factory {
         fun create(savedStateHandle: SavedStateHandle): CreateAccountVerificationCodeViewModel
     }
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     val createAccountNavArgs: CreateAccountDataNavArgs = savedStateHandle.navArgs()
 
@@ -123,7 +127,7 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
         codeTextState.clearText()
     }
 
-    @Suppress("ComplexMethod")
+    @Suppress("ComplexMethod", "LongMethod")
     private fun onCodeContinue() {
         codeState = codeState.copy(loading = true)
         viewModelScope.launch {
@@ -185,15 +189,27 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
                     is AddAuthenticatedUserUseCase.Result.Success -> it.userId
                 }
             }
-            registerClient(storedUserId, registerParam)
+            val sessionScope = when (val preparation = userSessionPreparationGate.prepare(storedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    updateCodeErrorState(
+                        CreateAccountCodeResult.Error.DialogError.GenericError(
+                            CoreFailure.Unknown(IllegalStateException("User session preparation failed: ${preparation.reason}"))
+                        )
+                    )
+                    return@launch
+                }
+            }
+            registerClient(storedUserId, sessionScope, registerParam)
         }
     }
 
     private suspend fun registerClient(
         storedUserId: UserId,
+        sessionScope: UserSessionScope,
         registerParam: RegisterParam.PersonalAccount
     ) {
-        registerClient(storedUserId, registerParam.password).let {
+        registerClient(sessionScope, registerParam.password).let {
             when (it) {
                 is RegisterClientResult.Failure -> {
                     updateCodeErrorState(it.toCodeError(storedUserId))
@@ -217,8 +233,8 @@ class CreateAccountVerificationCodeViewModel @AssistedInject constructor(
         codeState = codeState.copy(loading = false, result = codeError)
     }
 
-    private suspend fun registerClient(userId: UserId, password: String) =
-        clientScopeProviderFactory.create(userId).clientScope.getOrRegister(
+    private suspend fun registerClient(sessionScope: UserSessionScope, password: String) =
+        sessionScope.client.getOrRegister(
             RegisterClientParam(
                 password = password,
                 capabilities = null,

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/email/LoginEmailViewModelTest.kt
@@ -16,7 +16,7 @@
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
-@file:Suppress("MaxLineLength")
+@file:Suppress("MaxLineLength", "LargeClass")
 
 package com.wire.android.ui.authentication.login.email
 
@@ -44,6 +44,8 @@ import com.wire.android.util.ui.CountdownTimer
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.configuration.server.CommonApiVersionType
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
@@ -69,6 +71,7 @@ import com.wire.kalium.logic.feature.auth.verification.RequestSecondFactorVerifi
 import com.wire.kalium.logic.feature.client.ClientScope
 import com.wire.kalium.logic.feature.client.GetOrRegisterClientUseCase
 import com.wire.kalium.logic.feature.client.RegisterClientResult
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
@@ -625,6 +628,30 @@ class LoginEmailViewModelTest {
     }
 
     @Test
+    fun `given new session preparation fails, when canceling login, then preserve database and restore previous session`() = runTest {
+        val newUserId = UserId("newUserId", "domain")
+        val previousUserId = UserId("previousUserId", "domain")
+        val (arrangement, viewModel) = Arrangement()
+            .withPreparationFailure(UserSessionPreparationFailure.SupportRequired)
+            .withUpdateCurrentSessionReturning(UpdateCurrentSessionUseCase.Result.Success)
+            .arrange()
+        viewModel.loginJobData.value = LoginJobData(
+            job = mockk(relaxUnitFun = true),
+            previousSessionUserId = previousUserId,
+            newSessionUserId = newUserId,
+        )
+
+        viewModel.cancelLogin()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) {
+            arrangement.logoutUseCase(any(), any())
+            arrangement.deleteSessionUseCase(any())
+        }
+        coVerify(exactly = 1) { arrangement.updateCurrentSessionUseCase(previousUserId) }
+    }
+
+    @Test
     fun `given no previous session, when canceling login, then update current session to null`() = runTest {
         // given
         val (arrangement, viewModel) = Arrangement()
@@ -832,6 +859,9 @@ class LoginEmailViewModelTest {
         internal lateinit var coreLogic: CoreLogic
 
         @MockK
+        internal lateinit var userSessionScope: UserSessionScope
+
+        @MockK
         internal lateinit var requestSecondFactorCodeUseCase: RequestSecondFactorVerificationCodeUseCase
 
         @MockK
@@ -862,6 +892,9 @@ class LoginEmailViewModelTest {
             every { qualifiedIdMapper.fromStringToQualifiedID(any()) } returns USER_ID
             every { savedInputStore.userIdentifier = any<String>() } returns Unit
             every { coreLogic.getGlobalScope().validateEmailUseCase } returns validateEmailUseCase
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess(userSessionScope)
+            every { userSessionScope.users } returns userScope
+            every { userSessionScope.client } returns clientScope
             every { coreLogic.getSessionScope(any()).users } returns userScope
             every { userScope.persistSelfUserEmail } returns persistSelfUserEmailUseCase
             every { clientScopeProviderFactory.create(any()).clientScope } returns clientScope
@@ -870,6 +903,7 @@ class LoginEmailViewModelTest {
             every { authenticationScope.login } returns loginUseCase
             every { authenticationScope.requestSecondFactorVerificationCode } returns requestSecondFactorCodeUseCase
             every { coreLogic.versionedAuthenticationScope(any()) } returns autoVersionAuthScopeUseCase
+            every { userSessionScope.logout } returns logoutUseCase
             every { coreLogic.getSessionScope(any()).logout } returns logoutUseCase
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSessionUseCase
             every { coreLogic.getGlobalScope().session.updateCurrentSession } returns updateCurrentSessionUseCase
@@ -877,6 +911,11 @@ class LoginEmailViewModelTest {
             coEvery { currentSessionUseCase() } returns CurrentSessionResult.Success(AccountInfo.Valid(USER_ID))
             coEvery { countdownTimer.start(any(), any(), any()) } returns Unit
         }
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
 
         fun arrange() = this to LoginEmailViewModel(
             LoginNavArgs(loginPasswordPath = LoginPasswordPath(newServerConfig(1).links)),
@@ -937,6 +976,12 @@ class LoginEmailViewModelTest {
             coEvery {
                 currentSessionUseCase()
             } returns result
+        }
+
+        fun withPreparationFailure(reason: UserSessionPreparationFailure) = apply {
+            val result = mockk<PrepareUserSessionResult.Failure>()
+            every { result.reason } returns reason
+            coEvery { coreLogic.prepareUserSession(any()) } returns result
         }
 
         fun withDeleteSessionReturning(result: DeleteSessionUseCase.Result) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtensionTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/authentication/login/sso/LoginSSOViewModelExtensionTest.kt
@@ -21,12 +21,14 @@ package com.wire.android.ui.authentication.login.sso
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountTokens
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.session.StoreSessionParam
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.auth.AddAuthenticatedUserUseCase
 import com.wire.kalium.logic.feature.auth.LogoutUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.DeleteSessionUseCase
 import io.mockk.coEvery
 import io.mockk.coVerifyOrder
@@ -117,8 +119,11 @@ class LoginSSOViewModelExtensionTest {
         val coreLogic = mockk<CoreLogic>()
         val logout = mockk<LogoutUseCase>()
         val deleteSession = mockk<DeleteSessionUseCase>()
+        val userSessionScope = mockk<UserSessionScope>()
 
         init {
+            coEvery { coreLogic.prepareUserSession(userId) } returns preparationSuccess(userSessionScope)
+            every { userSessionScope.logout } returns logout
             every { coreLogic.getSessionScope(userId).logout } returns logout
             every { coreLogic.getGlobalScope().deleteSession } returns deleteSession
             coEvery { logout(LogoutReason.SELF_HARD_LOGOUT, true) } returns Unit
@@ -137,5 +142,10 @@ class LoginSSOViewModelExtensionTest {
         }
 
         fun arrange() = this to LoginSSOViewModelExtension(addAuthenticatedUser, coreLogic, false)
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/newauthentication/login/NewLoginViewModelTest.kt
@@ -840,7 +840,7 @@ class NewLoginViewModelTest {
 
         fun withRegisterClientReturning(result: RegisterClientResult) = apply {
             coEvery {
-                loginViewModelExtension.registerClient(any(), any(), any(), any())
+                loginViewModelExtension.registerClient(any<UserId>(), any(), any(), any())
             } returns result
         }
 


### PR DESCRIPTION
## Goal

Prepare a user session after authentication before login and registration flows access its database.

## Changes

- gate email login, SSO login, registration, and account creation on session preparation
- pass the prepared session scope to downstream authentication work
- surface preparation failures through the existing authentication error paths
- cover the updated login flows with focused tests

## Stack

- Epic branch: `mo/epic/async-db-migration`
- [PR 1](https://github.com/wireapp/wire-android/pull/5158)
- [PR 2](https://github.com/wireapp/wire-android/pull/5159)
- [PR 3](https://github.com/wireapp/wire-android/pull/5160)
- PR 4 of 7

Merge the stack bottom-up into the epic branch.
