### PR TITLE
feat(session): gate background session work PR 6

### DIFF
--- a/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/WireNotificationManager.kt
@@ -25,6 +25,8 @@ import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.media.PingRinger
 import com.wire.android.services.ServicesManager
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.dispatchers.DispatcherProvider
@@ -41,6 +43,7 @@ import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.user.E2EIRequiredResult
+import com.wire.kalium.logic.feature.UserSessionScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -91,6 +94,7 @@ class WireNotificationManager @Inject constructor(
     private val scope = CoroutineScope(SupervisorJob() + dispatcherProvider.default())
     private val fetchOnceMutex = Mutex()
     private val fetchOnceJobs = hashMapOf<UserId, Job>()
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
     private var observingWhileRunningJobs = ObservingJobs()
     private var observingPersistentlyJobs = ObservingJobs()
 
@@ -142,14 +146,25 @@ class WireNotificationManager @Inject constructor(
      * will join the first execution and return together.
      * @param userIdValue String value param of QualifiedID of the User that need to check Notifications for
      */
-    suspend fun fetchAndShowNotificationsOnce(userIdValue: String) {
-        val userId = checkIfUserIsAuthenticated(userIdValue) ?: return
+    @Suppress("ReturnCount")
+    suspend fun fetchAndShowNotificationsOnce(userIdValue: String): FetchNotificationsResult {
+        val userId = checkIfUserIsAuthenticated(userIdValue) ?: return FetchNotificationsResult.Failure
+        when (val preparation = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> Unit
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w(
+                    "$TAG user-session preparation failed for ${userId.toLogString()}: ${preparation.reason}"
+                )
+                return if (preparation.canRetry) FetchNotificationsResult.Retry else FetchNotificationsResult.Failure
+            }
+        }
 
         val syncAndNotificationJobForUser = fetchAndShowMessageNotificationsJob(userId)
 
         // Join the jobs for the user, waiting for its completion
         syncAndNotificationJobForUser?.start()
         syncAndNotificationJobForUser?.join()
+        return FetchNotificationsResult.Success
     }
 
     private suspend fun fetchAndShowMessageNotificationsJob(userId: UserId): Job? =
@@ -406,7 +421,7 @@ class WireNotificationManager @Inject constructor(
     ) {
         appLogger.d("$TAG observe incoming calls")
 
-        coreLogic.getSessionScope(userId).let { userSessionScope ->
+        preparedSessionScope(userId)?.let { userSessionScope ->
             userSessionScope.observeE2EIRequired()
                 .map { it is E2EIRequiredResult.NoGracePeriod }
                 .distinctUntilChanged()
@@ -439,7 +454,8 @@ class WireNotificationManager @Inject constructor(
         userId: UserId,
         currentScreenState: StateFlow<CurrentScreen>
     ) {
-        val selfUserNameState = coreLogic.getSessionScope(userId)
+        val userSessionScope = preparedSessionScope(userId) ?: return
+        val selfUserNameState = userSessionScope
             .users
             .observeSelfUser()
             .onEach { it.logIfEmptyUserName() }
@@ -447,12 +463,12 @@ class WireNotificationManager @Inject constructor(
             .distinctUntilChanged()
             .stateIn(scope)
 
-        val isBlockedByE2EIRequiredState = coreLogic.getSessionScope(userId).observeE2EIRequired()
+        val isBlockedByE2EIRequiredState = userSessionScope.observeE2EIRequired()
             .map { it is E2EIRequiredResult.NoGracePeriod }
             .distinctUntilChanged()
             .stateIn(scope)
 
-        coreLogic.getSessionScope(userId)
+        userSessionScope
             .messages
             .getNotifications()
             .cancellable()
@@ -504,17 +520,19 @@ class WireNotificationManager @Inject constructor(
         coreLogic.getGlobalScope().session.currentSessionFlow()
             .flatMapLatest {
                 if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
-                    val sessionScope = coreLogic.getSessionScope(it.accountInfo.userId)
-                    // wait for the initial cleanup of stale open calls to be completed before starting to observe the calls,
-                    // to avoid starting the service by mistake for the calls that are already stale
-                    sessionScope.calls.observeStaleOpenCallsCleanup()
-                        .dropWhile { completed -> !completed }
-                        .flatMapLatest {
-                            combine(
-                                sessionScope.calls.establishedCall(),
-                                sessionScope.calls.observeOutgoingCall()
-                            ) { establishedCalls, outgoingCalls -> (establishedCalls + outgoingCalls).isNotEmpty() }
-                        }
+                    flowOf(it.accountInfo.userId).flatMapLatest { userId ->
+                        val sessionScope = preparedSessionScope(userId) ?: return@flatMapLatest flowOf(null)
+                        // wait for the initial cleanup of stale open calls to be completed before starting to observe the calls,
+                        // to avoid starting the service by mistake for the calls that are already stale
+                        sessionScope.calls.observeStaleOpenCallsCleanup()
+                            .dropWhile { completed -> !completed }
+                            .flatMapLatest {
+                                combine(
+                                    sessionScope.calls.establishedCall(),
+                                    sessionScope.calls.observeOutgoingCall()
+                                ) { establishedCalls, outgoingCalls -> (establishedCalls + outgoingCalls).isNotEmpty() }
+                            }
+                    }
                 } else {
                     flowOf(null)
                 }
@@ -546,9 +564,9 @@ class WireNotificationManager @Inject constructor(
         val markNotified = conversationId?.let {
             MarkMessagesAsNotifiedUseCase.UpdateTarget.SingleConversation(conversationId, lastNotified)
         } ?: MarkMessagesAsNotifiedUseCase.UpdateTarget.AllConversations
-        coreLogic.getSessionScope(userId)
-            .messages
-            .markMessagesAsNotified(markNotified)
+        preparedSessionScope(userId)
+            ?.messages
+            ?.markMessagesAsNotified(markNotified)
     }
 
     private suspend fun markConnectionAsNotified(
@@ -557,10 +575,25 @@ class WireNotificationManager @Inject constructor(
     ) {
         appLogger.d("$TAG markConnectionAsNotified")
         userId?.let {
-            coreLogic.getSessionScope(it)
-                .conversations
-                .markConnectionRequestAsNotified(connectionRequestUserId)
+            preparedSessionScope(it)
+                ?.conversations
+                ?.markConnectionRequestAsNotified(connectionRequestUserId)
         }
+    }
+
+    private suspend fun preparedSessionScope(userId: UserId): UserSessionScope? =
+        when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("$TAG skipping database work for ${userId.toLogString()}: ${result.reason}")
+                null
+            }
+        }
+
+    sealed interface FetchNotificationsResult {
+        data object Success : FetchNotificationsResult
+        data object Retry : FetchNotificationsResult
+        data object Failure : FetchNotificationsResult
     }
 
     private fun playPingSoundIfNeeded(

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/EndOngoingCallReceiver.kt
@@ -18,63 +18,56 @@
 
 package com.wire.android.notification.broadcastreceivers
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
-import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.di.metro.wireApplicationGraph
-import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
 
-class EndOngoingCallReceiver : BroadcastReceiver() {
+class EndOngoingCallReceiver : CoroutineReceiver() {
 
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
 
     @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    @Inject
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
 
-    @Inject
-    @ApplicationScope
-    lateinit var coroutineScope: CoroutineScope
-
-    override fun onReceive(context: Context, intent: Intent) {
+    override fun onReceive(context: Context, intent: Intent?) {
         context.wireApplicationGraph.inject(this)
+        super.onReceive(context, intent)
+    }
+
+    override suspend fun receive(context: Context, intent: Intent) {
         val conversationId: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: return
         appLogger.i("EndOngoingCallReceiver: onReceive, conversationId: $conversationId")
 
-        coroutineScope.launch {
-            val userId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
-            val sessionScope =
-                if (userId != null) {
-                    coreLogic.getSessionScope(userId)
-                } else {
-                    val currentSession = coreLogic.globalScope { session.currentSession() }
-                    if (currentSession is CurrentSessionResult.Success) {
-                        coreLogic.getSessionScope(currentSession.accountInfo.userId)
-                    } else {
-                        null
-                    }
+        val requestedUserId: QualifiedID? = intent.getStringExtra(EXTRA_RECEIVER_USER_ID)?.toQualifiedID(qualifiedIdMapper)
+        val userId = requestedUserId ?: (coreLogic.globalScope { session.currentSession() } as? CurrentSessionResult.Success)
+            ?.accountInfo
+            ?.userId
+        val sessionScope = userId?.let {
+            when (val preparation = UserSessionPreparationGate(coreLogic).prepare(it)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    appLogger.w("EndOngoingCallReceiver: session preparation failed: ${preparation.reason}")
+                    null
                 }
-
-            sessionScope?.let {
-                it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
             }
+        }
+
+        sessionScope?.let {
+            it.calls.endCall(qualifiedIdMapper.fromStringToQualifiedID(conversationId))
         }
     }
 

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/IncomingCallActionReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/IncomingCallActionReceiver.kt
@@ -18,49 +18,42 @@
 
 package com.wire.android.notification.broadcastreceivers
 
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import com.wire.android.appLogger
-import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.NoSession
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.notification.CallNotificationManager
-import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logger.obfuscateId
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.data.id.toQualifiedID
 import com.wire.kalium.logic.data.user.UserId
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import dev.zacsweers.metro.Inject
 
-class IncomingCallActionReceiver : BroadcastReceiver() {
+class IncomingCallActionReceiver : CoroutineReceiver() {
 
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
 
     @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    @Inject
     @NoSession
     lateinit var qualifiedIdMapper: QualifiedIdMapper
 
     @Inject
-    @ApplicationScope
-    lateinit var coroutineScope: CoroutineScope
-
-    @Inject
     lateinit var callNotificationManager: CallNotificationManager
 
-    @Suppress("ReturnCount")
-    override fun onReceive(context: Context, intent: Intent) {
+    override fun onReceive(context: Context, intent: Intent?) {
         context.wireApplicationGraph.inject(this)
+        super.onReceive(context, intent)
+    }
+
+    @Suppress("ReturnCount")
+    override suspend fun receive(context: Context, intent: Intent) {
         val conversationIdString: String = intent.getStringExtra(EXTRA_CONVERSATION_ID) ?: run {
             appLogger.e("CallNotificationDismissReceiver: onReceive, conversation ID is missing")
             return
@@ -75,15 +68,18 @@ class IncomingCallActionReceiver : BroadcastReceiver() {
             return
         }
 
-        coroutineScope.launch(Dispatchers.Default) {
-            with(coreLogic.getSessionScope(userId)) {
+        when (val preparation = UserSessionPreparationGate(coreLogic).prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> with(preparation.sessionScope) {
                 val conversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationIdString)
                 if (action == ACTION_DECLINE_CALL) {
                     calls.rejectCall(conversationId)
                 }
             }
-            callNotificationManager.hideIncomingCallNotification(userId.toString(), conversationIdString)
+
+            is AppUserSessionPreparationResult.Failed ->
+                appLogger.w("CallNotificationDismissReceiver: session preparation failed: ${preparation.reason}")
         }
+        callNotificationManager.hideIncomingCallNotification(userId.toString(), conversationIdString)
     }
 
     companion object {

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiver.kt
@@ -25,6 +25,8 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.feature.AccountSwitchUseCase
 import com.wire.android.feature.SwitchAccountParam
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.android.util.lifecycle.AppBackgroundManager
 import com.wire.kalium.logic.CoreLogic
@@ -97,7 +99,14 @@ class NomadLogoutReceiver : CoroutineReceiver() {
             is CurrentSessionResult.Success -> {
                 val userId = session.accountInfo.userId
                 appLogger.i("$TAG Logging out user: ${userId.toLogString()}")
-                coreLogic.getSessionScope(userId).logout(LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
+                val sessionScope = when (val preparation = UserSessionPreparationGate(coreLogic).prepare(userId)) {
+                    is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                    is AppUserSessionPreparationResult.Failed -> {
+                        appLogger.e("$TAG session preparation failed: ${preparation.reason}")
+                        return
+                    }
+                }
+                sessionScope.logout(LogoutReason.SELF_HARD_LOGOUT, waitUntilCompletes = true)
                 coreLogic.getGlobalScope().deleteSession(userId)
                 accountSwitch(SwitchAccountParam.TryToSwitchToNextAccount).callAction(switchAccountObserver)
             }

--- a/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
+++ b/app/src/main/kotlin/com/wire/android/notification/broadcastreceivers/NotificationReplyReceiver.kt
@@ -28,7 +28,8 @@ import com.wire.android.di.NoSession
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.notification.MessageNotificationManager
 import com.wire.android.notification.NotificationConstants
-import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.QualifiedID
@@ -41,9 +42,6 @@ class NotificationReplyReceiver : CoroutineReceiver() { // requires zero argumen
     @Inject
     @KaliumCoreLogic
     lateinit var coreLogic: CoreLogic
-
-    @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
 
     @Inject
     @NoSession
@@ -64,7 +62,14 @@ class NotificationReplyReceiver : CoroutineReceiver() { // requires zero argumen
             val qualifiedUserId = qualifiedIdMapper.fromStringToQualifiedID(userId)
             val qualifiedConversationId = qualifiedIdMapper.fromStringToQualifiedID(conversationId)
 
-            with(coreLogic.getSessionScope(qualifiedUserId)) {
+            val sessionScope = when (val preparation = UserSessionPreparationGate(coreLogic).prepare(qualifiedUserId)) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                is AppUserSessionPreparationResult.Failed -> {
+                    updateNotification(context, conversationId, qualifiedUserId, null)
+                    return
+                }
+            }
+            with(sessionScope) {
                 syncExecutor.request {
                     messages.sendTextMessage(qualifiedConversationId, replyText).toEither()
                         .fold(

--- a/app/src/main/kotlin/com/wire/android/services/CallServiceManager.kt
+++ b/app/src/main/kotlin/com/wire/android/services/CallServiceManager.kt
@@ -20,6 +20,8 @@ package com.wire.android.services
 import com.wire.android.appLogger
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.notification.CallNotificationData
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.services.CallService.Action
 import com.wire.android.util.logging.logIfEmptyUserName
 import com.wire.kalium.common.functional.Either
@@ -48,6 +50,7 @@ import dev.zacsweers.metro.Inject
 
 class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: CoreLogic) {
     private val actions = Channel<Action>(capacity = Channel.BUFFERED, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     /** Handles the action by adding it to the channel for processing. */
     internal suspend fun handleAction(action: Action) = actions.send(action)
@@ -97,7 +100,7 @@ class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: Cor
         coreLogic.getGlobalScope().session.currentSessionFlow().firstOrNull().let {
             if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
                 val userId = it.accountInfo.userId
-                val userSessionScope = coreLogic.getSessionScope(userId)
+                val userSessionScope = preparedSessionScope(userId) ?: return@let
                 combine(
                     userSessionScope.calls.observeOutgoingCall(),
                     userSessionScope.calls.establishedCall(),
@@ -124,7 +127,8 @@ class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: Cor
             .flatMapLatest {
                 if (it is CurrentSessionResult.Success && it.accountInfo.isValid()) {
                     val userId = it.accountInfo.userId
-                    val userSessionScope = coreLogic.getSessionScope(userId)
+                    val userSessionScope = preparedSessionScope(userId)
+                        ?: return@flatMapLatest flowOf(Either.Left(StopReason.NO_VALID_CURRENT_SESSION))
                     val userName = userSessionScope.getUserName()
                     combine(
                         userSessionScope.calls.establishedCall().mapToCallNotificationData(userId, userName),
@@ -170,9 +174,18 @@ class CallServiceManager @Inject constructor(@KaliumCoreLogic val coreLogic: Cor
     private suspend fun getValidSessionIfExists(userId: UserId): Either<Unit, UserSessionScope> =
         coreLogic.getGlobalScope().doesValidSessionExist(userId).let { result ->
             if (result is DoesValidSessionExistResult.Success && result.doesValidSessionExist) {
-                coreLogic.getSessionScope(userId).right()
+                preparedSessionScope(userId)?.right() ?: Unit.left()
             } else {
                 Unit.left()
+            }
+        }
+
+    private suspend fun preparedSessionScope(userId: UserId): UserSessionScope? =
+        when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("$TAG: user-session preparation failed for ${userId.toLogString()}: ${result.reason}")
+                null
             }
         }
 

--- a/app/src/main/kotlin/com/wire/android/services/PendingMessagesForegroundService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PendingMessagesForegroundService.kt
@@ -39,6 +39,8 @@ import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.lifecycle.SyncLifecycleManager
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.logout.LogoutReason
@@ -310,13 +312,21 @@ class SendPendingMessagesAfterForegroundSyncUseCase @Inject constructor(
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     private val syncLifecycleManager: SyncLifecycleManager,
 ) {
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
+
     suspend operator fun invoke(userId: UserId) {
+        val userSessionScope = when (val result = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> result.sessionScope
+            is AppUserSessionPreparationResult.Failed -> {
+                appLogger.w("$TAG: user-session preparation failed for ${userId.toLogString()}: ${result.reason}")
+                return
+            }
+        }
         syncLifecycleManager.syncTemporarily(
             userId = userId,
             stayAliveExtraDuration = 3.seconds,
             waitForNextSyncState = true,
         ) {
-            val userSessionScope = coreLogic.getSessionScope(userId)
             appLogger.i(
                 "$TAG: sending pending messages for ${userId.toLogString()}, " +
                         "syncState=${userSessionScope.syncManager.syncState.value}, " +

--- a/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
+++ b/app/src/main/kotlin/com/wire/android/services/PersistentWebSocketService.kt
@@ -38,6 +38,8 @@ import com.wire.android.notification.NotificationConstants.WEB_SOCKET_CHANNEL_NA
 import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.WireNotificationManager
 import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
@@ -69,6 +71,8 @@ class PersistentWebSocketService : Service() {
 
     @Inject
     lateinit var notificationChannelsManager: NotificationChannelsManager
+
+    private val userSessionPreparationGate by lazy { UserSessionPreparationGate(coreLogic) }
 
     override fun onBind(intent: Intent?): IBinder? {
         return null
@@ -120,7 +124,14 @@ class PersistentWebSocketService : Service() {
         coroutineScope {
             usersToObserve.forEach { userId ->
                 launch {
-                    coreLogic.getSessionScope(userId).syncExecutor.request {
+                    val sessionScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+                        is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+                        is AppUserSessionPreparationResult.Failed -> {
+                            appLogger.w("Skipping persistent sync for ${userId.toLogString()}: ${preparation.reason}")
+                            return@launch
+                        }
+                    }
+                    sessionScope.syncExecutor.request {
                         awaitCancellation()
                     }
                 }

--- a/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/WireWorkerFactory.kt
@@ -26,9 +26,11 @@ import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.feature.StartPersistentWebsocketIfNecessaryUseCase
 import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.WireNotificationManager
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.android.sync.InitialSyncWorker
 import com.wire.android.workmanager.worker.DeleteConversationLocallyWorker
 import com.wire.android.workmanager.worker.NotificationFetchWorker
+import com.wire.android.workmanager.worker.NotificationTokenRegistrationWorker
 import com.wire.android.workmanager.worker.PersistentWebsocketCheckWorker
 import com.wire.android.workmanager.worker.AssetUploadObserverWorker
 import com.wire.kalium.logic.CoreLogic
@@ -40,6 +42,7 @@ class WireWorkerFactory @Inject constructor(
     private val wireNotificationManager: WireNotificationManager,
     private val notificationChannelsManager: NotificationChannelsManager,
     private val startPersistentWebsocketIfNecessary: StartPersistentWebsocketIfNecessaryUseCase,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
     @KaliumCoreLogic
     private val coreLogic: CoreLogic
 ) : WorkerFactory() {
@@ -53,6 +56,9 @@ class WireWorkerFactory @Inject constructor(
             NotificationFetchWorker::class.java.canonicalName ->
                 NotificationFetchWorker(appContext, workerParameters, wireNotificationManager, notificationChannelsManager)
 
+            NotificationTokenRegistrationWorker::class.java.canonicalName ->
+                NotificationTokenRegistrationWorker(appContext, workerParameters, coreLogic, userSessionPreparationGate)
+
             PersistentWebsocketCheckWorker::class.java.canonicalName ->
                 PersistentWebsocketCheckWorker(
                     appContext,
@@ -62,10 +68,22 @@ class WireWorkerFactory @Inject constructor(
                 )
 
             DeleteConversationLocallyWorker::class.java.canonicalName ->
-                DeleteConversationLocallyWorker(appContext, workerParameters, coreLogic, notificationChannelsManager)
+                DeleteConversationLocallyWorker(
+                    appContext,
+                    workerParameters,
+                    coreLogic,
+                    notificationChannelsManager,
+                    userSessionPreparationGate,
+                )
 
             AssetUploadObserverWorker::class.java.canonicalName ->
-                AssetUploadObserverWorker(appContext, workerParameters, coreLogic, notificationChannelsManager)
+                AssetUploadObserverWorker(
+                    appContext,
+                    workerParameters,
+                    coreLogic,
+                    notificationChannelsManager,
+                    userSessionPreparationGate,
+                )
 
             InitialSyncWorker::class.java.canonicalName ->
                 InitialSyncWorker(appContext, workerParameters, coreLogic, notificationChannelsManager)

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/AssetUploadObserverWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/AssetUploadObserverWorker.kt
@@ -31,6 +31,8 @@ import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
@@ -51,26 +53,50 @@ class AssetUploadObserverWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val coreLogic: CoreLogic,
     private val notificationChannelsManager: NotificationChannelsManager,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
 
         // Wait until there are no uploads in progress
         // switching to other user will cancel the observer and stop the worker
-        coreLogic.getGlobalScope().session.currentSessionFlow()
-            .filterIsInstance<CurrentSessionResult.Success>()
-            .map { it.accountInfo.userId }
-            .waitForUploadCompletion()
-
-        return Result.success()
+        return when (
+            coreLogic.getGlobalScope().session.currentSessionFlow()
+                .filterIsInstance<CurrentSessionResult.Success>()
+                .map { it.accountInfo.userId }
+                .waitForUploadCompletion()
+        ) {
+            UploadWaitResult.Complete -> Result.success()
+            UploadWaitResult.Retry -> Result.retry()
+            UploadWaitResult.Failure -> Result.failure()
+        }
     }
 
-    private suspend fun Flow<UserId>.waitForUploadCompletion() =
+    private suspend fun Flow<UserId>.waitForUploadCompletion(): UploadWaitResult =
         flatMapLatest { userId ->
-            coreLogic.getSessionScope(userId).messages.observeAssetUploadState()
-        }.first { uploadInProgress ->
-            uploadInProgress == false
-        }
+            when (
+                val preparation = userSessionPreparationGate.prepare(userId)
+            ) {
+                is AppUserSessionPreparationResult.Ready -> preparation.sessionScope.messages.observeAssetUploadState()
+                    .map { uploadInProgress -> UploadState.InProgress(uploadInProgress) }
+                is AppUserSessionPreparationResult.Failed -> kotlinx.coroutines.flow.flowOf(
+                    UploadState.PreparationFailed(preparation.canRetry)
+                )
+            }
+        }.first { state -> state !is UploadState.InProgress || !state.value }
+            .let { state ->
+                when (state) {
+                    is UploadState.InProgress -> UploadWaitResult.Complete
+                    is UploadState.PreparationFailed -> if (state.canRetry) UploadWaitResult.Retry else UploadWaitResult.Failure
+                }
+            }
+
+    private sealed interface UploadState {
+        data class InProgress(val value: Boolean) : UploadState
+        data class PreparationFailed(val canRetry: Boolean) : UploadState
+    }
+
+    private enum class UploadWaitResult { Complete, Retry, Failure }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         notificationChannelsManager.createRegularChannel(

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/DeleteConversationLocallyWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/DeleteConversationLocallyWorker.kt
@@ -35,6 +35,8 @@ import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.NotificationIds
 import com.wire.android.notification.openAppPendingIntent
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
@@ -64,6 +66,7 @@ class DeleteConversationLocallyWorker @AssistedInject constructor(
     @Assisted workerParams: WorkerParameters,
     private val coreLogic: CoreLogic,
     private val notificationChannelsManager: NotificationChannelsManager,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
 ) : CoroutineWorker(appContext, workerParams) {
     override suspend fun doWork(): Result = coroutineScope {
         val userIdString = inputData.getString(USER_ID)
@@ -80,7 +83,12 @@ class DeleteConversationLocallyWorker @AssistedInject constructor(
                 return@coroutineScope Result.failure() // If no valid session exists, fail the work
             }
         }
-        when (coreLogic.getSessionScope(userId).conversations.deleteConversationLocallyUseCase(conversationId)) {
+        val sessionScope = when (val preparation = userSessionPreparationGate.prepare(userId)) {
+            is AppUserSessionPreparationResult.Ready -> preparation.sessionScope
+            is AppUserSessionPreparationResult.Failed ->
+                return@coroutineScope if (preparation.canRetry) Result.retry() else Result.failure()
+        }
+        when (sessionScope.conversations.deleteConversationLocallyUseCase(conversationId)) {
             is ClearConversationContentUseCase.Result.Failure -> Result.retry()
             ClearConversationContentUseCase.Result.Success -> Result.success()
         }

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationFetchWorker.kt
@@ -44,11 +44,12 @@ class NotificationFetchWorker
     }
 
     override suspend fun doWork(): Result {
-        inputData.getString(USER_ID_INPUT_DATA)?.let { userId ->
-            wireNotificationManager.fetchAndShowNotificationsOnce(userId)
+        val userId = inputData.getString(USER_ID_INPUT_DATA) ?: return Result.failure()
+        return when (wireNotificationManager.fetchAndShowNotificationsOnce(userId)) {
+            WireNotificationManager.FetchNotificationsResult.Success -> Result.success()
+            WireNotificationManager.FetchNotificationsResult.Retry -> Result.retry()
+            WireNotificationManager.FetchNotificationsResult.Failure -> Result.failure()
         }
-
-        return Result.success()
     }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {

--- a/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationTokenRegistrationWorker.kt
+++ b/app/src/main/kotlin/com/wire/android/workmanager/worker/NotificationTokenRegistrationWorker.kt
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.workmanager.worker
+
+import android.content.Context
+import androidx.work.Constraints
+import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.wire.android.appLogger
+import com.wire.android.session.AppUserSessionPreparationResult
+import com.wire.android.session.UserSessionPreparationGate
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.session.GetAllSessionsResult
+
+class NotificationTokenRegistrationWorker(
+    appContext: Context,
+    workerParameters: WorkerParameters,
+    private val coreLogic: CoreLogic,
+    private val userSessionPreparationGate: UserSessionPreparationGate,
+) : CoroutineWorker(appContext, workerParameters) {
+
+    @Suppress("ReturnCount")
+    override suspend fun doWork(): Result {
+        val token = inputData.getString(INPUT_TOKEN) ?: return Result.failure()
+        val senderId = inputData.getString(INPUT_SENDER_ID) ?: return Result.failure()
+        val sessions = when (val result = coreLogic.globalScope { getSessions() }) {
+            is GetAllSessionsResult.Success -> result.sessions
+            GetAllSessionsResult.Failure.NoSessionFound -> emptyList()
+            is GetAllSessionsResult.Failure.Generic -> {
+                appLogger.w("$TAG unable to read sessions: ${result.genericFailure}")
+                return Result.retry()
+            }
+        }
+
+        val preparationFailures = sessions.filter { it.isValid() }.mapNotNull { session ->
+            when (val preparation = userSessionPreparationGate.prepare(session.userId)) {
+                is AppUserSessionPreparationResult.Ready -> null
+                is AppUserSessionPreparationResult.Failed -> preparation
+            }
+        }
+        if (preparationFailures.any { it.canRetry }) return Result.retry()
+        if (preparationFailures.isNotEmpty()) return Result.failure()
+
+        return when (val result = coreLogic.globalScope { saveNotificationToken(token, TRANSPORT, senderId) }) {
+            com.wire.kalium.logic.feature.notificationToken.Result.Success -> Result.success()
+            is com.wire.kalium.logic.feature.notificationToken.Result.Failure.Generic -> {
+                appLogger.w("$TAG token registration failed: ${result.failure}")
+                Result.retry()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "NotificationTokenRegistrationWorker"
+        private const val WORK_NAME = "notification_token_registration"
+        private const val INPUT_TOKEN = "token"
+        private const val INPUT_SENDER_ID = "sender_id"
+        private const val TRANSPORT = "GCM"
+
+        fun enqueue(workManager: WorkManager, token: String, senderId: String) {
+            val request = OneTimeWorkRequestBuilder<NotificationTokenRegistrationWorker>()
+                .setConstraints(Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build())
+                .setInputData(workDataOf(INPUT_TOKEN to token, INPUT_SENDER_ID to senderId))
+                .build()
+            workManager.enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, request)
+        }
+    }
+}

--- a/app/src/nonfree/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
+++ b/app/src/nonfree/kotlin/com/wire/android/services/WireFirebaseMessagingService.kt
@@ -29,42 +29,21 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.wire.android.BuildConfig
 import com.wire.android.appLogger
-import com.wire.android.di.KaliumCoreLogic
 import com.wire.android.di.metro.wireApplicationGraph
 import com.wire.android.util.NetworkUtil
-import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.workmanager.worker.NotificationFetchWorker
-import com.wire.kalium.logic.CoreLogic
-import com.wire.kalium.logic.feature.notificationToken.Result
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
+import com.wire.android.workmanager.worker.NotificationTokenRegistrationWorker
 import java.util.Locale
 import dev.zacsweers.metro.Inject
 
 class WireFirebaseMessagingService : FirebaseMessagingService() {
 
     @Inject
-    @KaliumCoreLogic
-    lateinit var coreLogic: CoreLogic
-
-    @Inject
     lateinit var networkUtil: NetworkUtil
-
-    @Inject
-    lateinit var dispatcherProvider: DispatcherProvider
-
-    private val scope by lazy {
-        // There's no UI, no need to run anything using the Main/UI Dispatcher
-        CoroutineScope(SupervisorJob() + dispatcherProvider.default())
-    }
 
     override fun onCreate() {
         val graph = wireApplicationGraph
-        coreLogic = graph.coreLogic
         networkUtil = graph.networkUtil
-        dispatcherProvider = graph.dispatcherProvider
         super.onCreate()
     }
 
@@ -127,24 +106,11 @@ class WireFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         super.onNewToken(token)
-        scope.launch {
-            coreLogic.globalScope {
-                saveNotificationToken(token, "GCM", BuildConfig.FIREBASE_PUSH_SENDER_ID)
-            }.let { result ->
-                when (result) {
-                    is Result.Failure.Generic ->
-                        appLogger.e("$TAG: token registration has an issue : ${result.failure} ")
-                    Result.Success ->
-                        appLogger.i("$TAG: token registered successfully")
-                }
-            }
-        }
-    }
-
-    override fun onDestroy() {
-        scope.cancel()
-        appLogger.i("$TAG: onDestroy")
-        super.onDestroy()
+        NotificationTokenRegistrationWorker.enqueue(
+            WorkManager.getInstance(applicationContext),
+            token,
+            BuildConfig.FIREBASE_PUSH_SENDER_ID,
+        )
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/WireNotificationManagerTest.kt
@@ -29,6 +29,8 @@ import com.wire.android.util.lifecycle.SyncLifecycleManager
 import com.wire.android.util.newServerConfig
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.GlobalKaliumScope
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.configuration.server.ServerConfig
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.call.Call
@@ -69,6 +71,7 @@ import io.mockk.MockKMatcherScope
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
@@ -130,6 +133,24 @@ class WireNotificationManagerTest {
             advanceUntilIdle()
 
             coVerify(exactly = 1) { arrangement.syncLifecycleManager.syncTemporarily(TEST_AUTH_TOKEN.userId, any()) }
+            coVerifyOrder {
+                arrangement.coreLogic.prepareUserSession(TEST_AUTH_TOKEN.userId)
+                arrangement.syncLifecycleManager.syncTemporarily(TEST_AUTH_TOKEN.userId, any())
+            }
+        }
+
+    @Test
+    fun givenBackgroundFirstOpenIsTemporarilyUnavailable_whenFetchingNotifications_thenWorkerCanRetry() =
+        runTest(dispatcherProvider.main()) {
+            val (arrangement, manager) = Arrangement()
+                .withSession(GetAllSessionsResult.Success(listOf(TEST_AUTH_TOKEN)))
+                .withPreparationFailure(UserSessionPreparationFailure.TemporarilyUnavailable)
+                .arrange()
+
+            val result = manager.fetchAndShowNotificationsOnce(TEST_AUTH_TOKEN.userId.value)
+
+            assertEquals(WireNotificationManager.FetchNotificationsResult.Retry, result)
+            coVerify(exactly = 0) { arrangement.syncLifecycleManager.syncTemporarily(any(), any()) }
         }
 
     @Test
@@ -1229,6 +1250,7 @@ class WireNotificationManagerTest {
             coEvery { syncManager.waitUntilLive() } returns Unit
             coEvery { globalKaliumScope.getSessions } returns getSessionsUseCase
             coEvery { coreLogic.getSessionScope(any()) } returns userSessionScope
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess(userSessionScope)
             coEvery { coreLogic.getGlobalScope() } returns globalKaliumScope
             coEvery { messageNotificationManager.handleNotification(any(), any(), any()) } returns Unit
             coEvery { callsScope.getIncomingCalls } returns getIncomingCallsUseCase
@@ -1261,7 +1283,7 @@ class WireNotificationManagerTest {
             selfUser: SelfUser = TestUser.SELF_USER,
             userId: MockKMatcherScope.() -> UserId
         ) {
-            coEvery { coreLogic.getSessionScope(userId()) } returns mockk {
+            val specificSessionScope = mockk<UserSessionScope> {
                 coEvery { syncManager } returns this@Arrangement.syncManager
                 coEvery { conversations } returns mockk {
                     coEvery { markConnectionRequestAsNotified } returns this@Arrangement.markConnectionRequestAsNotified
@@ -1281,11 +1303,24 @@ class WireNotificationManagerTest {
                 }
                 coEvery { observeE2EIRequired } returns this@Arrangement.observeE2EIRequired
             }
+            coEvery { coreLogic.getSessionScope(userId()) } returns specificSessionScope
+            coEvery { coreLogic.prepareUserSession(userId()) } returns preparationSuccess(specificSessionScope)
         }
+
+        private fun preparationSuccess(scope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns scope
+            }
 
         fun withSession(session: GetAllSessionsResult): Arrangement {
             coEvery { getSessionsUseCase() } returns session
             return this
+        }
+
+        fun withPreparationFailure(reason: UserSessionPreparationFailure): Arrangement = apply {
+            val result = mockk<PrepareUserSessionResult.Failure>()
+            every { result.reason } returns reason
+            coEvery { coreLogic.prepareUserSession(any()) } returns result
         }
 
         suspend fun withCurrentUserSession(session: CurrentSessionResult): Arrangement {

--- a/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
+++ b/app/src/test/kotlin/com/wire/android/notification/broadcastreceivers/NomadLogoutReceiverTest.kt
@@ -26,6 +26,7 @@ import com.wire.android.feature.SwitchAccountParam
 import com.wire.android.feature.SwitchAccountResult
 import com.wire.android.util.SwitchAccountObserver
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.logout.LogoutReason
 import com.wire.kalium.logic.data.user.UserId
@@ -63,7 +64,7 @@ class NomadLogoutReceiverTest {
         val intent = mockk<Intent> { every { action } returns NomadLogoutReceiver.ACTION_LOGOUT }
         arrangement.receiver.receive(arrangement.context, intent)
 
-        verify(exactly = 1) { arrangement.coreLogic.getSessionScope(userId) }
+        coVerify(exactly = 1) { arrangement.coreLogic.prepareUserSession(userId) }
         coVerifyOrder {
             arrangement.currentSession()
             arrangement.logoutUseCase(LogoutReason.SELF_HARD_LOGOUT, true)
@@ -89,8 +90,10 @@ class NomadLogoutReceiverTest {
             arrangement.deleteSession(any())
             arrangement.accountSwitch(any())
         }
+        coVerify(exactly = 0) {
+            arrangement.coreLogic.prepareUserSession(any())
+        }
         verify(exactly = 0) {
-            arrangement.coreLogic.getSessionScope(any())
             arrangement.context.startActivity(any())
         }
     }
@@ -106,7 +109,7 @@ class NomadLogoutReceiverTest {
         advanceUntilIdle()
 
         coVerify(exactly = 1) { arrangement.currentSession() }
-        verify(exactly = 0) { arrangement.coreLogic.getSessionScope(any()) }
+        coVerify(exactly = 0) { arrangement.coreLogic.prepareUserSession(any()) }
         coVerify(exactly = 0) {
             arrangement.logoutUseCase(any(), any())
             arrangement.deleteSession(any())
@@ -181,7 +184,7 @@ class NomadLogoutReceiverTest {
             every { coreLogic.getGlobalScope().isCurrentSessionNomadAccount } returns isCurrentSessionNomadAccount
             coEvery { isCurrentSessionNomadAccount() } returns true
             coEvery { accountSwitch(any()) } returns SwitchAccountResult.NoOtherAccountToSwitch
-            every { coreLogic.getSessionScope(any()) } returns userSessionScope
+            coEvery { coreLogic.prepareUserSession(any()) } returns preparationSuccess()
             every { nomadProfilesFeatureConfig.isEnabled() } returns true
         }
 
@@ -205,5 +208,10 @@ class NomadLogoutReceiverTest {
         fun withCurrentSessionNomadAccount(isNomad: Boolean) = apply {
             coEvery { isCurrentSessionNomadAccount() } returns isNomad
         }
+
+        private fun preparationSuccess(): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns userSessionScope
+            }
     }
 }

--- a/app/src/test/kotlin/com/wire/android/services/CallServiceManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/services/CallServiceManagerTest.kt
@@ -24,6 +24,7 @@ import com.wire.android.framework.TestUser
 import com.wire.android.notification.CallNotificationData
 import com.wire.kalium.common.functional.Either
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
@@ -33,11 +34,13 @@ import com.wire.kalium.logic.data.user.SelfUser
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.AnswerCallUseCase
 import com.wire.kalium.logic.feature.call.usecase.EndCallUseCase
+import com.wire.kalium.logic.feature.UserSessionScope
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
 import com.wire.kalium.logic.feature.session.DoesValidSessionExistResult
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import kotlinx.coroutines.flow.Flow
@@ -320,14 +323,21 @@ class CallServiceManagerTest {
             outgoing: Flow<List<Call>> = flowOf(emptyList()),
             established: Flow<List<Call>> = flowOf(emptyList()),
         ) = apply {
+            val sessionScope = mockk<UserSessionScope>(relaxed = true)
             withValidSessionExists(selfUser.id, DoesValidSessionExistResult.Success(true))
-            coEvery { coreLogic.getSessionScope(selfUser.id).users.observeSelfUser() } returns flowOf(selfUser)
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.getIncomingCalls() } returns incoming
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.observeOutgoingCall() } returns outgoing
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.establishedCall() } returns established
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.answerCall } returns answerCallForUser(selfUser.id)
-            coEvery { coreLogic.getSessionScope(selfUser.id).calls.endCall } returns endCallForUser(selfUser.id)
+            coEvery { coreLogic.prepareUserSession(selfUser.id) } returns preparationSuccess(sessionScope)
+            coEvery { sessionScope.users.observeSelfUser() } returns flowOf(selfUser)
+            coEvery { sessionScope.calls.getIncomingCalls() } returns incoming
+            coEvery { sessionScope.calls.observeOutgoingCall() } returns outgoing
+            coEvery { sessionScope.calls.establishedCall() } returns established
+            coEvery { sessionScope.calls.answerCall } returns answerCallForUser(selfUser.id)
+            coEvery { sessionScope.calls.endCall } returns endCallForUser(selfUser.id)
         }
+
+        private fun preparationSuccess(sessionScope: UserSessionScope): PrepareUserSessionResult.Success =
+            mockk<PrepareUserSessionResult.Success>().also { result ->
+                every { result.sessionScope } returns sessionScope
+            }
     }
 
     companion object {

--- a/features/sync/src/main/kotlin/com/wire/android/sync/InitialSyncWorker.kt
+++ b/features/sync/src/main/kotlin/com/wire/android/sync/InitialSyncWorker.kt
@@ -80,7 +80,7 @@ class InitialSyncWorker @AssistedInject constructor(
                                 null
                             }
 
-                            is PrepareUserSessionResult.Failure -> preparation.reason
+                            is PrepareUserSessionResult.Failure -> preparation.failure
                         }
                     }
                 }.awaitAll().filterNotNull()

--- a/features/sync/src/main/kotlin/com/wire/android/sync/InitialSyncWorker.kt
+++ b/features/sync/src/main/kotlin/com/wire/android/sync/InitialSyncWorker.kt
@@ -30,15 +30,18 @@ import com.wire.android.notification.NotificationChannelsManager
 import com.wire.android.notification.NotificationConstants
 import com.wire.android.notification.NotificationIds
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
+import com.wire.kalium.logic.UserSessionPreparationFailure
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.work.Work
 import com.wire.kalium.work.WorkId
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.takeWhile
-import kotlinx.coroutines.launch
 import com.wire.android.feature.notification.R as NR
 
 class InitialSyncWorker @AssistedInject constructor(
@@ -62,23 +65,34 @@ class InitialSyncWorker @AssistedInject constructor(
             Log.e("InitialSyncWorker", "Failure to get active sessions. Not waiting for Sync.")
             Result.failure()
         } else {
-            coroutineScope {
-                result.sessions.forEach { session ->
-                    launch {
-                        coreLogic.sessionScope(session.userId) {
-                            syncExecutor.request {
-                                Log.i("InitialSyncWorker", "Waiting for Initial Sync for user '${session.userId}' to finish.")
-                                longWork.observeWorkStatus(workId).takeWhile {
-                                    it !is Work.Status.Complete
-                                }.collect()
-                                Log.i("InitialSyncWorker", "Initial Sync for user '${session.userId}' complete.")
+            val preparationFailures = coroutineScope {
+                result.sessions.map { session ->
+                    async {
+                        when (val preparation = coreLogic.prepareUserSession(session.userId)) {
+                            is PrepareUserSessionResult.Success -> {
+                                preparation.sessionScope.syncExecutor.request {
+                                    Log.i("InitialSyncWorker", "Waiting for Initial Sync for user '${session.userId}' to finish.")
+                                    preparation.sessionScope.longWork.observeWorkStatus(workId).takeWhile {
+                                        it !is Work.Status.Complete
+                                    }.collect()
+                                    Log.i("InitialSyncWorker", "Initial Sync for user '${session.userId}' complete.")
+                                }
+                                null
                             }
+
+                            is PrepareUserSessionResult.Failure -> preparation.reason
                         }
                     }
+                }.awaitAll().filterNotNull()
+            }
+            when {
+                preparationFailures.any { it.isRetryable() } -> Result.retry()
+                preparationFailures.isNotEmpty() -> Result.failure()
+                else -> {
+                    Log.i("InitialSyncWorker", "Initial Sync complete for all users")
+                    Result.success()
                 }
             }
-            Log.i("InitialSyncWorker", "Initial Sync complete for all users")
-            Result.success()
         }
     }
 
@@ -110,3 +124,7 @@ class InitialSyncWorker @AssistedInject constructor(
             .build()
     }
 }
+
+private fun UserSessionPreparationFailure.isRetryable(): Boolean =
+    this is UserSessionPreparationFailure.InsufficientStorage ||
+            this is UserSessionPreparationFailure.TemporarilyUnavailable

--- a/features/sync/src/main/kotlin/com/wire/android/sync/MonitorSyncWorkUseCase.kt
+++ b/features/sync/src/main/kotlin/com/wire/android/sync/MonitorSyncWorkUseCase.kt
@@ -24,6 +24,7 @@ import androidx.work.WorkManager
 import com.wire.android.di.KaliumCoreLogic
 import com.wire.kalium.common.logger.kaliumLogger
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.PrepareUserSessionResult
 import com.wire.kalium.logic.feature.session.GetAllSessionsResult
 import com.wire.kalium.logic.feature.session.ObserveSessionsUseCase
 import com.wire.kalium.work.Work
@@ -51,8 +52,11 @@ class MonitorSyncWorkUseCase @Inject constructor(
      */
     suspend operator fun invoke() {
         allSessionsUseCase().filterIsInstance<GetAllSessionsResult.Success>().map { result ->
-            result.sessions.map { session ->
-                coreLogic.sessionScope(session.userId) { longWork }
+            result.sessions.mapNotNull { session ->
+                when (val preparation = coreLogic.prepareUserSession(session.userId)) {
+                    is PrepareUserSessionResult.Success -> preparation.sessionScope.longWork
+                    is PrepareUserSessionResult.Failure -> null
+                }
             }
         }.flatMapLatest { scopes ->
             scopes.map { scope ->


### PR DESCRIPTION
## Goal

Apply the same session preparation boundary to background entry points before they access user data.

## Changes

- gate notifications, receivers, services, workers, FCM, and sync entry points
- move push token registration into prepared-session worker execution
- skip or retry background work when preparation cannot complete safely
- cover notification, logout, and call service behavior with focused tests

## Stack

- Epic branch: `mo/epic/async-db-migration`
- [PR 1](https://github.com/wireapp/wire-android/pull/5158)
- [PR 2](https://github.com/wireapp/wire-android/pull/5159)
- [PR 3](https://github.com/wireapp/wire-android/pull/5160)
- [PR 4](https://github.com/wireapp/wire-android/pull/5161)
- [PR 5](https://github.com/wireapp/wire-android/pull/5162)
- PR 6 of 7

Merge the stack bottom-up into the epic branch.
