### PR TITLE
feat: disable end date input, prevent setting end to the next day [WPB-27039]

### DIFF
--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingScreen.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingScreen.kt
@@ -231,6 +231,7 @@ fun NewMeetingContent(
                         label = stringResource(R.string.new_meeting_ends_input_label),
                         datePlaceholder = stringResource(R.string.new_meeting_end_date_input_placeholder),
                         timePlaceholder = stringResource(R.string.new_meeting_end_time_input_placeholder),
+                        dateInputDisabled = true,
                     )
                     VerticalSpace.x8()
                     RepeatingIntervalDropDown(
@@ -420,6 +421,7 @@ private fun TimeInput(
     label: String,
     datePlaceholder: String,
     timePlaceholder: String,
+    dateInputDisabled: Boolean = false,
 ) {
     val dateTextFieldState = rememberTextFieldState(DateAndTimeParsers.meetingDate(time))
     val timeTextFieldState = rememberTextFieldState(DateAndTimeParsers.meetingTime(time))
@@ -441,7 +443,12 @@ private fun TimeInput(
                 placeholderText = datePlaceholder,
                 labelText = label.uppercase(),
                 keyboardOptions = KeyboardOptions.DefaultEmailDone,
-                state = if (timeError != null) WireTextFieldState.Error() else WireTextFieldState.Default,
+                state = when {
+                    dateInputDisabled -> WireTextFieldState.Disabled
+                    timeError != null -> WireTextFieldState.Error()
+                    else -> WireTextFieldState.Default
+                },
+                enabled = !dateInputDisabled,
                 readOnly = true,
                 shape = RoundedCornerShape(
                     topStart = dimensions().textFieldCornerSize,
@@ -451,7 +458,7 @@ private fun TimeInput(
                 ),
                 onTap = {
                     datePickerDialogState.show(Unit)
-                },
+                }.takeUnless { dateInputDisabled },
                 trailingIcon = {
                     Icon(
                         painter = painterResource(commonR.drawable.ic_calendar),

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingViewModel.kt
@@ -173,9 +173,11 @@ class NewMeetingViewModelImpl @AssistedInject constructor(
 
     override fun updateStartTime(startTime: Instant) {
         val currentDuration = state.endTime - state.startTime
+        val latestEndTime = startTime.latestEndTimeOnSameDay()
         state = state.copy(
             startTime = startTime,
-            endTime = startTime.plus(currentDuration) // adjust end time based on the new start time but keep the same duration
+            // adjust end time based on the new start time but try to keep the same duration, unless it extends into the next day
+            endTime = minOf(startTime.plus(currentDuration), latestEndTime)
         )
         validateStartAndEndTime()
     }
@@ -299,6 +301,21 @@ internal fun getNextFullHour(now: Instant, timeZone: TimeZone = TimeZone.current
         dayOfMonth = localFuture.dayOfMonth,
         hour = localFuture.hour,
         minute = 0,
+        second = 0,
+        nanosecond = 0
+    ).toInstant(timeZone)
+}
+
+// Find the latest possible end time on the same day as the given Instant, in the given time zone.
+// The latest possible end time is 23:59:00 on the same day in the given time zone.
+private fun Instant.latestEndTimeOnSameDay(timeZone: TimeZone = TimeZone.currentSystemDefault()): Instant {
+    val localStartTime = toLocalDateTime(timeZone)
+    return LocalDateTime(
+        year = localStartTime.year,
+        monthNumber = localStartTime.monthNumber,
+        dayOfMonth = localStartTime.dayOfMonth,
+        hour = 23,
+        minute = 59,
         second = 0,
         nanosecond = 0
     ).toInstant(timeZone)

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/create/NewMeetingViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/create/NewMeetingViewModelTest.kt
@@ -62,6 +62,9 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -184,6 +187,33 @@ class NewMeetingViewModelTest {
 
         assertEquals(NewMeetingState.TimeError.StartTimeInPastError, viewModel.state.startTimeError)
         assertFalse(viewModel.state.continueButtonEnabled)
+    }
+
+    @Test
+    fun givenStartTimeChanges_whenEndTimeFitsSameDay_thenEndTimeKeepsCurrentDuration() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T12:00:00Z")
+        val newStartTime = currentTime + 3.hours
+        val (_, viewModel) = arrangeViewModel(Arrangement(dispatcher).withCurrentTimeProvider { currentTime })
+
+        viewModel.updateStartTime(newStartTime)
+
+        assertEquals(newStartTime, viewModel.state.startTime)
+        assertEquals(newStartTime + 1.hours, viewModel.state.endTime)
+    }
+
+    @Test
+    fun givenStartTimeChanges_whenEndTimeWouldMoveToNextDay_thenEndTimeIsCappedAt2359() = runTest(dispatcher) {
+        val timeZone = TimeZone.currentSystemDefault()
+        val currentTime = LocalDateTime(2026, 1, 1, 12, 0).toInstant(timeZone)
+        val newStartTime = LocalDateTime(2026, 1, 1, 23, 30).toInstant(timeZone)
+        val latestEndTime = LocalDateTime(2026, 1, 1, 23, 59).toInstant(timeZone)
+        val (_, viewModel) = arrangeViewModel(Arrangement(dispatcher).withCurrentTimeProvider { currentTime })
+
+        viewModel.updateStartTime(newStartTime)
+
+        assertEquals(newStartTime, viewModel.state.startTime)
+        assertEquals(latestEndTime, viewModel.state.endTime)
+        assertNull(viewModel.state.endTimeError)
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-27039
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

For the release of M1, we will only allow meetings within the start date. So we need to disabled the end-date field.
In this PR, end date input is disabled, it always uses the same value as start date and user cannot click it and choose different end date. Also, adjusting end time after selecting start time is limited so that it doesn't go beyond the current day.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Schedule a meeting and try to select some start and end dates to confirm that it always stays within the same day.

### Attachments (Optional)

https://github.com/user-attachments/assets/1640c164-5238-4c86-b6e4-48d5cd06483c

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
