### PR TITLE
fix: starting conversation with user without clients (WPB-18997)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
+++ b/app/src/main/kotlin/com/wire/android/di/accountScoped/ConversationModule.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.conversation.ResetMLSConversationUseCase
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.conversation.AddMemberToConversationUseCase
 import com.wire.kalium.logic.feature.conversation.AddServiceToConversationUseCase
+import com.wire.kalium.logic.feature.conversation.CheckOneToOneConversationIsReadyUseCase
 import com.wire.kalium.logic.feature.conversation.ClearConversationContentUseCase
 import com.wire.kalium.logic.feature.conversation.ClearUsersTypingEventsUseCase
 import com.wire.kalium.logic.feature.conversation.ConversationScope
@@ -309,6 +310,11 @@ class ConversationModule {
     @Provides
     fun provideIsOneToOneConversationCreatedUseCase(conversationScope: ConversationScope): IsOneToOneConversationCreatedUseCase =
         conversationScope.isOneToOneConversationCreatedUseCase
+
+    @Provides
+    fun provideCheckOneToOneConversationIsReadyUseCase(
+        conversationScope: ConversationScope
+    ): CheckOneToOneConversationIsReadyUseCase = conversationScope.checkOneToOneConversationIsReadyUseCase
 
     @Provides
     fun provideGetConversationProtocolInfoUseCase(conversationScope: ConversationScope): GetConversationProtocolInfoUseCase =

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -41,7 +41,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
-import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
+import com.wire.kalium.logic.feature.conversation.CheckOneToOneConversationIsReadyUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
@@ -74,7 +74,7 @@ class OtherUserProfileScreenViewModel @AssistedInject constructor(
     private val observeClientList: ObserveClientsByUserIdUseCase,
     private val fetchUsersClients: FetchUsersClientsFromRemoteUseCase,
     private val getUserE2eiCertificateStatus: IsOtherUserE2EIVerifiedUseCase,
-    private val isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase,
+    private val checkOneToOneConversationIsReady: CheckOneToOneConversationIsReadyUseCase,
     private val mlsClientIdentity: GetMLSClientIdentityUseCase,
     private val isE2EIEnabled: IsE2EIEnabledUseCase,
     @Assisted savedStateHandle: SavedStateHandle
@@ -104,8 +104,13 @@ class OtherUserProfileScreenViewModel @AssistedInject constructor(
     }
     private fun getIfConversationExist() {
         viewModelScope.launch {
-            val isOneToOneConversationCreated = isOneToOneConversationCreated(userId)
-            state = state.copy(isConversationStarted = isOneToOneConversationCreated)
+            val readiness = checkOneToOneConversationIsReady(userId)
+            if (readiness is CheckOneToOneConversationIsReadyUseCase.Result.Failure) {
+                appLogger.w("Failed to check one-to-one conversation readiness: ${readiness.coreFailure}")
+            }
+            state = state.copy(
+                isConversationStarted = readiness is CheckOneToOneConversationIsReadyUseCase.Result.Ready
+            )
         }
     }
     private fun getMLSVerificationStatus() {

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModel.kt
@@ -39,7 +39,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
-import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
+import com.wire.kalium.logic.feature.conversation.CheckOneToOneConversationIsReadyUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
@@ -75,7 +75,7 @@ class OtherUserProfileScreenViewModel @AssistedInject constructor(
     private val observeClientList: ObserveClientsByUserIdUseCase,
     private val fetchUsersClients: FetchUsersClientsFromRemoteUseCase,
     private val getUserE2eiCertificateStatus: IsOtherUserE2EIVerifiedUseCase,
-    private val isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase,
+    private val checkOneToOneConversationIsReady: CheckOneToOneConversationIsReadyUseCase,
     private val mlsClientIdentity: GetMLSClientIdentityUseCase,
     private val isE2EIEnabled: IsE2EIEnabledUseCase,
     @Assisted navigationArgs: OtherUserProfileViewModelArgs,
@@ -109,8 +109,13 @@ class OtherUserProfileScreenViewModel @AssistedInject constructor(
     }
     private fun getIfConversationExist() {
         viewModelScope.launch {
-            val isOneToOneConversationCreated = isOneToOneConversationCreated(userId)
-            state = state.copy(isConversationStarted = isOneToOneConversationCreated)
+            val readiness = checkOneToOneConversationIsReady(userId)
+            if (readiness is CheckOneToOneConversationIsReadyUseCase.Result.Failure) {
+                appLogger.w("Failed to check one-to-one conversation readiness: ${readiness.coreFailure}")
+            }
+            state = state.copy(
+                isConversationStarted = readiness is CheckOneToOneConversationIsReadyUseCase.Result.Ready
+            )
         }
     }
     private fun getMLSVerificationStatus() {

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -23,6 +23,7 @@ import com.wire.android.assertIs
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.config.NavigationTestExtension
 import com.wire.android.ui.home.conversations.details.participants.usecase.ConversationRoleData
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.ConversationDetails
@@ -37,6 +38,7 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.data.user.type.UserTypeInfo
+import com.wire.kalium.logic.feature.conversation.CheckOneToOneConversationIsReadyUseCase
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
@@ -89,6 +91,35 @@ class OtherUserProfileScreenViewModelTest {
             arrangement.observeConversationRoleForUserUseCase(any(), any())
         }
         assertEquals(groupState, null)
+    }
+
+    @Test
+    fun `given one-to-one conversation is ready, when loading profile, then conversation is started`() = runTest {
+        val (_, viewModel) = OtherUserProfileViewModelArrangement()
+            .withConversationReadiness(CheckOneToOneConversationIsReadyUseCase.Result.Ready(CONVERSATION))
+            .arrange()
+
+        assertEquals(true, viewModel.state.isConversationStarted)
+    }
+
+    @Test
+    fun `given one-to-one conversation is not ready, when loading profile, then conversation is not started`() = runTest {
+        val (_, viewModel) = OtherUserProfileViewModelArrangement()
+            .withConversationReadiness(CheckOneToOneConversationIsReadyUseCase.Result.NotReady)
+            .arrange()
+
+        assertEquals(false, viewModel.state.isConversationStarted)
+    }
+
+    @Test
+    fun `given one-to-one readiness check fails, when loading profile, then conversation is not started`() = runTest {
+        val (_, viewModel) = OtherUserProfileViewModelArrangement()
+            .withConversationReadiness(
+                CheckOneToOneConversationIsReadyUseCase.Result.Failure(CoreFailure.Unknown(null))
+            )
+            .arrange()
+
+        assertEquals(false, viewModel.state.isConversationStarted)
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreenViewModelTest.kt
@@ -22,6 +22,7 @@ import app.cash.turbine.test
 import com.wire.android.assertIs
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.ui.home.conversations.details.participants.usecase.ConversationRoleData
+import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.Conversation.Member
 import com.wire.kalium.logic.data.conversation.ConversationDetails
@@ -36,6 +37,7 @@ import com.wire.kalium.logic.data.user.UserAvailabilityStatus
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.data.user.type.UserTypeInfo
+import com.wire.kalium.logic.feature.conversation.CheckOneToOneConversationIsReadyUseCase
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationDetailsUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.user.GetUserInfoResult
@@ -87,6 +89,35 @@ class OtherUserProfileScreenViewModelTest {
             arrangement.observeConversationRoleForUserUseCase(any(), any())
         }
         assertEquals(groupState, null)
+    }
+
+    @Test
+    fun `given one-to-one conversation is ready, when loading profile, then conversation is started`() = runTest {
+        val (_, viewModel) = OtherUserProfileViewModelArrangement()
+            .withConversationReadiness(CheckOneToOneConversationIsReadyUseCase.Result.Ready(CONVERSATION))
+            .arrange()
+
+        assertEquals(true, viewModel.state.isConversationStarted)
+    }
+
+    @Test
+    fun `given one-to-one conversation is not ready, when loading profile, then conversation is not started`() = runTest {
+        val (_, viewModel) = OtherUserProfileViewModelArrangement()
+            .withConversationReadiness(CheckOneToOneConversationIsReadyUseCase.Result.NotReady)
+            .arrange()
+
+        assertEquals(false, viewModel.state.isConversationStarted)
+    }
+
+    @Test
+    fun `given one-to-one readiness check fails, when loading profile, then conversation is not started`() = runTest {
+        val (_, viewModel) = OtherUserProfileViewModelArrangement()
+            .withConversationReadiness(
+                CheckOneToOneConversationIsReadyUseCase.Result.Failure(CoreFailure.Unknown(null))
+            )
+            .arrange()
+
+        assertEquals(false, viewModel.state.isConversationStarted)
     }
 
     @Test

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -31,8 +31,8 @@ import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModelTest
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
+import com.wire.kalium.logic.feature.conversation.CheckOneToOneConversationIsReadyUseCase
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationDetailsUseCase
-import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
@@ -86,7 +86,7 @@ internal class OtherUserProfileViewModelArrangement {
     lateinit var getUserE2eiCertificateStatus: IsOtherUserE2EIVerifiedUseCase
 
     @MockK
-    lateinit var isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase
+    lateinit var checkOneToOneConversationIsReady: CheckOneToOneConversationIsReadyUseCase
 
     @MockK
     lateinit var mlsClientIdentity: GetMLSClientIdentityUseCase
@@ -108,7 +108,7 @@ internal class OtherUserProfileViewModelArrangement {
             observeClientList,
             fetchUsersClientsFromRemote,
             getUserE2eiCertificateStatus,
-            isOneToOneConversationCreated,
+            checkOneToOneConversationIsReady,
             mlsClientIdentity,
             isE2EIEnabled,
             savedStateHandle,
@@ -140,7 +140,9 @@ internal class OtherUserProfileViewModelArrangement {
         )
         coEvery { getUserE2eiCertificateStatus.invoke(any()) } returns true
         coEvery { mlsClientIdentity.invoke(any()) } returns GetMLSClientIdentityResult.Success(mlsIdentity)
-        coEvery { isOneToOneConversationCreated.invoke(any()) } returns true
+        coEvery { checkOneToOneConversationIsReady.invoke(any()) } returns CheckOneToOneConversationIsReadyUseCase.Result.Ready(
+            OtherUserProfileScreenViewModelTest.CONVERSATION
+        )
         coEvery { isE2EIEnabled.invoke() } returns true
     }
 
@@ -161,6 +163,10 @@ internal class OtherUserProfileViewModelArrangement {
 
     suspend fun withUserInfo(result: GetUserInfoResult) = apply {
         coEvery { observeUserInfo(any()) } returns flowOf(result)
+    }
+
+    fun withConversationReadiness(result: CheckOneToOneConversationIsReadyUseCase.Result) = apply {
+        coEvery { checkOneToOneConversationIsReady(any()) } returns result
     }
 
     fun arrange() = this to viewModel

--- a/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileViewModelArrangement.kt
@@ -30,8 +30,8 @@ import com.wire.android.ui.userprofile.other.OtherUserProfileScreenViewModelTest
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.feature.client.FetchUsersClientsFromRemoteUseCase
 import com.wire.kalium.logic.feature.client.ObserveClientsByUserIdUseCase
+import com.wire.kalium.logic.feature.conversation.CheckOneToOneConversationIsReadyUseCase
 import com.wire.kalium.logic.feature.conversation.GetOneToOneConversationDetailsUseCase
-import com.wire.kalium.logic.feature.conversation.IsOneToOneConversationCreatedUseCase
 import com.wire.kalium.logic.feature.conversation.RemoveMemberFromConversationUseCase
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleResult
 import com.wire.kalium.logic.feature.conversation.UpdateConversationMemberRoleUseCase
@@ -82,7 +82,7 @@ internal class OtherUserProfileViewModelArrangement {
     lateinit var getUserE2eiCertificateStatus: IsOtherUserE2EIVerifiedUseCase
 
     @MockK
-    lateinit var isOneToOneConversationCreated: IsOneToOneConversationCreatedUseCase
+    lateinit var checkOneToOneConversationIsReady: CheckOneToOneConversationIsReadyUseCase
 
     @MockK
     lateinit var mlsClientIdentity: GetMLSClientIdentityUseCase
@@ -109,7 +109,7 @@ internal class OtherUserProfileViewModelArrangement {
             observeClientList,
             fetchUsersClientsFromRemote,
             getUserE2eiCertificateStatus,
-            isOneToOneConversationCreated,
+            checkOneToOneConversationIsReady,
             mlsClientIdentity,
             isE2EIEnabled,
             navigationArgs,
@@ -136,7 +136,9 @@ internal class OtherUserProfileViewModelArrangement {
         )
         coEvery { getUserE2eiCertificateStatus.invoke(any()) } returns true
         coEvery { mlsClientIdentity.invoke(any()) } returns GetMLSClientIdentityResult.Success(mlsIdentity)
-        coEvery { isOneToOneConversationCreated.invoke(any()) } returns true
+        coEvery { checkOneToOneConversationIsReady.invoke(any()) } returns CheckOneToOneConversationIsReadyUseCase.Result.Ready(
+            OtherUserProfileScreenViewModelTest.CONVERSATION
+        )
         coEvery { isE2EIEnabled.invoke() } returns true
     }
 
@@ -157,6 +159,10 @@ internal class OtherUserProfileViewModelArrangement {
 
     suspend fun withUserInfo(result: GetUserInfoResult) = apply {
         coEvery { observeUserInfo(any()) } returns flowOf(result)
+    }
+
+    fun withConversationReadiness(result: CheckOneToOneConversationIsReadyUseCase.Result) = apply {
+        coEvery { checkOneToOneConversationIsReady(any()) } returns result
     }
 
     fun arrange() = this to viewModel


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-18997
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-18997
----

# What's new in this PR?

### Issues
Android client allows creating 1:1 conversation with the user without clients (e.g. never logged in wire app).

### Solutions
Using new use case introduced in https://github.com/wireapp/kalium/pull/4404 to resolve one-on-one conversations correctly.
