### PR TITLE
fix: replace backup restore cancel button with loading indicator [WPB-19677]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogFlow.kt
@@ -73,8 +73,7 @@ fun RestoreBackupDialogFlow(
                 RestoreBackupStep(
                     backUpAndRestoreState = backUpAndRestoreState,
                     restoreDialogStateHolder = restoreDialogStateHolder,
-                    onOpenConversations = onOpenConversations,
-                    onCancelBackupRestore = onCancelBackupRestore
+                    onOpenConversations = onOpenConversations
                 )
             }
 
@@ -168,8 +167,7 @@ fun EnterPasswordStep(
 fun RestoreBackupStep(
     backUpAndRestoreState: BackupAndRestoreState,
     restoreDialogStateHolder: RestoreDialogStateHolder,
-    onOpenConversations: () -> Unit,
-    onCancelBackupRestore: () -> Unit
+    onOpenConversations: () -> Unit
 ) {
     with(restoreDialogStateHolder) {
         LaunchedEffect(backUpAndRestoreState.backupRestoreProgress) {
@@ -196,8 +194,7 @@ fun RestoreBackupStep(
         RestoreProgressDialog(
             isRestoreCompleted = isRestoreCompleted,
             restoreProgress = restoreProgress,
-            onOpenConversation = onOpenConversations,
-            onCancelBackupRestore = onCancelBackupRestore
+            onOpenConversation = onOpenConversations
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -35,6 +35,7 @@ import com.wire.android.ui.common.WireCheckIcon
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
+import com.wire.android.ui.common.button.IconAlignment
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.progress.WireLinearProgressIndicator
 import com.wire.android.ui.common.spacers.VerticalSpace
@@ -124,7 +125,6 @@ fun RestoreProgressDialog(
     isRestoreCompleted: Boolean,
     restoreProgress: Float,
     onOpenConversation: () -> Unit,
-    onCancelBackupRestore: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val progress by animateFloatAsState(targetValue = restoreProgress)
@@ -135,12 +135,12 @@ fun RestoreProgressDialog(
             // User is not able to dismiss the dialog
         },
         optionButton1Properties = WireDialogButtonProperties(
-            onClick = {
-                if (isRestoreCompleted) onOpenConversation() else onCancelBackupRestore()
-            },
-            text = if (isRestoreCompleted) stringResource(R.string.label_ok) else stringResource(id = R.string.label_cancel),
+            onClick = onOpenConversation,
+            text = if (isRestoreCompleted) stringResource(R.string.label_ok) else "",
             type = WireDialogButtonType.Primary,
-            state = if (isRestoreCompleted) WireButtonState.Default else WireButtonState.Disabled
+            state = if (isRestoreCompleted) WireButtonState.Default else WireButtonState.Disabled,
+            loading = !isRestoreCompleted,
+            loadingIndicatorAlignment = IconAlignment.Center
         ),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
@@ -171,7 +171,6 @@ fun PreviewRestoreProgressDialog() = WireTheme {
     RestoreProgressDialog(
         isRestoreCompleted = false,
         restoreProgress = 0.5f,
-        onOpenConversation = {},
-        onCancelBackupRestore = {},
+        onOpenConversation = {}
     )
 }

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -9878,24 +9878,22 @@ public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackup
     - onChooseFilePermissionPermanentlyDenied: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackupStep(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, restoreDialogStateHolder: com.wire.android.ui.home.settings.backup.dialog.restore.RestoreDialogStateHolder, onOpenConversations: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackupStep(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, restoreDialogStateHolder: com.wire.android.ui.home.settings.backup.dialog.restore.RestoreDialogStateHolder, onOpenConversations: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - backUpAndRestoreState: UNSTABLE (has mutable properties or unstable members)
     - restoreDialogStateHolder: STABLE (marked @Stable or @Immutable)
     - onOpenConversations: STABLE (function type)
-    - onCancelBackupRestore: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreProgressDialog(isRestoreCompleted: kotlin.Boolean, restoreProgress: kotlin.Float, onOpenConversation: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreProgressDialog(isRestoreCompleted: kotlin.Boolean, restoreProgress: kotlin.Float, onOpenConversation: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - isRestoreCompleted: STABLE (primitive type)
     - restoreProgress: STABLE (primitive type)
     - onOpenConversation: STABLE (function type)
-    - onCancelBackupRestore: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
@@ -12038,4 +12036,3 @@ public fun com.wire.android.util.ui.WireScrollableThemePreview(content: @[Compos
   restartable: true
   params:
     - content: STABLE (composable function type)
-

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/WireDialog.kt
@@ -50,16 +50,17 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.wire.android.ui.common.button.IconAlignment
 import com.wire.android.ui.common.button.WireButtonState
 import com.wire.android.ui.common.button.WirePrimaryButton
 import com.wire.android.ui.common.button.WireSecondaryButton
-import com.wire.android.util.CustomTabsHelper
 import com.wire.android.ui.common.button.WireTertiaryButton
 import com.wire.android.ui.common.progress.WireCircularProgressIndicator
 import com.wire.android.ui.theme.isTablet
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
+import com.wire.android.util.CustomTabsHelper
 
 @Stable
 @Composable
@@ -287,13 +288,34 @@ private fun WireDialogButtonProperties?.getButton(modifier: Modifier = Modifier)
         Box(modifier = modifier) {
             when (type) {
                 WireDialogButtonType.Primary ->
-                    WirePrimaryButton(onClick = onClick, text = text, state = state, loading = loading, description = description)
+                    WirePrimaryButton(
+                        onClick = onClick,
+                        text = text,
+                        state = state,
+                        loading = loading,
+                        trailingIconAlignment = loadingIndicatorAlignment,
+                        description = description
+                    )
 
                 WireDialogButtonType.Secondary ->
-                    WireSecondaryButton(onClick = onClick, text = text, state = state, loading = loading, description = description)
+                    WireSecondaryButton(
+                        onClick = onClick,
+                        text = text,
+                        state = state,
+                        loading = loading,
+                        trailingIconAlignment = loadingIndicatorAlignment,
+                        description = description
+                    )
 
                 WireDialogButtonType.Tertiary ->
-                    WireTertiaryButton(onClick = onClick, text = text, state = state, loading = loading, description = description)
+                    WireTertiaryButton(
+                        onClick = onClick,
+                        text = text,
+                        state = state,
+                        loading = loading,
+                        trailingIconAlignment = loadingIndicatorAlignment,
+                        description = description
+                    )
             }
         }
     }
@@ -307,6 +329,7 @@ data class WireDialogButtonProperties(
     val state: WireButtonState = WireButtonState.Default,
     val type: WireDialogButtonType = WireDialogButtonType.Secondary,
     val loading: Boolean = false,
+    val loadingIndicatorAlignment: IconAlignment = IconAlignment.Border,
     val description: String? = null
 )
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-19677
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

During backup restoration, the dialog displayed a disabled **Cancel** button. Tapping it had no effect because cancelling an ongoing restore is intentionally not supported.

### Solutions

- Replace the disabled **Cancel** label with a centered circular loading indicator.
- Keep the restore dialog non-dismissible while restoration is in progress.
- Display the **OK** button after the restore completes.
- Add configurable loading-indicator alignment to `WireDialogButtonProperties`.
