### PR TITLE
fix: recover from expired session network state [WPB-24698]

### DIFF
--- a/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/common/topappbar/CommonTopAppBarViewModelTest.kt
@@ -24,6 +24,7 @@ import com.wire.android.assertions.shouldHaveSize
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
+import com.wire.kalium.common.error.NetworkFailure
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.GlobalKaliumScope
 import com.wire.kalium.logic.data.auth.AccountInfo
@@ -55,6 +56,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.time.Duration
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
@@ -259,6 +261,35 @@ class CommonTopAppBarViewModelTest {
         val state = commonTopAppBarViewModel.state
 
         state.connectivityState shouldBeInstanceOf ConnectivityUIState.None::class
+    }
+
+    @Test
+    fun givenFailedSync_whenCurrentSessionExpires_thenWaitingConnectionIsCleared() = runTest {
+        val currentSessionFlow = MutableStateFlow<CurrentSessionResult>(
+            CurrentSessionResult.Success(AccountInfo.Valid(userId))
+        )
+        val (_, commonTopAppBarViewModel) = Arrangement()
+            .withCurrentSessionFlow(currentSessionFlow)
+            .withoutOngoingCall()
+            .withoutOutgoingCall()
+            .withoutIncomingCall()
+            .withCurrentScreen(CurrentScreen.Home)
+            .withSyncState(
+                SyncState.Failed(
+                    NetworkFailure.ServerMiscommunication(RuntimeException("refresh failed")),
+                    Duration.ZERO
+                )
+            )
+            .arrange()
+
+        advanceUntilIdle()
+        val connectivityState = commonTopAppBarViewModel.state.connectivityState
+        connectivityState shouldBeInstanceOf ConnectivityUIState.WaitingConnection::class
+
+        currentSessionFlow.value = CurrentSessionResult.Failure.SessionNotFound
+        advanceUntilIdle()
+
+        commonTopAppBarViewModel.state.connectivityState shouldBeInstanceOf ConnectivityUIState.None::class
     }
 
     @Test
@@ -475,6 +506,10 @@ class CommonTopAppBarViewModelTest {
                     AccountInfo.Valid(userId)
                 )
             )
+        }
+
+        fun withCurrentSessionFlow(currentSessionFlow: Flow<CurrentSessionResult>) = apply {
+            every { coreLogic.globalScope { session.currentSessionFlow() } } returns currentSessionFlow
         }
 
         fun withCurrentScreen(currentScreen: CurrentScreen) = apply {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-24698
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

After the current session expires, the application can retain a failed synchronization state and continue displaying the “Waiting for network” banner.

The underlying failure is an invalid session, not a connectivity problem.

### Solution

- Update the Kalium submodule to include terminal handling of expired-session token refresh failures.
- Add an application regression test verifying that the connectivity banner is cleared when the current session changes to `SessionNotFound`.
