### PR TITLE
fix: design adjustment for link previews in bubbles (WPB-8645)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/messages/item/MessageContentAndStatus.kt
@@ -228,6 +228,11 @@ private fun MessageContent(
                         preview = preview,
                         isAvailable = !message.isPending && message.isAvailable,
                         messageStyle = messageStyle,
+                        modifier = Modifier.padding(
+                            start = dimensions().spacing10x,
+                            end = dimensions().spacing10x,
+                            top = dimensions().spacing10x
+                        ),
                         onClick = { onLinkClick(preview.url) }
                     )
                 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/LinkPreviewCard.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/LinkPreviewCard.kt
@@ -20,15 +20,18 @@ package com.wire.android.ui.home.messagecomposer
 
 import android.annotation.SuppressLint
 import android.net.Uri
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
@@ -36,6 +39,7 @@ import com.wire.android.ui.common.colorsScheme
 import com.wire.android.ui.common.dimensions
 import com.wire.android.ui.common.image.WireImage
 import com.wire.android.ui.home.conversations.messages.item.MessageStyle
+import com.wire.android.ui.home.conversations.messages.item.surface
 import com.wire.android.ui.theme.Accent
 import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireColorScheme
@@ -49,12 +53,15 @@ fun LinkPreviewCard(
     preview: MessageLinkPreview,
     isAvailable: Boolean = true,
     messageStyle: MessageStyle = MessageStyle.NORMAL,
+    modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
 ) {
     val color = linkPreviewTextColor(messageStyle, isAvailable)
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
+            .clip(RoundedCornerShape(dimensions().messageAttachmentCornerSize))
+            .background(messageStyle.surface())
             .combinedClickable(
                 enabled = onClick != null,
                 onClick = { onClick?.invoke() }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/LinkPreviewCard.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/LinkPreviewCard.kt
@@ -60,7 +60,7 @@ fun LinkPreviewCard(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(dimensions().messageAttachmentCornerSize))
+            .clip(RoundedCornerShape(dimensions().corner10x))
             .background(messageStyle.surface())
             .combinedClickable(
                 enabled = onClick != null,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/LinkPreviewCard.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/LinkPreviewCard.kt
@@ -51,9 +51,9 @@ import com.wire.kalium.logic.data.message.linkpreview.MessageLinkPreview
 @Composable
 fun LinkPreviewCard(
     preview: MessageLinkPreview,
+    modifier: Modifier = Modifier,
     isAvailable: Boolean = true,
     messageStyle: MessageStyle = MessageStyle.NORMAL,
-    modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
 ) {
     val color = linkPreviewTextColor(messageStyle, isAvailable)

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -8523,13 +8523,14 @@ private fun com.wire.android.ui.home.messagecomposer.KeyboardRichTextOption(inde
     - content: STABLE (composable function type)
 
 @Composable
-public fun com.wire.android.ui.home.messagecomposer.LinkPreviewCard(preview: com.wire.kalium.logic.data.message.linkpreview.MessageLinkPreview, isAvailable: kotlin.Boolean, messageStyle: com.wire.android.ui.home.conversations.messages.item.MessageStyle, onClick: kotlin.Function0<kotlin.Unit>?): kotlin.Unit
+public fun com.wire.android.ui.home.messagecomposer.LinkPreviewCard(preview: com.wire.kalium.logic.data.message.linkpreview.MessageLinkPreview, isAvailable: kotlin.Boolean, messageStyle: com.wire.android.ui.home.conversations.messages.item.MessageStyle, modifier: androidx.compose.ui.Modifier, onClick: kotlin.Function0<kotlin.Unit>?): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - preview: UNSTABLE (has mutable properties or unstable members)
     - isAvailable: STABLE (primitive type)
     - messageStyle: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
     - onClick: STABLE (function type)
 
 @Composable
@@ -12055,3 +12056,4 @@ public fun com.wire.android.util.ui.WireScrollableThemePreview(content: @[Compos
   restartable: true
   params:
     - content: STABLE (composable function type)
+


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

- Apply and fix design adjustement for link previews

### Attachments (Optional)

**Before**

<img width="400" alt="28168" src="https://github.com/user-attachments/assets/55d930f7-13b5-4c1f-af88-a0b67f65d02b" />

**After**

https://github.com/user-attachments/assets/6a58478a-7cd4-4ccb-9444-d355883d77fa

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
