### PR TITLE
fix: disable pending message retry on app open

### DIFF
--- a/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
+++ b/app/src/main/kotlin/com/wire/android/GlobalObserversManager.kt
@@ -85,10 +85,6 @@ class GlobalObserversManager @Inject constructor(
         }
         scope.handleLogouts()
         scope.handleDeleteEphemeralMessageEndDate()
-
-        if (kaliumConfigs.pendingMessages) {
-            scope.retryPendingMessagesOnAppOpen()
-        }
     }
 
     private suspend fun setUpNotifications() {

--- a/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/GlobalObserversManagerTest.kt
@@ -171,7 +171,7 @@ class GlobalObserversManagerTest {
     }
 
     @Test
-    fun `given app visible and valid session, when app opens, then retry sending pending messages`() {
+    fun `given app visible and valid session, when app opens, then do not retry sending pending messages`() {
         val (arrangement, manager) = Arrangement()
             .withCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
             .withAppVisibleFlow(true)
@@ -179,7 +179,7 @@ class GlobalObserversManagerTest {
 
         manager.observe()
 
-        coVerify(exactly = 1) { arrangement.sendPendingMessagesAfterForegroundSync(TestUser.SELF_USER.id) }
+        coVerify(exactly = 0) { arrangement.sendPendingMessagesAfterForegroundSync(any()) }
     }
 
     @Test
@@ -257,7 +257,7 @@ class GlobalObserversManagerTest {
     }
 
     @Test
-    fun `given valid session when app becomes visible then retry sending pending messages`() {
+    fun `given valid session when app becomes visible then do not retry sending pending messages`() {
         val appVisibleFlow = MutableStateFlow(false)
         val (arrangement, manager) = Arrangement()
             .withCurrentSession(CurrentSessionResult.Success(AccountInfo.Valid(TestUser.SELF_USER.id)))
@@ -269,7 +269,7 @@ class GlobalObserversManagerTest {
 
         appVisibleFlow.value = true
 
-        coVerify(exactly = 1) { arrangement.sendPendingMessagesAfterForegroundSync(TestUser.SELF_USER.id) }
+        coVerify(exactly = 0) { arrangement.sendPendingMessagesAfterForegroundSync(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Prevent the foreground pending-message replay introduced in 4.32 from crashing the app when a persisted pending row contains content that cannot be encoded.

## Reproduction

1. Have a pending message whose persisted content is not valid for outbound protobuf encoding.
2. Bring the app to the foreground.
3. The global observer retries pending messages after sync and the mapper exception escapes the coroutine.

## Change

- Stop registering the app-open pending-message retry observer.
- Update observer tests to assert foreground transitions do not trigger pending-message replay.
- Keep existing explicit and manual resend paths unchanged.

A follow-up will harden pending-message encoding and re-enable the foreground trigger safely.