### PR TITLE
refactor(content): add common asset models

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -213,6 +213,7 @@ dependencies {
     implementationWithCoverage(projects.core.di)
     implementationWithCoverage(projects.core.media)
     implementationWithCoverage(projects.core.mediaPlayer)
+    implementation(projects.core.contentKmp)
     implementationWithCoverage(projects.core.notification)
     implementationWithCoverage(projects.core.navigation)
     implementationWithCoverage(projects.core.search)

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
-import java.io.File
+import okio.Path
 import dev.zacsweers.metro.Inject
 class RecordAudioMessagePlayer @Inject constructor(
     private val context: Context,
@@ -40,7 +40,7 @@ class RecordAudioMessagePlayer @Inject constructor(
     private val audioFocusHelper: AudioFocusHelper,
     @ApplicationScope private val scope: CoroutineScope
 ) {
-    private var currentAudioFile: File? = null
+    private var currentAudioFile: Path? = null
     private var audioState: AudioState = AudioState.DEFAULT
 
     init {
@@ -123,7 +123,7 @@ class RecordAudioMessagePlayer @Inject constructor(
         }
 
     suspend fun playAudio(
-        audioFile: File
+        audioFile: Path
     ) {
         if (currentAudioFile != null && audioFile.name == currentAudioFile?.name) {
             resumeOrPauseAudio()
@@ -160,14 +160,14 @@ class RecordAudioMessagePlayer @Inject constructor(
     }
 
     private suspend fun playAudioMessage(
-        audioFile: File,
+        audioFile: Path,
         position: Int
     ) {
         currentAudioFile = audioFile
 
         audioMediaPlayer.setDataSource(
             context,
-            audioFile.toUri()
+            audioFile.toFile().toUri()
         )
         audioFocusHelper.request()
         audioMediaPlayer.prepare()

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationNavArgs.kt
@@ -20,6 +20,8 @@ package com.wire.android.ui.home.conversations
 import android.os.Parcel
 import android.os.Parcelable
 import com.wire.android.ui.home.conversations.model.AssetBundle
+import com.wire.android.ui.home.conversations.model.PreparedAssetParceler
+import com.wire.content.asset.PreparedAsset
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.id.QualifiedID
 import kotlinx.parcelize.Parceler
@@ -28,6 +30,7 @@ import kotlinx.parcelize.TypeParceler
 
 @Parcelize
 @TypeParceler<ConversationId, QualifiedIdParceler>()
+@TypeParceler<PreparedAsset, PreparedAssetParceler>()
 data class ConversationNavArgs(
     val conversationId: ConversationId,
     val searchedMessageId: String? = null,

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationScreen.kt
@@ -85,6 +85,7 @@ import com.wire.android.ui.home.conversations.model.ExpirationStatus
 import com.wire.android.ui.home.conversations.model.MessageSenderId
 import com.wire.android.ui.home.conversations.model.UIMessage
 import com.wire.android.ui.home.conversations.model.UriAsset
+import com.wire.android.ui.home.conversations.model.uri
 import com.wire.android.ui.home.conversations.selfdeletion.SelfDeletionOptionsModalSheetLayout
 import com.wire.android.ui.home.conversations.sendmessage.SendMessageViewModel
 import com.wire.android.ui.home.gallery.MediaGalleryActionType

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModel.kt
@@ -37,6 +37,7 @@ import com.wire.android.ui.sharing.ImportedMediaAsset
 import com.wire.android.util.FileManager
 import com.wire.android.util.GetMediaMetadataUseCase
 import com.wire.android.util.getAudioLengthInMs
+import com.wire.content.asset.AssetFileNamePolicy
 import com.wire.kalium.cells.domain.CellUploadEvent
 import com.wire.kalium.cells.domain.CellUploadManager
 import com.wire.kalium.cells.domain.model.AttachmentDraft
@@ -47,6 +48,7 @@ import com.wire.kalium.cells.domain.usecase.RemoveAttachmentDraftUseCase
 import com.wire.kalium.cells.domain.usecase.RetryAttachmentUploadUseCase
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.util.fileExtension
@@ -61,7 +63,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okio.Path.Companion.toPath
-import java.io.File
 import com.wire.android.di.metro.WireAssistedViewModelBinding
 import com.wire.android.ui.home.conversations.ConversationCoreManualViewModelFactoryGroup
 
@@ -77,6 +78,7 @@ class MessageAttachmentsViewModel @AssistedInject constructor(
     private val fileManager: FileManager,
     private val sharedState: MessageSharedState,
     private val getMediaMetadata: GetMediaMetadataUseCase,
+    private val kaliumFileSystem: KaliumFileSystem,
     @Assisted navigationArgs: ConversationNavArgs,
 ) : ViewModel() {
 
@@ -152,7 +154,7 @@ class MessageAttachmentsViewModel @AssistedInject constructor(
     }
 
     private fun enqueueOrAddAttachment(bundle: AssetBundle) {
-        if (bundle.fileName.hasIncompatibleFileNameCharacters()) {
+        if (!AssetFileNamePolicy.isCompatible(bundle.fileName)) {
             pendingIncompatibleBundles.addLast(bundle)
             if (incompatibleFileNameDialogState is IncompatibleFileNameDialogState.Hidden) {
                 showNextIncompatibleDialog()
@@ -165,7 +167,7 @@ class MessageAttachmentsViewModel @AssistedInject constructor(
     private fun showNextIncompatibleDialog() {
         val next = pendingIncompatibleBundles.firstOrNull() ?: return
         incompatibleFileNameDialogState = IncompatibleFileNameDialogState.Visible(
-            sanitizedFileName = next.fileName.sanitizeIncompatibleFileNameCharacters(),
+            sanitizedFileName = AssetFileNamePolicy.sanitize(next.fileName),
         )
     }
 
@@ -209,7 +211,7 @@ class MessageAttachmentsViewModel @AssistedInject constructor(
         if (attachment.uploadError) {
             failedAttachmentDialogState = FailedAttachmentDialogState.Visible(
                 attachment = attachment,
-                showRetryOption = File(attachment.localFilePath).exists(),
+                showRetryOption = kaliumFileSystem.exists(attachment.localFilePath.toPath()),
             )
         } else {
             deleteAttachment(attachment)
@@ -270,7 +272,7 @@ class MessageAttachmentsViewModel @AssistedInject constructor(
         if (attachment.uploadError) {
             failedAttachmentDialogState = FailedAttachmentDialogState.Visible(
                 attachment = attachment,
-                showRetryOption = File(attachment.localFilePath).exists(),
+                showRetryOption = kaliumFileSystem.exists(attachment.localFilePath.toPath()),
             )
         } else {
             showAttachment(attachment)
@@ -320,13 +322,3 @@ sealed interface IncompatibleFileNameDialogState {
     data object Hidden : IncompatibleFileNameDialogState
     data class Visible(val sanitizedFileName: String) : IncompatibleFileNameDialogState
 }
-
-private fun String.hasIncompatibleFileNameCharacters(): Boolean =
-    this == "." || startsWith(".") || contains("/") || contains("\\") || contains("\"")
-
-private fun String.sanitizeIncompatibleFileNameCharacters(): String =
-    trimStart('.')
-        .replace("/", "_")
-        .replace("\\", "_")
-        .replace("\"", "_")
-        .ifEmpty { "file" }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewNavArgs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/media/preview/ImagesPreviewNavArgs.kt
@@ -20,8 +20,11 @@ package com.wire.android.ui.home.conversations.media.preview
 import android.net.Uri
 import android.os.Parcelable
 import com.wire.android.ui.home.conversations.model.AssetBundle
+import com.wire.android.ui.home.conversations.model.PreparedAssetParceler
+import com.wire.content.asset.PreparedAsset
 import com.wire.kalium.logic.data.id.ConversationId
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 
 data class ImagesPreviewNavArgs(
     val conversationId: ConversationId,
@@ -30,4 +33,5 @@ data class ImagesPreviewNavArgs(
 )
 
 @Parcelize
+@TypeParceler<PreparedAsset, PreparedAssetParceler>()
 data class ImagesPreviewNavBackArgs(val pendingBundles: List<AssetBundle>) : Parcelable

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/AssetBundle.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/AssetBundle.kt
@@ -20,60 +20,54 @@ package com.wire.android.ui.home.conversations.model
 
 import android.net.Uri
 import android.os.Parcel
-import android.os.Parcelable
-import androidx.compose.runtime.Stable
+import com.wire.content.asset.PreparedAsset
+import com.wire.content.external.ExternalContentImportRequest
+import com.wire.content.external.ExternalContentReference
 import com.wire.kalium.logic.data.asset.AttachmentType
 import kotlinx.parcelize.Parceler
-import kotlinx.parcelize.Parcelize
-import kotlinx.parcelize.TypeParceler
-import okio.Path
 import okio.Path.Companion.toPath
-import kotlin.math.roundToInt
 
-/**
- * Represents a set of metadata information of an asset message
- */
-@Parcelize
-@TypeParceler<Path, PathParceler>()
-data class AssetBundle(
-    val key: String,
-    val mimeType: String,
-    val dataPath: Path,
-    val dataSize: Long,
-    val fileName: String,
-    val assetType: AttachmentType,
-    val audioWavesMask: List<Int>? = null,
-) : Parcelable {
-
-    @Stable
-    val extensionWithSize: String
-        get() {
-            val assetExtension = fileName.split(".").last()
-            val oneKB = 1024L
-            val oneMB = oneKB * oneKB
-            return when {
-                dataSize < oneKB -> "${assetExtension.uppercase()} ($dataSize B)"
-                dataSize in oneKB..oneMB -> "${assetExtension.uppercase()} (${dataSize / oneKB} KB)"
-                else -> "${assetExtension.uppercase()} (${((dataSize / oneMB) * 100.0).roundToInt() / 100.0} MB)" // 2 decimals round off
-            }
-        }
-
-    val assetName: String
-        get() = fileName.split(".").first()
-}
+typealias AssetBundle = PreparedAsset
+typealias UriAsset = ExternalContentImportRequest
 
 /**
  * @param uri Uri of the asset
  * @param saveToDeviceIfInvalid if true then the asset will be copied to the public "media" directory if it's invalid (e.g. too large)
  */
-data class UriAsset(
-    val uri: Uri,
-    val saveToDeviceIfInvalid: Boolean = false,
-    val mimeType: String? = null,
-    val audioWavesMask: List<Int>? = null,
+@Suppress("FunctionName")
+fun UriAsset(
+    uri: Uri,
+    saveToDeviceIfInvalid: Boolean = false,
+    mimeType: String? = null,
+    audioWavesMask: List<Int>? = null,
+): ExternalContentImportRequest = ExternalContentImportRequest(
+    reference = ExternalContentReference(uri.toString()),
+    saveToDeviceIfInvalid = saveToDeviceIfInvalid,
+    mimeType = mimeType,
+    audioWavesMask = audioWavesMask,
 )
 
-object PathParceler : Parceler<Path> {
-    override fun create(parcel: Parcel) = parcel.readString().orEmpty().toPath()
-    override fun Path.write(parcel: Parcel, flags: Int) = parcel.writeString(this.toString())
+val ExternalContentImportRequest.uri: Uri
+    get() = Uri.parse(reference.token)
+
+object PreparedAssetParceler : Parceler<PreparedAsset> {
+    override fun create(parcel: Parcel) = PreparedAsset(
+        key = parcel.readString().orEmpty(),
+        mimeType = parcel.readString().orEmpty(),
+        dataPath = parcel.readString().orEmpty().toPath(),
+        dataSize = parcel.readLong(),
+        fileName = parcel.readString().orEmpty(),
+        assetType = AttachmentType.valueOf(parcel.readString().orEmpty()),
+        audioWavesMask = parcel.createIntArray()?.toList(),
+    )
+
+    override fun PreparedAsset.write(parcel: Parcel, flags: Int) {
+        parcel.writeString(key)
+        parcel.writeString(mimeType)
+        parcel.writeString(dataPath.toString())
+        parcel.writeLong(dataSize)
+        parcel.writeString(fileName)
+        parcel.writeString(assetType.name)
+        parcel.writeIntArray(audioWavesMask?.toIntArray())
+    }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -37,6 +37,7 @@ import com.wire.android.ui.home.conversations.MessageSharedState
 import com.wire.android.ui.home.conversations.SureAboutMessagingDialogState
 import com.wire.android.ui.home.conversations.model.AssetBundle
 import com.wire.android.ui.home.conversations.model.UriAsset
+import com.wire.android.ui.home.conversations.model.uri
 import com.wire.android.ui.home.conversations.usecase.HandleUriAssetUseCase
 import com.wire.android.ui.home.messagecomposer.model.ComposableMessageBundle
 import com.wire.android.ui.home.messagecomposer.model.MessageBundle

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
@@ -61,7 +61,7 @@ import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
 import kotlinx.coroutines.delay
-import java.io.File
+import okio.Path
 
 @Composable
 fun RecordAudioButtonClose(
@@ -185,7 +185,7 @@ fun RecordAudioButtonSend(
     audioState: AudioState,
     wavesMask: List<Int>?,
     onClick: () -> Unit,
-    outputFile: File?,
+    outputFile: Path?,
     onPlayAudio: () -> Unit,
     onSliderPositionChange: (Int) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioState.kt
@@ -18,15 +18,15 @@
 package com.wire.android.ui.home.messagecomposer.recordaudio
 
 import com.wire.android.media.audiomessage.AudioState
-import java.io.File
+import okio.Path
 
 data class RecordAudioState(
     val buttonState: RecordAudioButtonState = RecordAudioButtonState.ENABLED,
     val discardDialogState: RecordAudioDialogState = RecordAudioDialogState.Hidden,
     val permissionsDeniedDialogState: RecordAudioDialogState = RecordAudioDialogState.Hidden,
     val maxFileSizeReachedDialogState: RecordAudioDialogState = RecordAudioDialogState.Hidden,
-    val originalOutputFile: File? = null,
-    val effectsOutputFile: File? = null,
+    val originalOutputFile: Path? = null,
+    val effectsOutputFile: Path? = null,
     val shouldApplyEffects: Boolean = false,
     val audioState: AudioState = AudioState.DEFAULT,
     val wavesMask: List<Int>? = null

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -39,8 +39,8 @@ import com.wire.android.util.CurrentScreenManager
 import com.wire.android.util.SUPPORTED_AUDIO_MIME_TYPE
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.fileDateTime
-import com.wire.android.util.fromNioPathToContentUri
 import com.wire.android.util.getAudioLengthInMs
+import com.wire.android.util.pathToUri
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
@@ -51,10 +51,8 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
-import okio.Path.Companion.toPath
-import java.io.File
+import okio.Path
 import java.io.IOException
-import kotlin.io.path.deleteIfExists
 
 @Suppress("TooManyFunctions", "LongParameterList")
 class RecordAudioViewModel @Inject constructor(
@@ -90,7 +88,7 @@ class RecordAudioViewModel @Inject constructor(
         }
     }
 
-    fun getPlayableAudioFile(): File? = if (state.shouldApplyEffects) {
+    fun getPlayableAudioFile(): Path? = if (state.shouldApplyEffects) {
         state.effectsOutputFile
     } else {
         state.originalOutputFile
@@ -168,13 +166,13 @@ class RecordAudioViewModel @Inject constructor(
                 if (state.shouldApplyEffects && state.effectsOutputFile == null) {
                     state = state.copy(
                         effectsOutputFile = kaliumFileSystem
-                            .tempFilePath(getRecordingAudioEffectsFileName()).toFile()
+                            .tempFilePath(getRecordingAudioEffectsFileName())
                     )
                 }
                 audioMediaRecorder.setUp(assetSizeLimit)
                 if (audioMediaRecorder.startRecording()) {
                     state = state.copy(
-                        originalOutputFile = audioMediaRecorder.originalOutputPath!!.toFile(),
+                        originalOutputFile = audioMediaRecorder.originalOutputPath!!,
                         buttonState = RecordAudioButtonState.RECORDING
                     )
                 } else {
@@ -202,8 +200,8 @@ class RecordAudioViewModel @Inject constructor(
                 if (state.shouldApplyEffects && state.effectsOutputFile != null) {
                     generateAudioFileWithEffects(
                         context = context,
-                        originalFilePath = state.originalOutputFile!!.path,
-                        effectsFilePath = state.effectsOutputFile!!.path
+                        originalFilePath = state.originalOutputFile!!.toString(),
+                        effectsFilePath = state.effectsOutputFile!!.toString()
                     )
                 }
 
@@ -214,13 +212,13 @@ class RecordAudioViewModel @Inject constructor(
                         totalTimeInMs = AudioState.TotalTimeInMs.Known(
                             playableAudioFile?.let {
                                 getAudioLengthInMs(
-                                    dataPath = it.path.toPath(),
+                                    dataPath = it,
                                     mimeType = SUPPORTED_AUDIO_MIME_TYPE
                                 ).toInt()
                             } ?: 0
                         ),
                     ),
-                    wavesMask = playableAudioFile?.let { audioNormalizedLoudnessBuilder(it.path) }?.toWavesMask() ?: listOf()
+                    wavesMask = playableAudioFile?.let { audioNormalizedLoudnessBuilder(it.toString()) }?.toWavesMask() ?: listOf()
                 )
             }
         }
@@ -265,8 +263,8 @@ class RecordAudioViewModel @Inject constructor(
 
     fun discardRecording() {
         viewModelScope.launch {
-            state.originalOutputFile?.toPath()?.deleteIfExists()
-            state.effectsOutputFile?.toPath()?.deleteIfExists()
+            state.originalOutputFile?.let(::deleteIfExists)
+            state.effectsOutputFile?.let(::deleteIfExists)
             recordAudioMessagePlayer.stop()
             state = state.copy(
                 buttonState = RecordAudioButtonState.ENABLED,
@@ -300,16 +298,16 @@ class RecordAudioViewModel @Inject constructor(
             try {
                 when {
                     didSucceed -> {
-                        outputFile?.toPath()?.deleteIfExists()
-                        effectsFile?.toPath()?.deleteIfExists()
+                        outputFile?.let(::deleteIfExists)
+                        effectsFile?.let(::deleteIfExists)
                     }
 
                     state.shouldApplyEffects -> {
-                        outputFile?.toPath()?.deleteIfExists()
+                        outputFile?.let(::deleteIfExists)
                     }
 
                     !state.shouldApplyEffects -> {
-                        effectsFile?.toPath()?.deleteIfExists()
+                        effectsFile?.let(::deleteIfExists)
                     }
                 }
             } catch (exception: IOException) {
@@ -319,12 +317,12 @@ class RecordAudioViewModel @Inject constructor(
                 RecordAudioViewActions.Recorded(
                     uriAsset = UriAsset(
                         uri = if (didSucceed) {
-                            context.fromNioPathToContentUri(nioPath = audioMediaRecorder.m4aOutputPath!!.toNioPath())
+                            context.pathToUri(audioMediaRecorder.m4aOutputPath!!, null)
                         } else {
                             if (state.shouldApplyEffects) {
-                                context.fromNioPathToContentUri(nioPath = state.effectsOutputFile!!.toPath())
+                                context.pathToUri(effectsFile!!, null)
                             } else {
-                                context.fromNioPathToContentUri(nioPath = state.originalOutputFile!!.toPath())
+                                context.pathToUri(outputFile!!, null)
                             }
                         },
                         mimeType = if (didSucceed) {
@@ -363,7 +361,7 @@ class RecordAudioViewModel @Inject constructor(
             globalDataStore.setRecordAudioEffectsCheckboxEnabled(enabled)
             if (enabled && state.effectsOutputFile == null) {
                 val effectsFile = kaliumFileSystem
-                    .tempFilePath(getRecordingAudioEffectsFileName()).toFile()
+                    .tempFilePath(getRecordingAudioEffectsFileName())
                 if (state.buttonState == RecordAudioButtonState.READY_TO_SEND) {
                     state = state.copy(
                         buttonState = RecordAudioButtonState.ENCODING,
@@ -372,8 +370,8 @@ class RecordAudioViewModel @Inject constructor(
 
                     generateAudioFileWithEffects(
                         context = context,
-                        originalFilePath = state.originalOutputFile!!.path,
-                        effectsFilePath = effectsFile.path
+                        originalFilePath = state.originalOutputFile!!.toString(),
+                        effectsFilePath = effectsFile.toString()
                     )
 
                     state = state.copy(
@@ -384,7 +382,7 @@ class RecordAudioViewModel @Inject constructor(
                             currentPositionInMs = 0,
                             AudioState.TotalTimeInMs.Known(
                                 getAudioLengthInMs(
-                                    dataPath = effectsFile.path.toPath(),
+                                    dataPath = effectsFile,
                                     mimeType = SUPPORTED_AUDIO_MIME_TYPE
                                 ).toInt()
                             ),
@@ -409,6 +407,10 @@ class RecordAudioViewModel @Inject constructor(
     override fun onCleared() {
         super.onCleared()
         recordAudioMessagePlayer.close()
+    }
+
+    private fun deleteIfExists(path: Path) {
+        if (kaliumFileSystem.exists(path)) kaliumFileSystem.delete(path)
     }
 
     companion object {

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/attachment/MessageAttachmentsViewModelTest.kt
@@ -31,6 +31,7 @@ import com.wire.kalium.cells.domain.usecase.RemoveAttachmentDraftUseCase
 import com.wire.kalium.cells.domain.usecase.RetryAttachmentUploadUseCase
 import com.wire.kalium.common.functional.right
 import com.wire.kalium.logic.data.asset.AttachmentType
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.id.ConversationId
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
@@ -352,6 +353,9 @@ class MessageAttachmentsViewModelTest {
         @MockK
         lateinit var getMediaMetadata: GetMediaMetadataUseCase
 
+        @MockK
+        lateinit var kaliumFileSystem: KaliumFileSystem
+
         private val sharedState = MessageSharedState()
 
         private val uriAssetQueue = ArrayDeque<String>()
@@ -404,6 +408,7 @@ class MessageAttachmentsViewModelTest {
                 fileManager = fileManager,
                 sharedState = sharedState,
                 getMediaMetadata = getMediaMetadata,
+                kaliumFileSystem = kaliumFileSystem,
             )
             return this to viewModel
         }

--- a/core/content-kmp/build.gradle.kts
+++ b/core/content-kmp/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id(libs.plugins.wire.kmp.library.get().pluginId)
+}
+
+kotlin {
+    android {
+        namespace = "com.wire.content"
+        withHostTest {}
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api("com.wire.kalium:kalium-data")
+                api(libs.okio.core)
+                implementation(libs.jetbrains.compose.runtime)
+            }
+        }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
+    }
+}

--- a/core/content-kmp/src/commonMain/kotlin/com/wire/content/asset/AssetFileNamePolicy.kt
+++ b/core/content-kmp/src/commonMain/kotlin/com/wire/content/asset/AssetFileNamePolicy.kt
@@ -1,0 +1,35 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.content.asset
+
+object AssetFileNamePolicy {
+    fun isCompatible(fileName: String): Boolean =
+        fileName != "." &&
+            !fileName.startsWith('.') &&
+            !fileName.contains('/') &&
+            !fileName.contains('\\') &&
+            !fileName.contains('"')
+
+    fun sanitize(fileName: String): String = fileName
+        .trimStart('.')
+        .replace("/", "_")
+        .replace("\\", "_")
+        .replace("\"", "_")
+        .ifEmpty { "file" }
+}

--- a/core/content-kmp/src/commonMain/kotlin/com/wire/content/asset/PreparedAsset.kt
+++ b/core/content-kmp/src/commonMain/kotlin/com/wire/content/asset/PreparedAsset.kt
@@ -1,0 +1,60 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.content.asset
+
+import com.wire.kalium.logic.data.asset.AttachmentType
+import okio.Path
+import kotlin.math.roundToInt
+
+/**
+ * An asset that has been copied into app-private storage and is ready for policy checks or upload.
+ *
+ * Platform references such as Android content URIs deliberately do not belong in this model.
+ */
+data class PreparedAsset(
+    val key: String,
+    val mimeType: String,
+    val dataPath: Path,
+    val dataSize: Long,
+    val fileName: String,
+    val assetType: AttachmentType,
+    val audioWavesMask: List<Int>? = null,
+) {
+    val extensionWithSize: String
+        get() {
+            val assetExtension = fileName.substringAfterLast('.')
+            val oneMegabyte = BYTES_PER_KILOBYTE * BYTES_PER_KILOBYTE
+            return when {
+                dataSize < BYTES_PER_KILOBYTE -> "${assetExtension.uppercase()} ($dataSize B)"
+                dataSize in BYTES_PER_KILOBYTE..oneMegabyte ->
+                    "${assetExtension.uppercase()} (${dataSize / BYTES_PER_KILOBYTE} KB)"
+                else ->
+                    "${assetExtension.uppercase()} " +
+                        "(${((dataSize / oneMegabyte) * SIZE_DECIMAL_SCALE).roundToInt() / SIZE_DECIMAL_SCALE} MB)"
+            }
+        }
+
+    val assetName: String
+        get() = fileName.substringBefore('.')
+
+    private companion object {
+        const val BYTES_PER_KILOBYTE = 1024L
+        const val SIZE_DECIMAL_SCALE = 100.0
+    }
+}

--- a/core/content-kmp/src/commonMain/kotlin/com/wire/content/external/ExternalContent.kt
+++ b/core/content-kmp/src/commonMain/kotlin/com/wire/content/external/ExternalContent.kt
@@ -1,0 +1,59 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.content.external
+
+import com.wire.content.asset.PreparedAsset
+import kotlin.jvm.JvmInline
+
+/**
+ * Opaque handle owned by the platform edge. Common code can pass the token back to a platform
+ * capability, but must not interpret it as a URI, URL, authority, or file-system path.
+ */
+@JvmInline
+value class ExternalContentReference(val token: String) {
+    init {
+        require(token.isNotBlank()) { "An external content reference cannot be blank" }
+    }
+}
+
+data class ExternalContentImportRequest(
+    val reference: ExternalContentReference,
+    val saveToDeviceIfInvalid: Boolean = false,
+    val mimeType: String? = null,
+    val audioWavesMask: List<Int>? = null,
+)
+
+sealed interface ExternalContentImportResult {
+    data class Success(val asset: PreparedAsset) : ExternalContentImportResult
+    data class TooLarge(
+        val asset: PreparedAsset,
+        val maximumSizeBytes: Long,
+    ) : ExternalContentImportResult
+
+    data object Cancelled : ExternalContentImportResult
+    data object Unsupported : ExternalContentImportResult
+    data object Failure : ExternalContentImportResult
+}
+
+sealed interface PlatformResult<out T> {
+    data class Success<T>(val value: T) : PlatformResult<T>
+    data object Cancelled : PlatformResult<Nothing>
+    data object Unsupported : PlatformResult<Nothing>
+    data class Failure(val reason: String? = null) : PlatformResult<Nothing>
+}

--- a/core/content-kmp/src/commonTest/kotlin/com/wire/content/asset/PreparedAssetTest.kt
+++ b/core/content-kmp/src/commonTest/kotlin/com/wire/content/asset/PreparedAssetTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+
+package com.wire.content.asset
+
+import com.wire.content.external.ExternalContentImportResult
+import com.wire.content.external.ExternalContentReference
+import com.wire.kalium.logic.data.asset.AttachmentType
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class PreparedAssetTest {
+    @Test
+    fun extensionAndNameAreDerivedWithoutPlatformFileApis() {
+        val asset = asset(fileName = "meeting.notes.pdf", dataSize = 2L * 1024L * 1024L)
+
+        assertEquals("meeting", asset.assetName)
+        assertEquals("PDF (2.0 MB)", asset.extensionWithSize)
+    }
+
+    @Test
+    fun externalReferenceRejectsBlankTokens() {
+        assertFailsWith<IllegalArgumentException> { ExternalContentReference(" ") }
+    }
+
+    @Test
+    fun tooLargeResultKeepsBytePrecision() {
+        val asset = asset()
+
+        assertEquals(
+            ExternalContentImportResult.TooLarge(asset, 25L * 1024L * 1024L),
+            ExternalContentImportResult.TooLarge(asset, 25L * 1024L * 1024L),
+        )
+    }
+
+    @Test
+    fun fileNamePolicyPreservesCurrentCompatibilityRules() {
+        assertEquals(false, AssetFileNamePolicy.isCompatible(".hidden"))
+        assertEquals(false, AssetFileNamePolicy.isCompatible("bad/name"))
+        assertEquals("bad_name_", AssetFileNamePolicy.sanitize(".bad/name\""))
+        assertEquals("file", AssetFileNamePolicy.sanitize("."))
+    }
+
+    private fun asset(
+        fileName: String = "photo.jpg",
+        dataSize: Long = 42L,
+    ) = PreparedAsset(
+        key = "key",
+        mimeType = "image/jpeg",
+        dataPath = "/tmp/asset".toPath(),
+        dataSize = dataSize,
+        fileName = fileName,
+        assetType = AttachmentType.IMAGE,
+    )
+}

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -62,6 +62,7 @@ import com.wire.kalium.cells.domain.usecase.offline.OfflineFileInfo
 import com.wire.kalium.common.functional.fold
 import com.wire.kalium.common.functional.onFailure
 import com.wire.kalium.common.functional.onSuccess
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.featureConfig.CollaboraEdition
 import com.wire.kalium.logic.data.id.QualifiedIdMapper
 import com.wire.kalium.logic.feature.conversation.IsSelfUserViewerOnConversationUseCase
@@ -92,7 +93,6 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path.Companion.toPath
-import java.io.File
 import kotlin.time.Duration.Companion.milliseconds
 
 @Suppress("TooManyFunctions", "LongParameterList")
@@ -120,6 +120,7 @@ class CellViewModel @AssistedInject constructor(
     private val isSelfUserViewerOnConversation: IsSelfUserViewerOnConversationUseCase,
     private val userDataStore: UserDataStore,
     private val qualifiedIdMapper: QualifiedIdMapper,
+    private val kaliumFileSystem: KaliumFileSystem,
     /** When disabled, all offline-files UI (save actions, offline banner, offline browsing) is hidden. */
     @Named("offlineFilesEnabled") val offlineFilesEnabled: Boolean,
     @Named("inAppImageViewerEnabled") private val inAppImageViewerEnabled: Boolean,
@@ -551,9 +552,9 @@ class CellViewModel @AssistedInject constructor(
         deleteOfflineFile(node.uuid)
 
         // Delete the physical file from device storage
-        localPath?.takeIf { it.isNotBlank() }?.let { path ->
+        localPath?.takeIf { it.isNotBlank() }?.toPath()?.let { path ->
             withContext(kotlinx.coroutines.Dispatchers.IO) {
-                File(path).delete()
+                if (kaliumFileSystem.exists(path)) kaliumFileSystem.delete(path)
             }
         }
 

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/CellViewModelTest.kt
@@ -629,6 +629,7 @@ class CellViewModelTest {
                 isSelfUserViewerOnConversation = isSelfUserViewerOnConversation,
                 userDataStore = userDataStore,
                 qualifiedIdMapper = qualifiedIdMapper,
+                kaliumFileSystem = mockk(relaxed = true),
                 offlineFilesEnabled = true,
                 inAppImageViewerEnabled = inAppImageViewerEnabled,
             )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -320,6 +320,7 @@ junit5-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", ver
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
 mockk-core = { module = "io.mockk:mockk", version.ref = "mockk" }
 okio-fakeFileSystem = { module = "com.squareup.okio:okio-fakefilesystem", version.ref = "okio" }
+okio-core = { module = "com.squareup.okio:okio", version.ref = "okio" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }


### PR DESCRIPTION
## Intent
Move shared asset identity and app-private file state behind KMP-safe models without pulling Android APIs into common code.

## Changes
- add focused content KMP contracts for prepared assets, opaque external references, portable platform results, and naming policy
- split Android URI navigation wrappers from the common prepared-asset model
- replace app-private File and Path state in affected ViewModels with okio.Path and the existing KaliumFileSystem where practical
- keep URI parsing and WireActivityViewModel at the Android edge

## Scope
The current develop inventory still contains all 19 directly affected ViewModels. This first layer introduces only the shared models and filesystem state needed by later PRs.