### PR TITLE
refactor(media): add common playback coordination PR 4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -213,6 +213,7 @@ dependencies {
     implementationWithCoverage(projects.core.di)
     implementationWithCoverage(projects.core.media)
     implementationWithCoverage(projects.core.mediaPlayer)
+    implementation(projects.core.mediaPlayerKmp)
     implementation(projects.core.contentKmp)
     implementationWithCoverage(projects.core.notification)
     implementationWithCoverage(projects.core.navigation)

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModel.kt
@@ -33,6 +33,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.AssetContent.AssetMetadata
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.feature.message.ObserveMessageByIdUseCase
+import com.wire.media.player.AudioState
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
@@ -21,41 +21,10 @@ import androidx.annotation.StringRes
 import com.wire.android.R
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
 
-data class AudioState(
-    val audioMediaPlayingState: AudioMediaPlayingState,
-    val currentPositionInMs: Int,
-    val totalTimeInMs: TotalTimeInMs,
-) {
-    companion object {
-        val DEFAULT = AudioState(AudioMediaPlayingState.Stopped, 0, TotalTimeInMs.NotKnown)
-    }
-
-    // if the back-end returned the total time, we use that, in case it didn't we use what we get from
-    // the [ConversationAudioMessagePlayer.kt] which will emit the time once the users play the audio.
-    fun sanitizeTotalTime(otherClientTotalTime: Int): TotalTimeInMs {
-        if (otherClientTotalTime != 0) {
-            return TotalTimeInMs.Known(otherClientTotalTime)
-        }
-
-        return totalTimeInMs
-    }
-
-    fun isPlaying() = audioMediaPlayingState is AudioMediaPlayingState.Playing
-    fun isPlayingOrPaused() = audioMediaPlayingState is AudioMediaPlayingState.Playing
-            || audioMediaPlayingState is AudioMediaPlayingState.Paused
-
-    fun isPlayingOrPausedOrFetching() = audioMediaPlayingState is AudioMediaPlayingState.Playing
-            || audioMediaPlayingState is AudioMediaPlayingState.Paused
-            || audioMediaPlayingState is AudioMediaPlayingState.Fetching
-            || audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching
-
-    sealed class TotalTimeInMs {
-        object NotKnown : TotalTimeInMs()
-
-        data class Known(val value: Int) : TotalTimeInMs()
-    }
-}
+typealias AudioSpeed = com.wire.media.player.PlaybackSpeed
 
 sealed class PlayingAudioMessage {
     data object None : PlayingAudioMessage()
@@ -78,41 +47,13 @@ sealed class PlayingAudioMessage {
     }
 }
 
-@Suppress("MagicNumber")
-enum class AudioSpeed(val value: Float, @StringRes val titleRes: Int) {
-    NORMAL(1f, R.string.audio_speed_1),
-    FAST(1.5f, R.string.audio_speed_1_5),
-    MAX(2f, R.string.audio_speed_2);
-
-    fun toggle(): AudioSpeed = when (this) {
-        NORMAL -> FAST
-        FAST -> MAX
-        MAX -> NORMAL
+@get:StringRes
+val AudioSpeed.titleRes: Int
+    get() = when (this) {
+        AudioSpeed.NORMAL -> R.string.audio_speed_1
+        AudioSpeed.FAST -> R.string.audio_speed_1_5
+        AudioSpeed.MAX -> R.string.audio_speed_2
     }
-
-    companion object {
-        fun fromFloat(speed: Float): AudioSpeed = when {
-            (speed < FAST.value) -> NORMAL
-            (speed < MAX.value) -> FAST
-            else -> MAX
-        }
-    }
-}
-
-sealed class AudioMediaPlayingState {
-    object Playing : AudioMediaPlayingState()
-    object Stopped : AudioMediaPlayingState()
-
-    object Completed : AudioMediaPlayingState()
-
-    object Paused : AudioMediaPlayingState()
-
-    object Fetching : AudioMediaPlayingState()
-
-    object SuccessfulFetching : AudioMediaPlayingState()
-
-    object Failed : AudioMediaPlayingState()
-}
 
 sealed class AudioMediaPlayerStateUpdate(
     open val conversationId: ConversationId,

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayer.kt
@@ -6,27 +6,15 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+
 package com.wire.android.media.audiomessage
 
-import android.content.Context
-import android.media.MediaPlayer
-import android.media.MediaPlayer.SEEK_CLOSEST_SYNC
-import android.net.Uri
 import com.wire.android.di.ApplicationScope
 import com.wire.android.di.KaliumCoreLogic
-import com.wire.android.services.ServicesManager
+import com.wire.android.mediaplayer.AndroidMediaPlayerPlaybackEngineFactory
 import com.wire.android.ui.common.R as commonR
 import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.extension.intervalFlow
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.CoreLogic
 import com.wire.kalium.logic.data.id.ConversationId
@@ -35,190 +23,81 @@ import com.wire.kalium.logic.feature.asset.MessageAssetResult
 import com.wire.kalium.logic.feature.message.GetNextAudioMessageInConversationUseCase
 import com.wire.kalium.logic.feature.message.GetSenderNameByMessageIdUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
-import com.wire.android.di.ApplicationContext
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioPlaybackStateStore
+import com.wire.media.player.AudioState
+import com.wire.media.player.AudioStateUpdate
+import com.wire.media.player.MediaPlaybackCoordinator
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSource
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.AppScope
-import dev.zacsweers.metro.SingleIn
 
 @SingleIn(AppScope::class)
 @Suppress("TooManyFunctions")
-class ConversationAudioMessagePlayer
-@Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val audioMediaPlayer: MediaPlayer,
-    private val servicesManager: Lazy<ServicesManager>,
-    private val audioFocusHelper: AudioFocusHelper,
+class ConversationAudioMessagePlayer @Inject constructor(
+    engineFactory: AndroidMediaPlayerPlaybackEngineFactory,
+    private val platformController: ConversationAudioPlatformController,
     @KaliumCoreLogic private val coreLogic: CoreLogic,
     @ApplicationScope private val scope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) {
-    private companion object {
-        const val UPDATE_POSITION_INTERVAL_IN_MS = 1000L
-    }
+    private val playbackCoordinator = MediaPlaybackCoordinator(
+        engine = engineFactory.create(),
+        scope = scope,
+        positionPollIntervalMs = UPDATE_POSITION_INTERVAL_IN_MS,
+    )
+    private val stateStore = AudioPlaybackStateStore<MessageIdWrapper>()
+    private var currentAudioMessageId: MessageIdWrapper? = null
+    private var pendingDurationMs: Int? = null
+
+    val observableAudioMessagesState: Flow<Map<MessageIdWrapper, AudioState>> = stateStore.states
+    val audioSpeed: Flow<AudioSpeed> = playbackCoordinator.state
+        .map { it.speed }
+        .distinctUntilChanged()
 
     init {
-        audioMediaPlayer.setOnCompletionListener {
-            currentAudioMessageId?.let {
-                scope.launch {
-                    if (!tryToPlayNextAudio(it)) {
-                        forceToStopCurrentAudioMessage()
-                    }
-                }
-            }
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            playbackCoordinator.events.collect(::handlePlaybackEvent)
         }
-
-        audioFocusHelper.setListener(
-            onPauseCurrentAudio = { scope.launch { pauseCurrentAudioMessage() } },
-            onResumeCurrentAudio = { scope.launch { resumeCurrentAudioMessage() } }
+        platformController.setFocusListener(
+            onPause = { scope.launch { pauseCurrentAudioMessage() } },
+            onResume = { scope.launch { resumeCurrentAudioMessage() } },
         )
     }
 
-    private var audioMessageStateHistory: Map<MessageIdWrapper, AudioState> = emptyMap()
-    private var currentAudioMessageId: MessageIdWrapper? = null
-
-    private val audioMessageStateUpdate = MutableSharedFlow<AudioMediaPlayerStateUpdate>(
-        onBufferOverflow = BufferOverflow.SUSPEND
-    )
-
-    private val _audioSpeed = MutableStateFlow<AudioSpeed>(AudioSpeed.NORMAL)
-    val audioSpeed: Flow<AudioSpeed> = _audioSpeed.onStart { emit(_audioSpeed.value) }
-
-    private val seekToAudioPosition = MutableSharedFlow<Pair<MessageIdWrapper, Int>>(
-        onBufferOverflow = BufferOverflow.SUSPEND
-    )
-
-    private val positionCheckTrigger = MutableSharedFlow<Unit>()
-
-    // MediaPlayer API does not have any mechanism that would inform as about the currentPosition,
-    // in a callback manner, therefore we need to create a timer manually that ticks every UPDATE_POSITION_INTERVAL_IN_MS
-    // and emits the current position
-    private val mediaPlayerPosition = positionCheckTrigger
-        .map {
-            currentAudioMessageId?.let {
-                audioMessageStateHistory[it]?.let { state -> state.isPlaying() }
-            } ?: false
-        }
-        .distinctUntilChanged()
-        .flatMapLatest { isAnythingPlaying ->
-            if (isAnythingPlaying) {
-                intervalFlow(UPDATE_POSITION_INTERVAL_IN_MS)
-                    .conflate()
-                    .map {
-                        if (audioMediaPlayer.isPlaying) {
-                            currentAudioMessageId to audioMediaPlayer.currentPosition
-                        } else {
-                            null
-                        }
-                    }
-                    .filterNotNull()
-                    .distinctUntilChanged()
-            } else {
-                // no need for tick-tack checking if there no playing message
-                emptyFlow<Pair<MessageIdWrapper, Int>>()
-            }
-        }
-
-    private val positionChangedUpdate = merge(mediaPlayerPosition, seekToAudioPosition)
-        .map { (messageId, position) ->
-            messageId?.let {
-                AudioMediaPlayerStateUpdate.PositionChangeUpdate(it.conversationId, it.messageId, position)
-            }
-        }.filterNotNull()
-
-    // Flow collecting the audio message state updates as well as the audio message position
-    // updates, the collected values are then put into the map holding the state for each individual audio message.
-    // The audio message position can be either updated by the user manually by for example a Slider component or by the player itself.
-    val observableAudioMessagesState: Flow<Map<MessageIdWrapper, AudioState>> =
-        merge(positionChangedUpdate, audioMessageStateUpdate).map { audioMessageStateUpdate ->
-            val messageIdKey =
-                MessageIdWrapper(audioMessageStateUpdate.conversationId, audioMessageStateUpdate.messageId)
-            val currentState = audioMessageStateHistory.getOrDefault(
-                messageIdKey,
-                AudioState.DEFAULT
-            )
-
-            when (audioMessageStateUpdate) {
-                is AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate -> {
-                    audioMessageStateHistory = audioMessageStateHistory.toMutableMap().apply {
-                        put(
-                            messageIdKey,
-                            currentState.copy(audioMediaPlayingState = audioMessageStateUpdate.audioMediaPlayingState)
-                        )
-                    }
-                    positionCheckTrigger.emit(Unit)
-                }
-
-                is AudioMediaPlayerStateUpdate.PositionChangeUpdate -> {
-                    audioMessageStateHistory = audioMessageStateHistory.toMutableMap().apply {
-                        put(
-                            messageIdKey,
-                            currentState.copy(currentPositionInMs = audioMessageStateUpdate.position)
-                        )
-                    }
-                }
-
-                is AudioMediaPlayerStateUpdate.TotalTimeUpdate -> {
-                    audioMessageStateHistory = audioMessageStateHistory.toMutableMap().apply {
-                        put(
-                            messageIdKey,
-                            currentState.copy(
-                                totalTimeInMs = AudioState.TotalTimeInMs.Known(audioMessageStateUpdate.totalTimeInMs)
-                            )
-                        )
-                    }
-                }
-            }
-
-            audioMessageStateHistory
-        }.shareIn(scope, SharingStarted.WhileSubscribed(), 1)
-            .onStart { emit(audioMessageStateHistory) }
-
-    // Flow contains currently playing or last paused Audio message date.
-    // If there is such a message state is PlayingAudioMessageState.Some,
-    // PlayingAudioMessageState.None otherwise
     val playingAudioMessageFlow: Flow<PlayingAudioMessage> = observableAudioMessagesState
-        .scan(PlayingAudioMessage.None as PlayingAudioMessage) { prevState, statesHistory ->
+        .scan(PlayingAudioMessage.None as PlayingAudioMessage) { previous, history ->
             val currentMessageId = currentAudioMessageId
-            val state = currentMessageId?.let { statesHistory[it] }
+            val state = currentMessageId?.let(history::get)
 
             when {
-                (state?.isPlayingOrPausedOrFetching() != true) -> PlayingAudioMessage.None
-
-                (prevState is PlayingAudioMessage.Some && prevState.messageId == currentMessageId.messageId) ->
-                    // no need to request Sender name if we already have it
+                state?.isPlayingOrPausedOrFetching() != true -> PlayingAudioMessage.None
+                previous is PlayingAudioMessage.Some && previous.messageId == currentMessageId.messageId ->
                     PlayingAudioMessage.Some(
                         conversationId = currentMessageId.conversationId,
                         messageId = currentMessageId.messageId,
-                        authorName = prevState.authorName,
-                        state = state
+                        authorName = previous.authorName,
+                        state = state,
                     )
-
                 else -> {
                     val authorName = getSenderNameByMessageId(currentMessageId.conversationId, currentMessageId.messageId)
-                        ?.let { UIText.DynamicString(it) }
+                        ?.let(UIText::DynamicString)
                         ?: UIText.StringResource(commonR.string.username_unavailable_label)
-
                     PlayingAudioMessage.Some(
                         conversationId = currentMessageId.conversationId,
                         messageId = currentMessageId.messageId,
@@ -228,165 +107,132 @@ class ConversationAudioMessagePlayer
                 }
             }
         }
-        .shareIn(scope, SharingStarted.WhileSubscribed(), 1)
+        .shareIn(scope, SharingStarted.WhileSubscribed(), replay = 1)
 
-    suspend fun playAudio(
-        conversationId: ConversationId,
-        messageId: String
-    ) {
-        val isRequestedAudioMessageCurrentlyPlaying = currentAudioMessageId == MessageIdWrapper(conversationId, messageId)
-        if (isRequestedAudioMessageCurrentlyPlaying) {
-            resumeOrPause(conversationId, messageId)
+    suspend fun playAudio(conversationId: ConversationId, messageId: String) {
+        val requested = MessageIdWrapper(conversationId, messageId)
+        if (requested == currentAudioMessageId) {
+            resumeOrPause()
         } else {
             stopCurrentAudioMessage()
-            playAudioMessage(
-                conversationId = conversationId,
-                messageId = messageId,
-                position = previouslyResumedPosition(conversationId, messageId)
-            )
+            playAudioMessage(requested, stateStore.restoredPosition(requested))
         }
     }
 
     suspend fun setSpeed(speed: AudioSpeed) {
-        val currentParams = audioMediaPlayer.playbackParams
-        audioMediaPlayer.playbackParams = currentParams.setSpeed(speed.value)
-        updateSpeedFlow()
+        playbackCoordinator.setSpeed(speed)
     }
 
     suspend fun forceToStopCurrentAudioMessage() {
         stopCurrentAudioMessage()
-        servicesManager.value.stopPlayingAudioMessageService()
-        audioFocusHelper.abandon()
+        platformController.stopPlaybackService()
+        platformController.abandonFocus()
     }
 
     suspend fun resumeOrPauseCurrentAudioMessage() {
-        currentAudioMessageId?.let { (conversationId, messageId) ->
-            resumeOrPause(conversationId, messageId)
-        }
-    }
-
-    private suspend fun playAudioMessage(
-        conversationId: ConversationId,
-        messageId: String,
-        position: Int? = null
-    ) {
-        currentAudioMessageId = MessageIdWrapper(conversationId, messageId)
-
-        val currentAccountResult = coreLogic.getGlobalScope().session.currentSession()
-        if (currentAccountResult is CurrentSessionResult.Failure) return
-        val userId = (currentAccountResult as CurrentSessionResult.Success).accountInfo.userId
-
-        audioMessageStateUpdate.emit(
-            AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(conversationId, messageId, AudioMediaPlayingState.Fetching)
-        )
-
-        when (val result = getAssetMessage(userId, conversationId, messageId)) {
-            is MessageAssetResult.Success -> {
-                audioMessageStateUpdate.emit(
-                    AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(
-                        conversationId,
-                        messageId,
-                        AudioMediaPlayingState.SuccessfulFetching
-                    )
-                )
-
-                val isFetchedAudioCurrentlyQueuedToPlay = MessageIdWrapper(conversationId, messageId) == currentAudioMessageId
-
-                if (isFetchedAudioCurrentlyQueuedToPlay) {
-                    audioMediaPlayer.setDataSource(context, Uri.parse(result.decodedAssetPath.toString()))
-                    audioMediaPlayer.prepare()
-
-                    if (position != null) audioMediaPlayer.seekTo(position)
-
-                    audioFocusHelper.request()
-                    audioMediaPlayer.start()
-
-                    setSpeed(_audioSpeed.value)
-
-                    audioMessageStateUpdate.emit(
-                        AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(
-                            conversationId,
-                            messageId,
-                            AudioMediaPlayingState.Playing
-                        )
-                    )
-
-                    servicesManager.value.startPlayingAudioMessageService()
-
-                    audioMessageStateUpdate.emit(
-                        AudioMediaPlayerStateUpdate.TotalTimeUpdate(conversationId, messageId, audioMediaPlayer.duration)
-                    )
-                }
-            }
-
-            is MessageAssetResult.Failure -> {
-                audioMessageStateUpdate.emit(
-                    AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(
-                        conversationId,
-                        messageId,
-                        AudioMediaPlayingState.Failed
-                    )
-                )
-            }
-        }
+        if (currentAudioMessageId != null) resumeOrPause()
     }
 
     suspend fun setPosition(conversationId: ConversationId, messageId: String, position: Int) {
-        val currentAudioState = audioMessageStateHistory[MessageIdWrapper(conversationId, messageId)]
-
-        if (currentAudioState != null) {
-            val isAudioMessageCurrentlyPlaying = currentAudioMessageId == MessageIdWrapper(conversationId, messageId)
-
-            if (isAudioMessageCurrentlyPlaying) {
-                audioMediaPlayer.seekTo(position.toLong(), SEEK_CLOSEST_SYNC)
-            }
+        val key = MessageIdWrapper(conversationId, messageId)
+        if (stateStore.state(key) != null) {
+            if (currentAudioMessageId == key) playbackCoordinator.seekTo(position)
+            stateStore.update(key, AudioStateUpdate.PositionChanged(position))
         }
-
-        seekToAudioPosition.emit(MessageIdWrapper(conversationId, messageId) to position)
     }
 
     suspend fun preloadAudioMessage(conversationId: ConversationId, messageId: String) {
-        val currentAccountResult = coreLogic.getGlobalScope().session.currentSession()
-        if (currentAccountResult is CurrentSessionResult.Success) {
-            val userId = currentAccountResult.accountInfo.userId
-            getAssetMessage(userId, conversationId, messageId)
+        currentUserId()?.let { userId -> getAssetMessage(userId, conversationId, messageId) }
+    }
+
+    private suspend fun playAudioMessage(key: MessageIdWrapper, position: Int?) {
+        currentAudioMessageId = key
+        pendingDurationMs = null
+        val userId = currentUserId() ?: return
+        stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Fetching))
+
+        when (val result = getAssetMessage(userId, key.conversationId, key.messageId)) {
+            is MessageAssetResult.Success -> {
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.SuccessfulFetching))
+                if (key == currentAudioMessageId) {
+                    platformController.requestFocus()
+                    playbackCoordinator.prepare(
+                        source = PlaybackSource.Local(result.decodedAssetPath),
+                        restoredPositionMs = position ?: 0,
+                        playWhenReady = true,
+                    )
+                }
+            }
+            is MessageAssetResult.Failure ->
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Failed))
         }
     }
 
-    private suspend fun resumeOrPause(conversationId: ConversationId, messageId: String) {
-        if (audioMediaPlayer.isPlaying) {
-            pause(conversationId, messageId)
-            audioFocusHelper.abandon()
+    private suspend fun resumeOrPause() {
+        if (playbackCoordinator.state.value.isPlaying) {
+            pauseCurrentAudioMessage()
+            platformController.abandonFocus()
         } else {
-            audioFocusHelper.request()
-            resume(conversationId, messageId)
+            platformController.requestFocus()
+            resumeCurrentAudioMessage()
         }
     }
 
-    private suspend fun pauseCurrentAudioMessage() {
-        currentAudioMessageId?.let {
-            val currentAudioState = audioMessageStateHistory[it]
-            if (currentAudioState?.audioMediaPlayingState != AudioMediaPlayingState.Fetching) {
-                pause(it.conversationId, it.messageId)
+    private fun pauseCurrentAudioMessage() {
+        currentAudioMessageId?.let { key ->
+            if (stateStore.state(key)?.audioMediaPlayingState != AudioMediaPlayingState.Fetching) {
+                playbackCoordinator.pause()
             }
         }
     }
 
-    private suspend fun resumeCurrentAudioMessage() {
-        currentAudioMessageId?.let {
-            val currentAudioState = audioMessageStateHistory[it]
-            if (currentAudioState?.audioMediaPlayingState != AudioMediaPlayingState.Fetching) {
-                resume(it.conversationId, it.messageId)
+    private fun resumeCurrentAudioMessage() {
+        currentAudioMessageId?.let { key ->
+            if (stateStore.state(key)?.audioMediaPlayingState != AudioMediaPlayingState.Fetching) {
+                playbackCoordinator.play()
             }
         }
     }
 
-    private suspend fun stopCurrentAudioMessage() {
-        currentAudioMessageId?.let {
-            val currentAudioState = audioMessageStateHistory[it]
-            if (currentAudioState?.audioMediaPlayingState != AudioMediaPlayingState.Fetching) {
-                stop(it.conversationId, it.messageId)
+    private fun stopCurrentAudioMessage() {
+        currentAudioMessageId?.let { key ->
+            if (stateStore.state(key)?.audioMediaPlayingState != AudioMediaPlayingState.Fetching) {
+                playbackCoordinator.stop()
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Stopped))
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Completed))
+                stateStore.update(key, AudioStateUpdate.PositionChanged(0))
+                currentAudioMessageId = null
+                pendingDurationMs = null
             }
+        }
+    }
+
+    private suspend fun handlePlaybackEvent(event: PlaybackEvent) {
+        val key = currentAudioMessageId ?: return
+        when (event) {
+            is PlaybackEvent.Ready -> pendingDurationMs = event.durationMs
+            PlaybackEvent.Playing -> {
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Playing))
+                pendingDurationMs?.let { durationMs ->
+                    stateStore.update(key, AudioStateUpdate.TotalTimeChanged(durationMs))
+                    pendingDurationMs = null
+                }
+                platformController.startPlaybackService()
+            }
+            PlaybackEvent.Paused ->
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Paused))
+            is PlaybackEvent.PositionChanged ->
+                stateStore.update(key, AudioStateUpdate.PositionChanged(event.positionMs))
+            PlaybackEvent.Completed -> {
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Completed))
+                stateStore.update(key, AudioStateUpdate.PositionChanged(playbackCoordinator.state.value.durationMs))
+                if (!tryToPlayNextAudio(key)) forceToStopCurrentAudioMessage()
+            }
+            is PlaybackEvent.Failed -> {
+                pendingDurationMs = null
+                stateStore.update(key, AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Failed))
+            }
+            else -> Unit
         }
     }
 
@@ -400,10 +246,8 @@ class ConversationAudioMessagePlayer
     ): MessageAssetResult = withContext(dispatchers.io()) {
         val key = GetAssetMessageKey(userId, conversationId, messageId)
         getAssetMessageMutex.withLock {
-            // keep deferred in the map to prevent multiple calls to the same asset at the same time, instead just reuse the existing one
             val deferredResult = getAssetMessageDeferredMap[key]
-            // if no deferred exists or the existing one is already completed with failure, create a new one
-            if (deferredResult == null || (deferredResult.isCompleted && deferredResult.getCompleted() is MessageAssetResult.Failure)) {
+            if (deferredResult == null || deferredResult.isCompletedWithFailure()) {
                 coreLogic.getSessionScope(userId).messages.getAssetMessage(conversationId, messageId).also {
                     getAssetMessageDeferredMap[key] = it
                 }
@@ -411,9 +255,10 @@ class ConversationAudioMessagePlayer
                 deferredResult
             }
         }.await().let { result ->
-            // if deferred is completed successfully but the file does not exist, then remove and retry the call
-            // this is to handle the case when the file has been uploaded and the file name has changed from temporary to proper one
-            if (result is MessageAssetResult.Success && !result.decodedAssetPath.toFile().exists()) {
+            if (
+                result is MessageAssetResult.Success &&
+                !coreLogic.getSessionScope(userId).kaliumFileSystem.exists(result.decodedAssetPath)
+            ) {
                 getAssetMessageMutex.withLock {
                     coreLogic.getSessionScope(userId).messages.getAssetMessage(conversationId, messageId).also {
                         getAssetMessageDeferredMap[key] = it
@@ -425,92 +270,49 @@ class ConversationAudioMessagePlayer
         }
     }
 
-    private suspend fun resume(conversationId: ConversationId, messageId: String) {
-        audioMediaPlayer.start()
-        updateSpeedFlow()
+    private fun Deferred<MessageAssetResult>.isCompletedWithFailure(): Boolean =
+        isCompleted && getCompleted() is MessageAssetResult.Failure
 
-        audioMessageStateUpdate.emit(
-            AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(conversationId, messageId, AudioMediaPlayingState.Playing)
-        )
-        servicesManager.value.startPlayingAudioMessageService()
-    }
-
-    private suspend fun pause(conversationId: ConversationId, messageId: String) {
-        audioMediaPlayer.pause()
-
-        audioMessageStateUpdate.emit(
-            AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(conversationId, messageId, AudioMediaPlayingState.Paused)
-        )
-    }
-
-    private suspend fun stop(conversationId: ConversationId, messageId: String) {
-        audioMediaPlayer.reset()
-
-        audioMessageStateUpdate.emit(
-            AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(conversationId, messageId, AudioMediaPlayingState.Stopped)
-        )
-
-        audioMessageStateUpdate.emit(
-            AudioMediaPlayerStateUpdate.AudioMediaPlayingStateUpdate(conversationId, messageId, AudioMediaPlayingState.Completed)
-        )
-
-        seekToAudioPosition.emit(MessageIdWrapper(conversationId, messageId) to 0)
-        currentAudioMessageId = null
-    }
-
-    private suspend fun updateSpeedFlow() {
-        val currentSpeed = AudioSpeed.fromFloat(audioMediaPlayer.playbackParams.speed)
-        _audioSpeed.emit(currentSpeed)
-    }
-
-    private suspend fun tryToPlayNextAudio(currentMessageIdWrapper: MessageIdWrapper): Boolean {
-        val (conversationId, currentMessageId) = currentMessageIdWrapper
-
-        val currentAccountResult = coreLogic.getGlobalScope().session.currentSession()
-        if (currentAccountResult is CurrentSessionResult.Success) {
-            coreLogic
-                .getSessionScope((currentAccountResult).accountInfo.userId)
-                .messages
-                .getNextAudioMessageInConversation(conversationId, currentMessageId).let { nextAudio ->
-                    if (nextAudio is GetNextAudioMessageInConversationUseCase.Result.Success) {
-                        playAudio(conversationId, nextAudio.messageId)
-                        return true
-                    }
-                }
+    private suspend fun tryToPlayNextAudio(current: MessageIdWrapper): Boolean {
+        val userId = currentUserId() ?: return false
+        return when (
+            val next = coreLogic.getSessionScope(userId).messages
+                .getNextAudioMessageInConversation(current.conversationId, current.messageId)
+        ) {
+            is GetNextAudioMessageInConversationUseCase.Result.Success -> {
+                playAudio(current.conversationId, next.messageId)
+                true
+            }
+            else -> false
         }
-        return false
     }
 
     private suspend fun getSenderNameByMessageId(conversationId: ConversationId, messageId: String): String? {
-        val currentAccountResult = coreLogic.getGlobalScope().session.currentSession()
-        if (currentAccountResult is CurrentSessionResult.Failure) return null
-
-        val senderNameResult = coreLogic
-            .getSessionScope((currentAccountResult as CurrentSessionResult.Success).accountInfo.userId)
-            .messages
-            .getSenderNameByMessageId(conversationId, messageId)
-
-        return if (senderNameResult is GetSenderNameByMessageIdUseCase.Result.Success) senderNameResult.name else null
-    }
-
-    private fun previouslyResumedPosition(conversationId: ConversationId, requestedAudioMessageId: String): Int? {
-        return audioMessageStateHistory[MessageIdWrapper(conversationId, requestedAudioMessageId)]?.run {
-            if (audioMediaPlayingState == AudioMediaPlayingState.Completed) {
-                0
-            } else {
-                currentPositionInMs
-            }
+        val userId = currentUserId() ?: return null
+        return when (
+            val result = coreLogic.getSessionScope(userId).messages.getSenderNameByMessageId(conversationId, messageId)
+        ) {
+            is GetSenderNameByMessageIdUseCase.Result.Success -> result.name
+            else -> null
         }
     }
 
+    private suspend fun currentUserId(): UserId? =
+        (coreLogic.getGlobalScope().session.currentSession() as? CurrentSessionResult.Success)?.accountInfo?.userId
+
     internal fun clear() {
-        audioMediaPlayer.reset()
+        playbackCoordinator.stop()
         currentAudioMessageId = null
-        audioMessageStateHistory = emptyMap()
-        servicesManager.value.stopPlayingAudioMessageService()
+        pendingDurationMs = null
+        stateStore.clear()
+        platformController.stopPlaybackService()
     }
 
     data class MessageIdWrapper(val conversationId: ConversationId, val messageId: String)
+
+    private companion object {
+        const val UPDATE_POSITION_INTERVAL_IN_MS = 1_000L
+    }
 }
 
-typealias GetAssetMessageKey = Triple<UserId, ConversationId, String>
+private typealias GetAssetMessageKey = Triple<UserId, ConversationId, String>

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioPlatformController.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/ConversationAudioPlatformController.kt
@@ -1,0 +1,46 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.android.media.audiomessage
+
+import com.wire.android.services.ServicesManager
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
+
+interface ConversationAudioPlatformController {
+    fun setFocusListener(onPause: () -> Unit, onResume: () -> Unit)
+    fun requestFocus(): Boolean
+    fun abandonFocus()
+    fun startPlaybackService()
+    fun stopPlaybackService()
+}
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<ConversationAudioPlatformController>())
+class AndroidConversationAudioPlatformController(
+    private val servicesManager: Lazy<ServicesManager>,
+    private val audioFocusHelper: AudioFocusHelper,
+) : ConversationAudioPlatformController {
+    override fun setFocusListener(onPause: () -> Unit, onResume: () -> Unit) {
+        audioFocusHelper.setListener(onPause, onResume)
+    }
+
+    override fun requestFocus(): Boolean = audioFocusHelper.request()
+
+    override fun abandonFocus() = audioFocusHelper.abandon()
+
+    override fun startPlaybackService() = servicesManager.value.startPlayingAudioMessageService()
+
+    override fun stopPlaybackService() = servicesManager.value.stopPlayingAudioMessageService()
+}

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
@@ -21,6 +21,8 @@ import android.content.Context
 import android.media.MediaPlayer
 import androidx.core.net.toUri
 import com.wire.android.di.ApplicationScope
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/model/messagetypes/audio/AudioMessageType.kt
@@ -65,13 +65,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.wire.android.R
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
 import com.wire.android.media.audiomessage.AudioMessageArgs
 import com.wire.android.media.audiomessage.AudioMessageViewModel
 import com.wire.android.media.audiomessage.AudioSpeed
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.equalizedWavesMask
 import com.wire.android.media.audiomessage.sampledWavesMask
+import com.wire.android.media.audiomessage.titleRes
 import com.wire.android.model.Clickable
 import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
@@ -104,6 +103,8 @@ import com.wire.android.util.DateAndTimeParsers
 import com.wire.android.util.ui.PreviewMultipleThemes
 import com.wire.kalium.logic.data.asset.AssetTransferStatus
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
 
 @Composable
 fun AudioMessage(

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModel.kt
@@ -31,7 +31,6 @@ import com.wire.android.BuildConfig
 import com.wire.android.di.CurrentAccount
 import com.wire.android.mapper.UserTypeMapper
 import com.wire.android.mapper.toConversationItem
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.model.BadgeEventType
@@ -60,6 +59,7 @@ import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
 import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
+import com.wire.media.player.AudioMediaPlayingState
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioButtons.kt
@@ -46,8 +46,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.sp
 import com.wire.android.R
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.ui.common.WireCheckbox
 import com.wire.android.ui.common.button.IconAlignment
 import com.wire.android.ui.common.button.WireButtonState
@@ -60,6 +58,8 @@ import com.wire.android.ui.theme.WireTheme
 import com.wire.android.ui.theme.wireDimensions
 import com.wire.android.ui.theme.wireTypography
 import com.wire.android.util.ui.PreviewMultipleThemes
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
 import kotlinx.coroutines.delay
 import okio.Path
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioState.kt
@@ -17,7 +17,7 @@
  */
 package com.wire.android.ui.home.messagecomposer.recordaudio
 
-import com.wire.android.media.audiomessage.AudioState
+import com.wire.media.player.AudioState
 import okio.Path
 
 data class RecordAudioState(

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -28,8 +28,6 @@ import androidx.lifecycle.viewModelScope
 import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.media.audiomessage.AudioFocusHelper
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.RecordAudioMessagePlayer
 import com.wire.android.media.audiomessage.toWavesMask
 import com.wire.android.ui.common.ActionsViewModel
@@ -47,6 +45,8 @@ import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow

--- a/app/src/test/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/media/audiomessage/AudioMessageViewModelTest.kt
@@ -25,6 +25,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.feature.message.ObserveMessageByIdUseCase
+import com.wire.media.player.AudioState
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify

--- a/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/media/audiomessage/ConversationAudioMessagePlayerTest.kt
@@ -1,6 +1,6 @@
 /*
  * Wire
- * Copyright (C) 2025 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,641 +17,276 @@
  */
 package com.wire.android.media.audiomessage
 
-import android.content.Context
-import android.media.MediaPlayer
-import android.media.PlaybackParams
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.wire.android.config.TestDispatcherProvider
-import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.MessageIdWrapper
-import com.wire.android.services.ServicesManager
+import com.wire.android.mediaplayer.AndroidMediaPlayerPlaybackEngineFactory
 import com.wire.kalium.common.error.NetworkFailure
+import com.wire.kalium.common.error.StorageFailure
 import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.data.auth.AccountInfo
 import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.GetMessageAssetUseCase
 import com.wire.kalium.logic.feature.asset.MessageAssetResult
-import com.wire.kalium.logic.feature.message.GetMessageByIdUseCase
+import com.wire.kalium.logic.feature.message.GetNextAudioMessageInConversationUseCase
+import com.wire.kalium.logic.feature.message.GetSenderNameByMessageIdUseCase
 import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
+import com.wire.media.player.MediaPlaybackEngine
+import com.wire.media.player.PlaybackCommand
+import com.wire.media.player.PlaybackCommandResult
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSnapshot
+import com.wire.media.player.PlaybackSource
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
+import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okio.Path
 import okio.Path.Companion.toOkioPath
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 
 private val dispatcher = UnconfinedTestDispatcher()
 
-@Suppress("LongMethod")
 class ConversationAudioMessagePlayerTest {
 
     @TempDir
     lateinit var tempDir: File
 
     @Test
-    fun givenTheSuccessfulAssetFetch_whenPlayingAudioForFirstTime_thenEmitStatesAsExpected() = runTest(dispatcher) {
-        val testAudioMessageId = "some-dummy-message-id"
-        val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val messageIdWrapper = MessageIdWrapper(conversationId, testAudioMessageId)
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-            .withAudioMediaPlayerReturningTotalTime(1000)
-            .withSuccessfulAssetFetch()
+    fun givenSuccessfulFetch_whenNativeEngineIsReady_thenPlayingStateAndPlatformEffectsAreEmitted() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val messageId = "message"
+        val key = ConversationAudioMessagePlayer.MessageIdWrapper(conversationId, messageId)
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
             .withCurrentSession()
+            .withSuccessfulAssetFetch()
             .arrange()
 
-        conversationAudioMessagePlayer.observableAudioMessagesState.test {
-            // skip first emit from onStart
-            awaitItem()
-            conversationAudioMessagePlayer.playAudio(
-                conversationId,
-                testAudioMessageId
-            )
+        player.observableAudioMessagesState.test {
+            assertTrue(awaitItem().isEmpty())
 
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
+            player.playAudio(conversationId, messageId)
 
-                val totalTime = currentState!!.totalTimeInMs
-                assert(totalTime is AudioState.TotalTimeInMs.Known)
-                assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
-            }
+            awaitState { it[key]?.audioMediaPlayingState == AudioMediaPlayingState.Fetching }
+            awaitState { it[key]?.audioMediaPlayingState == AudioMediaPlayingState.SuccessfulFetching }
+            val prepare = arrangement.engine.commands.single() as PlaybackCommand.Prepare
+            assertInstanceOf(PlaybackSource.Local::class.java, prepare.source)
+            assertTrue(prepare.playWhenReady)
+            assertEquals(1, arrangement.platform.requestFocusCalls)
 
+            arrangement.engine.emit(PlaybackEvent.Ready(durationMs = 1_000))
+
+            awaitState { states ->
+                states[key]?.let { state ->
+                    state.audioMediaPlayingState == AudioMediaPlayingState.Playing &&
+                        state.totalTimeInMs == AudioState.TotalTimeInMs.Known(1_000)
+                } == true
+            }
+            assertEquals(PlaybackCommand.Play, arrangement.engine.commands.last())
+            assertEquals(1, arrangement.platform.startServiceCalls)
             cancelAndIgnoreRemainingEvents()
         }
-
-        with(arrangement) {
-            verify { mediaPlayer.prepare() }
-            verify { mediaPlayer.setDataSource(any(), any()) }
-            verify { mediaPlayer.start() }
-
-            verify(exactly = 1) { audioFocusHelper.request() }
-            verify(exactly = 1) { servicesManager.startPlayingAudioMessageService() }
-
-            verify(exactly = 0) { mediaPlayer.seekTo(any()) }
-        }
     }
 
     @Test
-    fun givenTheSuccessfulAssetFetch_whenPlayingTheSameMessageIdTwiceSequentially_thenEmitStatesAsExpected() = runTest(dispatcher) {
-        val testAudioMessageId = "some-dummy-message-id"
-        val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val messageIdWrapper = MessageIdWrapper(conversationId, testAudioMessageId)
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-            .withSuccessfulAssetFetch()
+    fun givenPlayingMessage_whenSelectedAgain_thenPlaybackPausesAndResumes() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
             .withCurrentSession()
-            .withAudioMediaPlayerReturningTotalTime(1000)
-            .withMediaPlayerPlaying()
+            .withSuccessfulAssetFetch()
             .arrange()
 
-        conversationAudioMessagePlayer.observableAudioMessagesState.test {
-            // skip first emit from onStart
-            awaitItem()
-            // playing first time
-            conversationAudioMessagePlayer.playAudio(
-                conversationId,
-                testAudioMessageId
-            )
+        arrangement.start(player, conversationId, "message")
 
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-            }
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-            }
-            awaitItem() // currentPosition update
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
+        player.playAudio(conversationId, "message")
+        assertEquals(PlaybackCommand.Pause, arrangement.engine.commands.last())
+        assertEquals(1, arrangement.platform.abandonFocusCalls)
 
-                val totalTime = currentState!!.totalTimeInMs
-                assert(totalTime is AudioState.TotalTimeInMs.Known)
-                assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
-            }
-
-            // playing second time
-            conversationAudioMessagePlayer.playAudio(
-                conversationId,
-                testAudioMessageId
-            )
-            awaitAndAssertStateUpdate { state ->
-                val currentState = state[messageIdWrapper]
-                assert(currentState != null)
-                assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Paused)
-            }
-
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        with(arrangement) {
-            verify(exactly = 1) { mediaPlayer.prepare() }
-            verify(exactly = 1) { mediaPlayer.setDataSource(any(), any()) }
-            verify(exactly = 1) { mediaPlayer.start() }
-            verify(exactly = 1) { mediaPlayer.pause() }
-
-            verify(exactly = 0) { mediaPlayer.seekTo(any()) }
-        }
+        player.playAudio(conversationId, "message")
+        assertEquals(PlaybackCommand.Play, arrangement.engine.commands.last())
+        assertEquals(2, arrangement.platform.requestFocusCalls)
     }
 
     @Test
-    fun givenTheSuccessfulAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayed_thenEmitStatesAsExpected() =
-        runTest(dispatcher) {
-            val firstAudioMessageId = "some-dummy-message-id1"
-            val secondAudioMessageId = "some-dummy-message-id2"
-            val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-            val firstAudioMessageIdWrapper = MessageIdWrapper(conversationId, firstAudioMessageId)
-            val secondAudioMessageIdWrapper = MessageIdWrapper(conversationId, secondAudioMessageId)
-            val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-                .withSuccessfulAssetFetch()
-                .withCurrentSession()
-                .withAudioMediaPlayerReturningTotalTime(1000)
-                .arrange()
-
-            conversationAudioMessagePlayer.observableAudioMessagesState.test {
-                // skip first emit from onStart
-                awaitItem()
-                // playing first audio message
-                conversationAudioMessagePlayer.playAudio(
-                    conversationId,
-                    firstAudioMessageId
-                )
-
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    val totalTime = currentState!!.totalTimeInMs
-                    assert(totalTime is AudioState.TotalTimeInMs.Known)
-                    assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
-                }
-
-                // playing second audio message
-                conversationAudioMessagePlayer.playAudio(
-                    conversationId,
-                    secondAudioMessageId
-                )
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Stopped)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Completed)
-                }
-                awaitItem() // seekToAudioPosition
-                awaitAndAssertStateUpdate { state ->
-                    assertEquals(2, state.size)
-
-                    val currentState = state[secondAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[secondAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[secondAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-                }
-
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            with(arrangement) {
-                verify(exactly = 2) { mediaPlayer.prepare() }
-                verify(exactly = 2) { mediaPlayer.setDataSource(any(), any()) }
-                verify(exactly = 2) { mediaPlayer.start() }
-
-                verify(exactly = 0) { mediaPlayer.seekTo(any()) }
-            }
-        }
-
-    @Test
-    fun givenTheSuccessfulAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayedAndSecondResumed_thenEmitStatesAsExpected() =
-        runTest(dispatcher) {
-            val firstAudioMessageId = "some-dummy-message-id1"
-            val secondAudioMessageId = "some-dummy-message-id2"
-            val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-            val firstAudioMessageIdWrapper = MessageIdWrapper(conversationId, firstAudioMessageId)
-            val secondAudioMessageIdWrapper = MessageIdWrapper(conversationId, secondAudioMessageId)
-            val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-                .withSuccessfulAssetFetch()
-                .withCurrentSession()
-                .withAudioMediaPlayerReturningTotalTime(1000)
-                .arrange()
-
-            conversationAudioMessagePlayer.observableAudioMessagesState.test {
-                // skip first emit from onStart
-                awaitItem()
-                // playing first audio message
-                conversationAudioMessagePlayer.playAudio(
-                    conversationId,
-                    firstAudioMessageId
-                )
-
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-
-                    val totalTime = currentState!!.totalTimeInMs
-                    assert(totalTime is AudioState.TotalTimeInMs.Known)
-                    assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
-                }
-
-                // playing second audio message
-                conversationAudioMessagePlayer.playAudio(
-                    ConversationId("some-dummy-value", "some.dummy.domain"),
-                    secondAudioMessageId
-                )
-
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Stopped)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Completed)
-                }
-                awaitItem() // seekToAudioPosition
-                awaitAndAssertStateUpdate { state ->
-                    assertEquals(2, state.size)
-
-                    val currentState = state[secondAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[secondAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[secondAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-                }
-
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    val totalTime = currentState!!.totalTimeInMs
-                    assert(totalTime is AudioState.TotalTimeInMs.Known)
-                    assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
-                }
-
-                // playing first audio message again, resuming it
-                conversationAudioMessagePlayer.playAudio(
-                    ConversationId("some-dummy-value", "some.dummy.domain"),
-                    firstAudioMessageId
-                )
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[secondAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Stopped)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Completed)
-                }
-                awaitItem() // seekToAudioPosition
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[firstAudioMessageIdWrapper]
-                    assert(currentState != null)
-
-                    val totalTime = currentState!!.totalTimeInMs
-                    assert(totalTime is AudioState.TotalTimeInMs.Known)
-                    assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
-                }
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            with(arrangement) {
-                verify(exactly = 3) { mediaPlayer.prepare() }
-                verify(exactly = 3) { mediaPlayer.setDataSource(any(), any()) }
-                verify(exactly = 3) { mediaPlayer.start() }
-
-                verify(exactly = 1) { mediaPlayer.seekTo(any()) }
-            }
-        }
-
-    @Test
-    fun givenTheSuccessfulAssetFetch_whenPlayingDifferentAudioAfterFirstOneIsPlayedAndSecondStoppedAndResume_thenEmitStatesAsExpected() =
-        runTest(dispatcher) {
-            val testAudioMessageId = "some-dummy-message-id"
-            val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-            val messageIdWrapper = MessageIdWrapper(conversationId, testAudioMessageId)
-            val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-                .withSuccessfulAssetFetch()
-                .withCurrentSession()
-                .withAudioMediaPlayerReturningTotalTime(1000)
-                .withMediaPlayerPlaying()
-                .arrange()
-
-            conversationAudioMessagePlayer.observableAudioMessagesState.test {
-                // skip first emit from onStart
-                awaitItem()
-                // playing first time
-                conversationAudioMessagePlayer.playAudio(
-                    conversationId,
-                    testAudioMessageId
-                )
-
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[messageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Fetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[messageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching)
-                }
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[messageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-                }
-                awaitItem() // currentPosition update
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[messageIdWrapper]
-                    assert(currentState != null)
-                    val totalTime = currentState!!.totalTimeInMs
-                    assert(totalTime is AudioState.TotalTimeInMs.Known)
-                    assert((totalTime as AudioState.TotalTimeInMs.Known).value == 1000)
-                }
-
-                // playing second time
-                conversationAudioMessagePlayer.playAudio(
-                    conversationId,
-                    testAudioMessageId
-                )
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[messageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Paused)
-                }
-
-                // stop the media player by mocking the return value of isPlaying
-                arrangement.withMediaPlayerStopped()
-
-                // playing third time
-                conversationAudioMessagePlayer.playAudio(
-                    conversationId,
-                    testAudioMessageId
-                )
-                awaitAndAssertStateUpdate { state ->
-                    val currentState = state[messageIdWrapper]
-                    assert(currentState != null)
-                    assert(currentState!!.audioMediaPlayingState is AudioMediaPlayingState.Playing)
-                }
-
-                cancelAndIgnoreRemainingEvents()
-            }
-
-            with(arrangement) {
-                verify(exactly = 1) { mediaPlayer.prepare() }
-                verify(exactly = 1) { mediaPlayer.setDataSource(any(), any()) }
-                verify(exactly = 2) { mediaPlayer.start() }
-                verify(exactly = 1) { mediaPlayer.pause() }
-
-                verify(exactly = 0) { mediaPlayer.seekTo(any()) }
-            }
-        }
-
-    @Test
-    fun givenTheSuccessfulAssetFetch_whenAudioSpeedChanged_thenMediaPlayerParamsWereUpdated() = runTest(dispatcher) {
-        val params = PlaybackParams()
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-            .withSuccessfulAssetFetch()
+    fun givenFocusChanges_whenPlaying_thenNativePlaybackPausesAndResumes() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
             .withCurrentSession()
-            .withAudioMediaPlayerReturningParams(params)
+            .withSuccessfulAssetFetch()
             .arrange()
 
-        // when
-        conversationAudioMessagePlayer.setSpeed(AudioSpeed.MAX)
+        arrangement.start(player, conversationId, "message")
 
-        // then
-        verify(exactly = 1) { arrangement.mediaPlayer.playbackParams = params.setSpeed(2F) }
+        arrangement.platform.loseFocus()
+        assertEquals(PlaybackCommand.Pause, arrangement.engine.commands.last())
+
+        arrangement.platform.regainFocus()
+        assertEquals(PlaybackCommand.Play, arrangement.engine.commands.last())
     }
 
     @Test
-    fun givenPlayingAudioMessage_whenStopAudioCalled_thenServiceStoppedAndAudioFocusAbandoned() = runTest(dispatcher) {
-        val testAudioMessageId = "some-dummy-message-id"
-        val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-            .withAudioMediaPlayerReturningTotalTime(1000)
-            .withSuccessfulAssetFetch()
+    fun givenNextMessage_whenPlaybackCompletes_thenNextMessageIsPreparedWithoutStoppingService() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
             .withCurrentSession()
+            .withSuccessfulAssetFetch()
+            .withNextAudioMessage("second")
             .arrange()
 
-        conversationAudioMessagePlayer.observableAudioMessagesState.test {
-            // skip first emit from onStart
-            awaitItem()
-            conversationAudioMessagePlayer.playAudio(
-                conversationId,
-                testAudioMessageId
-            )
+        arrangement.start(player, conversationId, "first")
+        arrangement.engine.emit(PlaybackEvent.Completed)
 
-            conversationAudioMessagePlayer.forceToStopCurrentAudioMessage()
-
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        with(arrangement) {
-            verify(exactly = 1) { audioFocusHelper.abandon() }
-            verify(exactly = 1) { servicesManager.stopPlayingAudioMessageService() }
-        }
+        val nextPrepare = arrangement.engine.commands.last() as PlaybackCommand.Prepare
+        assertEquals(PlaybackSource.Local(arrangement.assetPath), nextPrepare.source)
+        coVerify(exactly = 1) { arrangement.getNextAudioMessage(conversationId, "first") }
+        assertEquals(0, arrangement.platform.stopServiceCalls)
+        assertEquals(0, arrangement.platform.abandonFocusCalls)
     }
 
     @Test
-    fun givenCachedSuccessfulAudioMessageFetchWithExistingFile_whenPlayingAgain_thenReuseTheSameAssetResult() = runTest(dispatcher) {
-        val audioMessageId = "some-dummy-message-id"
-        val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-            .withAudioMediaPlayerReturningTotalTime(1000)
+    fun givenNoNextMessage_whenPlaybackCompletes_thenPlaybackServiceAndFocusAreReleased() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
+            .withCurrentSession()
+            .withSuccessfulAssetFetch()
+            .arrange()
+
+        arrangement.start(player, conversationId, "message")
+        arrangement.engine.emit(PlaybackEvent.Completed)
+
+        assertEquals(1, arrangement.platform.stopServiceCalls)
+        assertEquals(1, arrangement.platform.abandonFocusCalls)
+        assertTrue(arrangement.engine.commands.contains(PlaybackCommand.Stop))
+    }
+
+    @Test
+    fun givenChangedSpeed_whenNextMessageStarts_thenSpeedIsRetainedAcrossPreparation() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
+            .withCurrentSession()
+            .withSuccessfulAssetFetch()
+            .withNextAudioMessage("second")
+            .arrange()
+
+        arrangement.start(player, conversationId, "first")
+        player.setSpeed(AudioSpeed.MAX)
+        arrangement.engine.emit(PlaybackEvent.Completed)
+        arrangement.engine.emit(PlaybackEvent.Ready(durationMs = 2_000))
+
+        assertEquals(
+            listOf(PlaybackCommand.SetSpeed(AudioSpeed.MAX), PlaybackCommand.Play),
+            arrangement.engine.commands.takeLast(2),
+        )
+    }
+
+    @Test
+    fun givenCachedAssetStillExists_whenMessageIsPlayedAgain_thenCachedResultIsReused() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
+            .withCurrentSession()
             .withSuccessfulAssetFetch(fileExists = true)
-            .withCurrentSession()
             .arrange()
 
-        conversationAudioMessagePlayer.playAudio(conversationId, audioMessageId) // play the first time
-        conversationAudioMessagePlayer.forceToStopCurrentAudioMessage() // mock the completion of the audio media player
-        conversationAudioMessagePlayer.playAudio(conversationId, audioMessageId) // play the second time
+        arrangement.start(player, conversationId, "message")
+        player.forceToStopCurrentAudioMessage()
+        player.playAudio(conversationId, "message")
 
-        with(arrangement) {
-            coVerify(exactly = 1) { // only one time because the result is cached
-                getAssetMessage(conversationId, audioMessageId)
-            }
-        }
+        coVerify(exactly = 1) { arrangement.getAssetMessage(conversationId, "message") }
     }
 
     @Test
-    fun givenCachedSuccessfulAudioMessageFetchWithNonExistingFile_whenPlayingAgain_thenGetAssetAgain() = runTest(dispatcher) {
-        val audioMessageId = "some-dummy-message-id"
-        val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-            .withAudioMediaPlayerReturningTotalTime(1000)
-            .withSuccessfulAssetFetch()
+    fun givenCachedAssetWasDeleted_whenMessageIsPlayedAgain_thenAssetIsFetchedAgain() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
             .withCurrentSession()
+            .withSuccessfulAssetFetch(fileExists = true)
             .arrange()
 
-        arrangement.withSuccessfulAssetFetch(fileExists = true) // first time the file exists
-        conversationAudioMessagePlayer.playAudio(conversationId, audioMessageId) // play the first time
-        conversationAudioMessagePlayer.forceToStopCurrentAudioMessage() // mock the completion of the audio media player
-        arrangement.withSuccessfulAssetFetch(fileExists = false) // second time the file does not exist anymore
-        conversationAudioMessagePlayer.playAudio(conversationId, audioMessageId) // play the second time
+        arrangement.start(player, conversationId, "message")
+        player.forceToStopCurrentAudioMessage()
+        arrangement.withSuccessfulAssetFetch(fileExists = false)
+        player.playAudio(conversationId, "message")
 
-        with(arrangement) {
-            coVerify(exactly = 2) { // two times because the file did not exist so it's fetched again with proper file path
-                getAssetMessage(conversationId, audioMessageId)
-            }
-        }
+        coVerify(exactly = 2) { arrangement.getAssetMessage(conversationId, "message") }
     }
 
     @Test
-    fun givenCachedFailedAudioMessageFetch_whenPlayingAgain_thenGetAssetAgain() = runTest(dispatcher) {
-        val audioMessageId = "some-dummy-message-id"
-        val conversationId = ConversationId("some-dummy-value", "some.dummy.domain")
-        val (arrangement, conversationAudioMessagePlayer) = Arrangement(tempDir)
-            .withAudioMediaPlayerReturningTotalTime(1000)
+    fun givenFailedFetch_whenMessageIsPlayed_thenFailureIsExposedWithoutPreparingNativePlayback() = runTest(dispatcher) {
+        val conversationId = testConversationId()
+        val key = ConversationAudioMessagePlayer.MessageIdWrapper(conversationId, "message")
+        val (arrangement, player) = Arrangement(tempDir, backgroundScope)
+            .withCurrentSession()
             .withFailedAssetFetch()
-            .withCurrentSession()
             .arrange()
 
-        conversationAudioMessagePlayer.playAudio(conversationId, audioMessageId) // play the first time
-        conversationAudioMessagePlayer.forceToStopCurrentAudioMessage() // mock the completion of the audio media player
-        conversationAudioMessagePlayer.playAudio(conversationId, audioMessageId) // play the second time
+        player.observableAudioMessagesState.test {
+            awaitItem()
+            player.playAudio(conversationId, "message")
 
-        with(arrangement) {
-            coVerify(exactly = 2) { // two times because the result is failed so it's fetched again
-                getAssetMessage(conversationId, audioMessageId)
-            }
+            awaitState { it[key]?.audioMediaPlayingState == AudioMediaPlayingState.Fetching }
+            awaitState { it[key]?.audioMediaPlayingState == AudioMediaPlayingState.Failed }
+            assertTrue(arrangement.engine.commands.isEmpty())
+            assertEquals(0, arrangement.platform.requestFocusCalls)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 
-    private suspend fun <T> TurbineTestContext<T>.awaitAndAssertStateUpdate(assertion: (T) -> Unit) {
-        val state = awaitItem()
-        assert(state != null)
-
-        assertion(state)
+    private suspend fun TurbineTestContext<Map<ConversationAudioMessagePlayer.MessageIdWrapper, AudioState>>.awaitState(
+        predicate: (Map<ConversationAudioMessagePlayer.MessageIdWrapper, AudioState>) -> Boolean,
+    ): Map<ConversationAudioMessagePlayer.MessageIdWrapper, AudioState> {
+        while (true) {
+            val states = awaitItem()
+            if (predicate(states)) return states
+        }
     }
+
+    private fun testConversationId() = ConversationId("conversation", "wire.test")
 }
 
-class Arrangement(private val tempDir: File) {
-
-    @MockK
-    lateinit var context: Context
-
+private class Arrangement(
+    private val tempDir: File,
+    private val testScope: CoroutineScope,
+) {
     @MockK
     lateinit var coreLogic: CoreLogic
-
-    @MockK
-    lateinit var mediaPlayer: MediaPlayer
-
-    @MockK
-    lateinit var servicesManager: ServicesManager
-
-    @MockK
-    lateinit var audioFocusHelper: AudioFocusHelper
 
     @MockK
     lateinit var getAssetMessage: GetMessageAssetUseCase
 
     @MockK
-    lateinit var getMessageById: GetMessageByIdUseCase
+    lateinit var getNextAudioMessage: GetNextAudioMessageInConversationUseCase
 
-    private val testScope: CoroutineScope = CoroutineScope(dispatcher)
+    @MockK
+    lateinit var getSenderName: GetSenderNameByMessageIdUseCase
 
-    private val conversationAudioMessagePlayer by lazy {
+    @MockK
+    lateinit var kaliumFileSystem: KaliumFileSystem
+
+    val engine = FakePlaybackEngine()
+    val platform = FakeConversationAudioPlatformController()
+    val assetPath: Path
+        get() = File(tempDir, ASSET_NAME).toOkioPath()
+
+    private val engineFactory = mockk<AndroidMediaPlayerPlaybackEngineFactory>()
+    private val player by lazy {
         ConversationAudioMessagePlayer(
-            context = context,
-            audioMediaPlayer = mediaPlayer,
-            servicesManager = lazyOf(servicesManager),
-            audioFocusHelper = audioFocusHelper,
+            engineFactory = engineFactory,
+            platformController = platform,
             coreLogic = coreLogic,
             scope = testScope,
             dispatchers = TestDispatcherProvider(dispatcher),
@@ -660,66 +295,137 @@ class Arrangement(private val tempDir: File) {
 
     init {
         MockKAnnotations.init(this, relaxed = true)
-
+        every { engineFactory.create() } returns engine
         every { coreLogic.getSessionScope(any()).messages.getAssetMessage } returns getAssetMessage
-        every { coreLogic.getSessionScope(any()).messages.getMessageById } returns getMessageById
-        every { mediaPlayer.currentPosition } returns 100
-
-        every { servicesManager.stopPlayingAudioMessageService() } returns Unit
-        every { servicesManager.startPlayingAudioMessageService() } returns Unit
-
-        every { audioFocusHelper.setListener(any(), any()) } returns Unit
-        every { audioFocusHelper.abandon() } returns Unit
-        every { audioFocusHelper.request() } returns true
+        every { coreLogic.getSessionScope(any()).messages.getNextAudioMessageInConversation } returns getNextAudioMessage
+        every { coreLogic.getSessionScope(any()).messages.getSenderNameByMessageId } returns getSenderName
+        every { coreLogic.getSessionScope(any()).kaliumFileSystem } returns kaliumFileSystem
+        every { kaliumFileSystem.exists(any()) } answers { firstArg<Path>().toFile().exists() }
+        coEvery { getNextAudioMessage(any(), any()) } returns
+            GetNextAudioMessageInConversationUseCase.Result.Failure(StorageFailure.DataNotFound)
+        coEvery { getSenderName(any(), any()) } returns
+            GetSenderNameByMessageIdUseCase.Result.Failure(StorageFailure.DataNotFound)
     }
 
     fun withCurrentSession() = apply {
-        coEvery { coreLogic.getGlobalScope().session.currentSession.invoke() } returns CurrentSessionResult.Success(
-            AccountInfo.Valid(UserId("some-user-value", "some.user.domain"))
+        coEvery { coreLogic.getGlobalScope().session.currentSession() } returns CurrentSessionResult.Success(
+            AccountInfo.Valid(UserId("user", "wire.test"))
         )
     }
 
     fun withSuccessfulAssetFetch(fileExists: Boolean = true) = apply {
-        val assetFile = File(tempDir, "some-dummy-asset-name")
-        if (fileExists) {
-            assetFile.createNewFile()
-        } else {
-            assetFile.delete()
-        }
-        coEvery {
-            getAssetMessage.invoke(any<ConversationId>(), any<String>())
-        } returns CompletableDeferred(
+        val assetFile = assetPath.toFile()
+        if (fileExists) assetFile.createNewFile() else assetFile.delete()
+        coEvery { getAssetMessage(any<ConversationId>(), any<String>()) } returns CompletableDeferred(
             MessageAssetResult.Success(
-                decodedAssetPath = assetFile.toOkioPath(),
+                decodedAssetPath = assetPath,
                 assetSize = 0,
-                assetName = "some-dummy-asset-name"
+                assetName = ASSET_NAME,
             )
         )
     }
 
     fun withFailedAssetFetch() = apply {
-        coEvery {
-            getAssetMessage.invoke(any<ConversationId>(), any<String>())
-        } returns CompletableDeferred(
+        coEvery { getAssetMessage(any<ConversationId>(), any<String>()) } returns CompletableDeferred(
             MessageAssetResult.Failure(NetworkFailure.NoNetworkConnection(null), false)
         )
     }
 
-    fun withMediaPlayerPlaying() = apply {
-        every { mediaPlayer.isPlaying } returns true
+    fun withNextAudioMessage(messageId: String) = apply {
+        coEvery { getNextAudioMessage(any(), any()) } returns
+            GetNextAudioMessageInConversationUseCase.Result.Success(messageId, "asset")
     }
 
-    fun withMediaPlayerStopped() = apply {
-        every { mediaPlayer.isPlaying } returns false
+    suspend fun start(
+        player: ConversationAudioMessagePlayer,
+        conversationId: ConversationId,
+        messageId: String,
+    ) {
+        player.playAudio(conversationId, messageId)
+        engine.emit(PlaybackEvent.Ready(durationMs = 1_000))
     }
 
-    fun withAudioMediaPlayerReturningTotalTime(total: Int) = apply {
-        every { mediaPlayer.duration } returns total
+    fun arrange() = this to player
+
+    private companion object {
+        const val ASSET_NAME = "audio.m4a"
+    }
+}
+
+private class FakePlaybackEngine : MediaPlaybackEngine {
+    val commands = mutableListOf<PlaybackCommand>()
+    private var listener: ((PlaybackEvent) -> Unit)? = null
+    private var prepared = false
+
+    override fun setEventListener(listener: ((PlaybackEvent) -> Unit)?) {
+        this.listener = listener
     }
 
-    fun withAudioMediaPlayerReturningParams(params: PlaybackParams = PlaybackParams()) = apply {
-        every { mediaPlayer.playbackParams } returns params
+    override fun execute(command: PlaybackCommand): PlaybackCommandResult {
+        commands += command
+        if (command in preparedCommands && !prepared) return PlaybackCommandResult.Failure("not_prepared")
+        when (command) {
+            is PlaybackCommand.Prepare -> prepared = false
+            PlaybackCommand.Play -> emit(PlaybackEvent.Playing)
+            PlaybackCommand.Pause -> emit(PlaybackEvent.Paused)
+            PlaybackCommand.Stop -> {
+                prepared = false
+                emit(PlaybackEvent.Stopped)
+            }
+            is PlaybackCommand.SeekTo -> emit(PlaybackEvent.PositionChanged(command.positionMs, 0))
+            is PlaybackCommand.SetMuted -> emit(PlaybackEvent.MutedChanged(command.muted))
+            is PlaybackCommand.SetSpeed -> emit(PlaybackEvent.SpeedChanged(command.speed))
+            PlaybackCommand.Release -> emit(PlaybackEvent.Released)
+        }
+        return PlaybackCommandResult.Executed
     }
 
-    fun arrange() = this to conversationAudioMessagePlayer
+    override fun snapshot(): PlaybackSnapshot? = null
+
+    fun emit(event: PlaybackEvent) {
+        if (event is PlaybackEvent.Ready) prepared = true
+        listener?.invoke(event)
+    }
+
+    private companion object {
+        val preparedCommands = setOf(
+            PlaybackCommand.Play,
+            PlaybackCommand.Pause,
+        )
+    }
+}
+
+private class FakeConversationAudioPlatformController : ConversationAudioPlatformController {
+    var requestFocusCalls = 0
+    var abandonFocusCalls = 0
+    var startServiceCalls = 0
+    var stopServiceCalls = 0
+    private var onPause: () -> Unit = {}
+    private var onResume: () -> Unit = {}
+
+    override fun setFocusListener(onPause: () -> Unit, onResume: () -> Unit) {
+        this.onPause = onPause
+        this.onResume = onResume
+    }
+
+    override fun requestFocus(): Boolean {
+        requestFocusCalls++
+        return true
+    }
+
+    override fun abandonFocus() {
+        abandonFocusCalls++
+    }
+
+    override fun startPlaybackService() {
+        startServiceCalls++
+    }
+
+    override fun stopPlaybackService() {
+        stopServiceCalls++
+    }
+
+    fun loseFocus() = onPause()
+
+    fun regainFocus() = onResume()
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelArrangement.kt
@@ -22,7 +22,6 @@ import androidx.paging.PagingData
 import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.media.audiomessage.AudioSpeed
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.MessageIdWrapper
 import com.wire.android.media.audiomessage.PlayingAudioMessage
@@ -35,6 +34,7 @@ import com.wire.content.external.FileExporter
 import com.wire.content.external.PlatformResult
 import com.wire.kalium.common.error.CoreFailure
 import com.wire.kalium.logic.data.asset.AttachmentType
+import com.wire.media.player.AudioState
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.ConversationDetails
 import com.wire.kalium.logic.data.conversation.MutedConversationStatus

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/messages/ConversationMessagesViewModelTest.kt
@@ -26,8 +26,6 @@ import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
 import com.wire.android.framework.TestMessage
 import com.wire.android.framework.TestMessage.GENERIC_ASSET_CONTENT
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer.MessageIdWrapper
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.model.UserAvatarData
@@ -48,6 +46,8 @@ import com.wire.kalium.logic.data.message.Message
 import com.wire.kalium.logic.data.message.MessageContent
 import com.wire.kalium.logic.data.message.paging.NomadMessagePagingResult
 import com.wire.kalium.logic.data.user.UserId
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
 import com.wire.kalium.logic.feature.conversation.GetConversationUnreadEventsCountUseCase
 import com.wire.kalium.network.NetworkState
 import io.mockk.coVerify

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversationslist/ConversationListViewModelTest.kt
@@ -30,8 +30,6 @@ import com.wire.android.framework.TestConversationDetails
 import com.wire.android.framework.TestConversationItem
 import com.wire.android.framework.TestUser
 import com.wire.android.mapper.UserTypeMapper
-import com.wire.android.media.audiomessage.AudioMediaPlayingState
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.ConversationAudioMessagePlayer
 import com.wire.android.media.audiomessage.PlayingAudioMessage
 import com.wire.android.ui.home.conversations.usecase.GetConversationsFromSearchUseCase
@@ -48,6 +46,8 @@ import com.wire.kalium.logic.feature.conversation.RefreshConversationsWithoutMet
 import com.wire.kalium.logic.feature.legalhold.LegalHoldStateForSelfUser
 import com.wire.kalium.logic.feature.legalhold.ObserveLegalHoldStateForSelfUserUseCase
 import com.wire.kalium.logic.feature.publicuser.RefreshUsersWithoutMetadataUseCase
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
 import com.wire.kalium.logic.feature.user.GetSelfTeamIdUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -24,7 +24,6 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.framework.FakeKaliumFileSystem
 import com.wire.android.media.audiomessage.AudioFocusHelper
-import com.wire.android.media.audiomessage.AudioState
 import com.wire.android.media.audiomessage.RecordAudioMessagePlayer
 import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModelTest.Arrangement.Companion.ASSET_SIZE_LIMIT
 import com.wire.android.util.CurrentScreen
@@ -36,6 +35,7 @@ import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
+import com.wire.media.player.AudioState
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase.AssetSizeLimits.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
 import io.mockk.MockKAnnotations

--- a/core/media-player-kmp/build.gradle.kts
+++ b/core/media-player-kmp/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id(libs.plugins.wire.kmp.library.get().pluginId)
+}
+
+kotlin {
+    android {
+        namespace = "com.wire.media.player"
+        withHostTest {}
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(libs.coroutines.core)
+                api(libs.okio.core)
+                implementation(libs.jetbrains.compose.runtime)
+            }
+        }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.coroutines.test)
+            }
+        }
+    }
+}

--- a/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/AudioPlaybackStateStore.kt
+++ b/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/AudioPlaybackStateStore.kt
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.player
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+data class AudioState(
+    val audioMediaPlayingState: AudioMediaPlayingState,
+    val currentPositionInMs: Int,
+    val totalTimeInMs: TotalTimeInMs,
+) {
+    fun sanitizeTotalTime(otherClientTotalTime: Int): TotalTimeInMs =
+        if (otherClientTotalTime != 0) TotalTimeInMs.Known(otherClientTotalTime) else totalTimeInMs
+
+    fun isPlaying(): Boolean = audioMediaPlayingState is AudioMediaPlayingState.Playing
+
+    fun isPlayingOrPaused(): Boolean = audioMediaPlayingState is AudioMediaPlayingState.Playing ||
+        audioMediaPlayingState is AudioMediaPlayingState.Paused
+
+    fun isPlayingOrPausedOrFetching(): Boolean = isPlayingOrPaused() ||
+        audioMediaPlayingState is AudioMediaPlayingState.Fetching ||
+        audioMediaPlayingState is AudioMediaPlayingState.SuccessfulFetching
+
+    sealed interface TotalTimeInMs {
+        data object NotKnown : TotalTimeInMs
+        data class Known(val value: Int) : TotalTimeInMs
+    }
+
+    companion object {
+        val DEFAULT = AudioState(AudioMediaPlayingState.Stopped, 0, TotalTimeInMs.NotKnown)
+    }
+}
+
+sealed interface AudioMediaPlayingState {
+    data object Playing : AudioMediaPlayingState
+    data object Stopped : AudioMediaPlayingState
+    data object Completed : AudioMediaPlayingState
+    data object Paused : AudioMediaPlayingState
+    data object Fetching : AudioMediaPlayingState
+    data object SuccessfulFetching : AudioMediaPlayingState
+    data object Failed : AudioMediaPlayingState
+}
+
+sealed interface AudioStateUpdate {
+    data class PlayingStateChanged(val state: AudioMediaPlayingState) : AudioStateUpdate
+    data class PositionChanged(val positionMs: Int) : AudioStateUpdate
+    data class TotalTimeChanged(val totalTimeMs: Int) : AudioStateUpdate
+}
+
+/** Platform-independent state history for independently rendered conversation audio messages. */
+class AudioPlaybackStateStore<Key> {
+    private val mutableStates = MutableStateFlow<Map<Key, AudioState>>(emptyMap())
+    val states: StateFlow<Map<Key, AudioState>> = mutableStates.asStateFlow()
+
+    fun update(key: Key, update: AudioStateUpdate) {
+        mutableStates.update { history ->
+            val current = history[key] ?: AudioState.DEFAULT
+            history + (key to current.reduce(update))
+        }
+    }
+
+    fun state(key: Key): AudioState? = states.value[key]
+
+    fun restoredPosition(key: Key): Int? = state(key)?.let { state ->
+        if (state.audioMediaPlayingState == AudioMediaPlayingState.Completed) 0 else state.currentPositionInMs
+    }
+
+    fun clear() {
+        mutableStates.value = emptyMap()
+    }
+
+    private fun AudioState.reduce(update: AudioStateUpdate): AudioState = when (update) {
+        is AudioStateUpdate.PlayingStateChanged -> copy(audioMediaPlayingState = update.state)
+        is AudioStateUpdate.PositionChanged -> copy(currentPositionInMs = update.positionMs)
+        is AudioStateUpdate.TotalTimeChanged -> copy(totalTimeInMs = AudioState.TotalTimeInMs.Known(update.totalTimeMs))
+    }
+}

--- a/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/MediaPlaybackCoordinator.kt
+++ b/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/MediaPlaybackCoordinator.kt
@@ -1,0 +1,195 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.player
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/** Common audio/video state machine. Native engines only execute commands and report events. */
+@Suppress("TooManyFunctions")
+class MediaPlaybackCoordinator(
+    private val engine: MediaPlaybackEngine,
+    private val scope: CoroutineScope,
+    private val positionPollIntervalMs: Long = DEFAULT_POSITION_POLL_INTERVAL_MS,
+) {
+    private val mutableState = MutableStateFlow(PlaybackState())
+    val state: StateFlow<PlaybackState> = mutableState.asStateFlow()
+
+    private val mutableEvents = MutableSharedFlow<PlaybackEvent>(extraBufferCapacity = EVENT_BUFFER_CAPACITY)
+    val events: SharedFlow<PlaybackEvent> = mutableEvents.asSharedFlow()
+
+    private var positionPollJob: Job? = null
+    private var playWhenReady = false
+
+    init {
+        engine.setEventListener(::onEngineEvent)
+    }
+
+    fun prepare(
+        source: PlaybackSource,
+        restoredPositionMs: Int = 0,
+        playWhenReady: Boolean = false,
+    ): PlaybackCommandResult = dispatch(
+        PlaybackCommand.Prepare(source, restoredPositionMs.coerceAtLeast(0), playWhenReady)
+    )
+
+    fun play(): PlaybackCommandResult = dispatch(PlaybackCommand.Play)
+
+    fun pause(): PlaybackCommandResult = dispatch(PlaybackCommand.Pause)
+
+    fun stop(): PlaybackCommandResult = dispatch(PlaybackCommand.Stop)
+
+    fun seekTo(positionMs: Int): PlaybackCommandResult = dispatch(
+        PlaybackCommand.SeekTo(positionMs.coerceIn(0, state.value.durationMs.coerceAtLeast(positionMs)))
+    )
+
+    fun setMuted(muted: Boolean): PlaybackCommandResult = dispatch(PlaybackCommand.SetMuted(muted))
+
+    fun toggleMute(): PlaybackCommandResult = setMuted(!state.value.isMuted)
+
+    fun setSpeed(speed: PlaybackSpeed): PlaybackCommandResult = dispatch(PlaybackCommand.SetSpeed(speed))
+
+    fun replay(): PlaybackCommandResult {
+        val seekResult = seekTo(0)
+        return if (seekResult is PlaybackCommandResult.Failure) seekResult else play()
+    }
+
+    fun togglePlayPause(): PlaybackCommandResult = when {
+        state.value.isCompleted -> replay()
+        state.value.isPlaying -> pause()
+        else -> play()
+    }
+
+    fun release(): PlaybackCommandResult = dispatch(PlaybackCommand.Release)
+
+    fun dispatch(command: PlaybackCommand): PlaybackCommandResult {
+        if (state.value.isReleased && command != PlaybackCommand.Release) return PlaybackCommandResult.Failure("released")
+        if (command is PlaybackCommand.Prepare) {
+            playWhenReady = command.playWhenReady
+            onEngineEvent(PlaybackEvent.Preparing(command.restoredPositionMs))
+        }
+
+        val result = engine.execute(command)
+        when (result) {
+            PlaybackCommandResult.Executed -> applyOptimisticEvent(command)
+            PlaybackCommandResult.Unsupported -> Unit
+            is PlaybackCommandResult.Failure -> onEngineEvent(PlaybackEvent.Failed(result.reason))
+        }
+        return result
+    }
+
+    private fun applyOptimisticEvent(command: PlaybackCommand) {
+        when (command) {
+            PlaybackCommand.Play -> onEngineEvent(PlaybackEvent.Playing)
+            PlaybackCommand.Pause -> onEngineEvent(PlaybackEvent.Paused)
+            PlaybackCommand.Stop -> onEngineEvent(PlaybackEvent.Stopped)
+            is PlaybackCommand.SeekTo -> onEngineEvent(
+                PlaybackEvent.PositionChanged(command.positionMs, state.value.durationMs)
+            )
+            is PlaybackCommand.SetMuted -> onEngineEvent(PlaybackEvent.MutedChanged(command.muted))
+            is PlaybackCommand.SetSpeed -> onEngineEvent(PlaybackEvent.SpeedChanged(command.speed))
+            PlaybackCommand.Release -> onEngineEvent(PlaybackEvent.Released)
+            is PlaybackCommand.Prepare -> Unit
+        }
+    }
+
+    private fun onEngineEvent(event: PlaybackEvent) {
+        val updatedState = mutableState.value.reduce(event)
+        if (updatedState == mutableState.value) return
+        mutableState.value = updatedState
+        mutableEvents.tryEmit(event)
+        when (event) {
+            PlaybackEvent.Playing -> startPositionPolling()
+            PlaybackEvent.Paused,
+            PlaybackEvent.Stopped,
+            PlaybackEvent.Completed,
+            PlaybackEvent.Released,
+            is PlaybackEvent.Failed -> stopPositionPolling()
+            is PlaybackEvent.Ready -> {
+                if (state.value.speed != PlaybackSpeed.NORMAL) setSpeed(state.value.speed)
+                if (state.value.isMuted) setMuted(true)
+                if (playWhenReady) {
+                    playWhenReady = false
+                    play()
+                }
+            }
+            else -> Unit
+        }
+    }
+
+    private fun startPositionPolling() {
+        if (positionPollJob?.isActive == true) return
+        positionPollJob = scope.launch {
+            while (isActive) {
+                engine.snapshot()?.let { snapshot ->
+                    onEngineEvent(
+                        PlaybackEvent.PositionChanged(snapshot.currentPositionMs, snapshot.durationMs)
+                    )
+                }
+                delay(positionPollIntervalMs)
+            }
+        }
+    }
+
+    private fun stopPositionPolling() {
+        positionPollJob?.cancel()
+        positionPollJob = null
+    }
+
+    private fun PlaybackState.reduce(event: PlaybackEvent): PlaybackState = when (event) {
+        is PlaybackEvent.Preparing -> copy(
+            isPrepared = false,
+            isPlaying = false,
+            isStarted = event.restoredPositionMs > 0,
+            isCompleted = false,
+            isBuffering = true,
+            currentPositionMs = event.restoredPositionMs,
+            failureReason = null,
+        )
+        is PlaybackEvent.Ready -> copy(
+            isPrepared = true,
+            isBuffering = false,
+            durationMs = event.durationMs.coerceAtLeast(0),
+        )
+        is PlaybackEvent.Buffering -> copy(isBuffering = event.buffering)
+        PlaybackEvent.Playing -> copy(isPlaying = true, isStarted = true, isCompleted = false)
+        PlaybackEvent.Paused -> copy(isPlaying = false)
+        PlaybackEvent.Stopped -> copy(isPlaying = false, isStarted = false, isCompleted = false, currentPositionMs = 0)
+        is PlaybackEvent.PositionChanged -> copy(
+            currentPositionMs = event.positionMs.coerceAtLeast(0),
+            durationMs = event.durationMs.coerceAtLeast(0),
+        )
+        PlaybackEvent.Completed -> copy(
+            isPlaying = false,
+            isStarted = true,
+            isCompleted = true,
+            currentPositionMs = durationMs,
+        )
+        is PlaybackEvent.MutedChanged -> copy(isMuted = event.muted)
+        is PlaybackEvent.SpeedChanged -> copy(speed = event.speed)
+        is PlaybackEvent.Failed -> copy(isPlaying = false, isBuffering = false, failureReason = event.reason)
+        PlaybackEvent.Released -> copy(isPlaying = false, isBuffering = false, isReleased = true)
+    }
+
+    private companion object {
+        const val DEFAULT_POSITION_POLL_INTERVAL_MS = 200L
+        const val EVENT_BUFFER_CAPACITY = 32
+    }
+}

--- a/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/PlaybackModels.kt
+++ b/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/PlaybackModels.kt
@@ -1,0 +1,101 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.player
+
+import okio.Path
+
+sealed interface PlaybackSource {
+    data class Local(val path: Path) : PlaybackSource
+    data class Remote(val location: String) : PlaybackSource
+}
+
+@Suppress("MagicNumber")
+enum class PlaybackSpeed(val value: Float) {
+    NORMAL(1f),
+    FAST(1.5f),
+    MAX(2f);
+
+    fun toggle(): PlaybackSpeed = when (this) {
+        NORMAL -> FAST
+        FAST -> MAX
+        MAX -> NORMAL
+    }
+
+    companion object {
+        fun fromFloat(speed: Float): PlaybackSpeed = when {
+            speed < FAST.value -> NORMAL
+            speed < MAX.value -> FAST
+            else -> MAX
+        }
+    }
+}
+
+data class PlaybackState(
+    val isPrepared: Boolean = false,
+    val isPlaying: Boolean = false,
+    val isStarted: Boolean = false,
+    val isCompleted: Boolean = false,
+    val isBuffering: Boolean = false,
+    val isMuted: Boolean = false,
+    val currentPositionMs: Int = 0,
+    val durationMs: Int = 0,
+    val speed: PlaybackSpeed = PlaybackSpeed.NORMAL,
+    val failureReason: String? = null,
+    val isReleased: Boolean = false,
+)
+
+data class PlaybackSnapshot(
+    val currentPositionMs: Int,
+    val durationMs: Int,
+)
+
+sealed interface PlaybackCommand {
+    data class Prepare(
+        val source: PlaybackSource,
+        val restoredPositionMs: Int = 0,
+        val playWhenReady: Boolean = false,
+    ) : PlaybackCommand
+
+    data object Play : PlaybackCommand
+    data object Pause : PlaybackCommand
+    data object Stop : PlaybackCommand
+    data class SeekTo(val positionMs: Int) : PlaybackCommand
+    data class SetMuted(val muted: Boolean) : PlaybackCommand
+    data class SetSpeed(val speed: PlaybackSpeed) : PlaybackCommand
+    data object Release : PlaybackCommand
+}
+
+sealed interface PlaybackEvent {
+    data class Preparing(val restoredPositionMs: Int) : PlaybackEvent
+    data class Ready(val durationMs: Int) : PlaybackEvent
+    data class Buffering(val buffering: Boolean) : PlaybackEvent
+    data object Playing : PlaybackEvent
+    data object Paused : PlaybackEvent
+    data object Stopped : PlaybackEvent
+    data class PositionChanged(val positionMs: Int, val durationMs: Int) : PlaybackEvent
+    data object Completed : PlaybackEvent
+    data class MutedChanged(val muted: Boolean) : PlaybackEvent
+    data class SpeedChanged(val speed: PlaybackSpeed) : PlaybackEvent
+    data class Failed(val reason: String? = null) : PlaybackEvent
+    data object Released : PlaybackEvent
+}
+
+sealed interface PlaybackCommandResult {
+    data object Executed : PlaybackCommandResult
+    data object Unsupported : PlaybackCommandResult
+    data class Failure(val reason: String? = null) : PlaybackCommandResult
+}
+
+interface MediaPlaybackEngine {
+    fun setEventListener(listener: ((PlaybackEvent) -> Unit)?)
+    fun execute(command: PlaybackCommand): PlaybackCommandResult
+    fun snapshot(): PlaybackSnapshot?
+}

--- a/core/media-player-kmp/src/commonTest/kotlin/com/wire/media/player/AudioPlaybackStateStoreTest.kt
+++ b/core/media-player-kmp/src/commonTest/kotlin/com/wire/media/player/AudioPlaybackStateStoreTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AudioPlaybackStateStoreTest {
+    @Test
+    fun `state history keeps message position duration and playing state independently`() {
+        val store = AudioPlaybackStateStore<String>()
+
+        store.update("first", AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Playing))
+        store.update("first", AudioStateUpdate.PositionChanged(200))
+        store.update("first", AudioStateUpdate.TotalTimeChanged(1_000))
+        store.update("second", AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Paused))
+
+        assertEquals(AudioMediaPlayingState.Playing, store.state("first")?.audioMediaPlayingState)
+        assertEquals(200, store.state("first")?.currentPositionInMs)
+        assertEquals(AudioState.TotalTimeInMs.Known(1_000), store.state("first")?.totalTimeInMs)
+        assertEquals(AudioMediaPlayingState.Paused, store.state("second")?.audioMediaPlayingState)
+        assertEquals(200, store.restoredPosition("first"))
+    }
+
+    @Test
+    fun `completed message restores from the beginning`() {
+        val store = AudioPlaybackStateStore<String>()
+        store.update("message", AudioStateUpdate.PositionChanged(800))
+        store.update("message", AudioStateUpdate.PlayingStateChanged(AudioMediaPlayingState.Completed))
+
+        assertEquals(0, store.restoredPosition("message"))
+    }
+}

--- a/core/media-player-kmp/src/commonTest/kotlin/com/wire/media/player/MediaPlaybackCoordinatorTest.kt
+++ b/core/media-player-kmp/src/commonTest/kotlin/com/wire/media/player/MediaPlaybackCoordinatorTest.kt
@@ -1,0 +1,150 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.player
+
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MediaPlaybackCoordinatorTest {
+    @Test
+    fun `prepare and native events produce common preparation and buffering state`() = runTest {
+        val engine = FakePlaybackEngine()
+        val coordinator = MediaPlaybackCoordinator(engine, backgroundScope)
+
+        coordinator.prepare(PlaybackSource.Local("/video.mp4".toPath()), restoredPositionMs = 250)
+        assertTrue(coordinator.state.value.isBuffering)
+        assertEquals(250, coordinator.state.value.currentPositionMs)
+
+        engine.emit(PlaybackEvent.Buffering(true))
+        engine.emit(PlaybackEvent.Ready(durationMs = 1_000))
+
+        assertTrue(coordinator.state.value.isPrepared)
+        assertFalse(coordinator.state.value.isBuffering)
+        assertEquals(1_000, coordinator.state.value.durationMs)
+    }
+
+    @Test
+    fun `play pause seek mute speed completion and replay share one state machine`() = runTest {
+        val engine = FakePlaybackEngine()
+        val coordinator = MediaPlaybackCoordinator(engine, backgroundScope)
+        coordinator.prepare(PlaybackSource.Remote("https://wire.test/video"))
+        engine.emit(PlaybackEvent.Ready(1_000))
+
+        coordinator.play()
+        assertTrue(coordinator.state.value.isPlaying)
+        assertTrue(coordinator.state.value.isStarted)
+
+        coordinator.seekTo(400)
+        coordinator.toggleMute()
+        coordinator.setSpeed(PlaybackSpeed.FAST)
+        assertEquals(400, coordinator.state.value.currentPositionMs)
+        assertTrue(coordinator.state.value.isMuted)
+        assertEquals(PlaybackSpeed.FAST, coordinator.state.value.speed)
+
+        coordinator.pause()
+        assertFalse(coordinator.state.value.isPlaying)
+
+        engine.emit(PlaybackEvent.Completed)
+        assertTrue(coordinator.state.value.isCompleted)
+        assertEquals(1_000, coordinator.state.value.currentPositionMs)
+
+        coordinator.togglePlayPause()
+        assertTrue(coordinator.state.value.isPlaying)
+        assertFalse(coordinator.state.value.isCompleted)
+        assertEquals(0, coordinator.state.value.currentPositionMs)
+    }
+
+    @Test
+    fun `play when ready restores position before starting`() = runTest {
+        val engine = FakePlaybackEngine()
+        val coordinator = MediaPlaybackCoordinator(engine, backgroundScope)
+
+        coordinator.prepare(
+            source = PlaybackSource.Local("/audio.m4a".toPath()),
+            restoredPositionMs = 700,
+            playWhenReady = true,
+        )
+        engine.emit(PlaybackEvent.Ready(2_000))
+
+        assertTrue(coordinator.state.value.isPlaying)
+        assertEquals(700, coordinator.state.value.currentPositionMs)
+        assertTrue(engine.commands.contains(PlaybackCommand.Play))
+    }
+
+    @Test
+    fun `playing polls native position and stopping cancels polling`() = runTest {
+        val engine = FakePlaybackEngine().apply {
+            snapshot = PlaybackSnapshot(currentPositionMs = 321, durationMs = 900)
+        }
+        val coordinator = MediaPlaybackCoordinator(engine, backgroundScope, positionPollIntervalMs = 50)
+
+        coordinator.play()
+        runCurrent()
+        assertEquals(321, coordinator.state.value.currentPositionMs)
+
+        engine.snapshot = PlaybackSnapshot(currentPositionMs = 654, durationMs = 900)
+        advanceTimeBy(50)
+        runCurrent()
+        assertEquals(654, coordinator.state.value.currentPositionMs)
+
+        coordinator.pause()
+        val snapshotsAfterPause = engine.snapshotCalls
+        advanceTimeBy(200)
+        runCurrent()
+        assertEquals(snapshotsAfterPause, engine.snapshotCalls)
+    }
+
+    @Test
+    fun `release tears down engine and rejects later commands`() = runTest {
+        val engine = FakePlaybackEngine()
+        val coordinator = MediaPlaybackCoordinator(engine, backgroundScope)
+
+        coordinator.release()
+
+        assertTrue(coordinator.state.value.isReleased)
+        assertIs<PlaybackCommandResult.Failure>(coordinator.play())
+        assertEquals(PlaybackCommand.Release, engine.commands.last())
+    }
+
+    private class FakePlaybackEngine : MediaPlaybackEngine {
+        val commands = mutableListOf<PlaybackCommand>()
+        var snapshot: PlaybackSnapshot? = null
+        var snapshotCalls: Int = 0
+        private var listener: ((PlaybackEvent) -> Unit)? = null
+
+        override fun setEventListener(listener: ((PlaybackEvent) -> Unit)?) {
+            this.listener = listener
+        }
+
+        override fun execute(command: PlaybackCommand): PlaybackCommandResult {
+            commands += command
+            return PlaybackCommandResult.Executed
+        }
+
+        override fun snapshot(): PlaybackSnapshot? {
+            snapshotCalls++
+            return snapshot
+        }
+
+        fun emit(event: PlaybackEvent) {
+            listener?.invoke(event)
+        }
+    }
+}

--- a/core/media-player/build.gradle.kts
+++ b/core/media-player/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     implementation(project(":core:di"))
     implementation(project(":core:ui-common"))
+    implementation(project(":core:media-player-kmp"))
 
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)

--- a/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/AndroidMediaPlayerPlaybackEngineFactory.kt
+++ b/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/AndroidMediaPlayerPlaybackEngineFactory.kt
@@ -1,0 +1,166 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.android.mediaplayer
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.MediaPlayer
+import android.net.Uri
+import com.wire.android.di.ApplicationContext
+import com.wire.media.player.MediaPlaybackEngine
+import com.wire.media.player.PlaybackCommand
+import com.wire.media.player.PlaybackCommandResult
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSnapshot
+import com.wire.media.player.PlaybackSource
+import dev.zacsweers.metro.Inject
+import java.io.IOException
+
+@Inject
+class AndroidMediaPlayerPlaybackEngineFactory(
+    @ApplicationContext private val context: Context,
+) {
+    fun create(): MediaPlaybackEngine = AndroidMediaPlayerPlaybackEngine(context)
+}
+
+private class AndroidMediaPlayerPlaybackEngine(
+    private val context: Context,
+) : MediaPlaybackEngine {
+    private val player = MediaPlayer().apply {
+        setAudioAttributes(
+            AudioAttributes.Builder()
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .build()
+        )
+        setOnPreparedListener {
+            prepared = true
+            if (restoredPositionMs > 0) seekTo(restoredPositionMs)
+            eventListener?.invoke(PlaybackEvent.Ready(duration.coerceAtLeast(0)))
+        }
+        setOnCompletionListener { eventListener?.invoke(PlaybackEvent.Completed) }
+        setOnErrorListener { _, what, extra ->
+            eventListener?.invoke(PlaybackEvent.Failed("media_player_error_${what}_$extra"))
+            true
+        }
+    }
+
+    private var eventListener: ((PlaybackEvent) -> Unit)? = null
+    private var prepared = false
+    private var released = false
+    private var restoredPositionMs = 0
+
+    override fun setEventListener(listener: ((PlaybackEvent) -> Unit)?) {
+        eventListener = listener
+    }
+
+    override fun execute(command: PlaybackCommand): PlaybackCommandResult = try {
+        executeCommand(command)
+    } catch (error: IOException) {
+        PlaybackCommandResult.Failure(error.message)
+    } catch (error: SecurityException) {
+        PlaybackCommandResult.Failure("permission_denied")
+    } catch (error: IllegalArgumentException) {
+        PlaybackCommandResult.Failure(error.message)
+    } catch (error: IllegalStateException) {
+        PlaybackCommandResult.Failure(error.message)
+    }
+
+    private fun executeCommand(command: PlaybackCommand): PlaybackCommandResult =
+        when (command) {
+            is PlaybackCommand.Prepare -> prepare(command)
+            PlaybackCommand.Play -> ifPrepared {
+                player.start()
+                eventListener?.invoke(PlaybackEvent.Playing)
+            }
+            PlaybackCommand.Pause -> ifPrepared {
+                if (player.isPlaying) player.pause()
+                eventListener?.invoke(PlaybackEvent.Paused)
+            }
+            PlaybackCommand.Stop -> {
+                if (!released) player.reset()
+                prepared = false
+                eventListener?.invoke(PlaybackEvent.Stopped)
+                PlaybackCommandResult.Executed
+            }
+            is PlaybackCommand.SeekTo -> ifPrepared {
+                player.seekTo(command.positionMs)
+                eventListener?.invoke(
+                    PlaybackEvent.PositionChanged(command.positionMs, player.duration.coerceAtLeast(0))
+                )
+            }
+            is PlaybackCommand.SetMuted -> ifNotReleased {
+                val volume = if (command.muted) 0f else 1f
+                player.setVolume(volume, volume)
+                eventListener?.invoke(PlaybackEvent.MutedChanged(command.muted))
+            }
+            is PlaybackCommand.SetSpeed -> ifPrepared {
+                player.playbackParams = player.playbackParams.setSpeed(command.speed.value)
+                eventListener?.invoke(PlaybackEvent.SpeedChanged(command.speed))
+            }
+            PlaybackCommand.Release -> release()
+        }
+
+    override fun snapshot(): PlaybackSnapshot? = if (!prepared || released) {
+        null
+    } else {
+        try {
+            PlaybackSnapshot(player.currentPosition.coerceAtLeast(0), player.duration.coerceAtLeast(0))
+        } catch (_: IllegalStateException) {
+            null
+        }
+    }
+
+    private fun prepare(command: PlaybackCommand.Prepare): PlaybackCommandResult = ifNotReleased {
+        player.reset()
+        prepared = false
+        restoredPositionMs = command.restoredPositionMs
+        player.setDataSource(context, command.source.toAndroidUri())
+        player.prepareAsync()
+    }
+
+    private inline fun ifPrepared(block: () -> Unit): PlaybackCommandResult =
+        if (!prepared || released) {
+            PlaybackCommandResult.Failure("not_prepared")
+        } else {
+            block()
+            PlaybackCommandResult.Executed
+        }
+
+    private inline fun ifNotReleased(block: () -> Unit): PlaybackCommandResult =
+        if (released) {
+            PlaybackCommandResult.Failure("released")
+        } else {
+            block()
+            PlaybackCommandResult.Executed
+        }
+
+    private fun release(): PlaybackCommandResult {
+        if (!released) {
+            try {
+                if (prepared) player.stop()
+            } catch (_: IllegalStateException) {
+                // Release still has to run when the native player is between states.
+            }
+            player.release()
+            prepared = false
+            released = true
+            eventListener?.invoke(PlaybackEvent.Released)
+            eventListener = null
+        }
+        return PlaybackCommandResult.Executed
+    }
+
+    private fun PlaybackSource.toAndroidUri(): Uri = when (this) {
+        is PlaybackSource.Local -> Uri.fromFile(path.toFile())
+        is PlaybackSource.Remote -> Uri.parse(location)
+    }
+}

--- a/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/AndroidVideoPlaybackEngine.kt
+++ b/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/AndroidVideoPlaybackEngine.kt
@@ -1,0 +1,157 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.android.mediaplayer
+
+import android.content.Context
+import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.PlayerView
+import com.wire.android.di.ApplicationContext
+import com.wire.media.player.MediaPlaybackEngine
+import com.wire.media.player.PlaybackCommand
+import com.wire.media.player.PlaybackCommandResult
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSnapshot
+import com.wire.media.player.PlaybackSource
+import dev.zacsweers.metro.Inject
+
+interface VideoPlaybackSurfaceController {
+    fun attach(view: PlayerView)
+    fun detach(view: PlayerView)
+}
+
+data class AndroidVideoPlaybackSession(
+    val engine: MediaPlaybackEngine,
+    val surfaceController: VideoPlaybackSurfaceController,
+)
+
+@Inject
+class AndroidVideoPlaybackSessionFactory(
+    @ApplicationContext private val context: Context,
+) {
+    fun create(): AndroidVideoPlaybackSession {
+        val engine = AndroidVideoPlaybackEngine(context)
+        return AndroidVideoPlaybackSession(engine, engine)
+    }
+}
+
+private class AndroidVideoPlaybackEngine(
+    context: Context,
+) : MediaPlaybackEngine, VideoPlaybackSurfaceController {
+    private val player = ExoPlayer.Builder(context).build()
+    private var eventListener: ((PlaybackEvent) -> Unit)? = null
+    private var restoredPositionMs = 0
+    private var released = false
+
+    private val listener = object : Player.Listener {
+        override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (isPlaying) eventListener?.invoke(PlaybackEvent.Playing)
+        }
+
+        override fun onPlaybackStateChanged(playbackState: Int) {
+            eventListener?.invoke(PlaybackEvent.Buffering(playbackState == Player.STATE_BUFFERING))
+            when (playbackState) {
+                Player.STATE_READY -> {
+                    if (restoredPositionMs > 0) {
+                        player.seekTo(restoredPositionMs.toLong())
+                        restoredPositionMs = 0
+                    }
+                    eventListener?.invoke(PlaybackEvent.Ready(player.duration.coerceAtLeast(0).toInt()))
+                }
+                Player.STATE_ENDED -> eventListener?.invoke(PlaybackEvent.Completed)
+            }
+        }
+
+        override fun onPlayerError(error: androidx.media3.common.PlaybackException) {
+            eventListener?.invoke(PlaybackEvent.Failed(error.errorCodeName))
+        }
+    }
+
+    init {
+        player.addListener(listener)
+    }
+
+    override fun setEventListener(listener: ((PlaybackEvent) -> Unit)?) {
+        eventListener = listener
+    }
+
+    override fun execute(command: PlaybackCommand): PlaybackCommandResult = if (released) {
+        PlaybackCommandResult.Failure("released")
+    } else {
+        when (command) {
+            is PlaybackCommand.Prepare -> {
+                restoredPositionMs = command.restoredPositionMs
+                player.setMediaItem(MediaItem.fromUri(command.source.toAndroidUri()))
+                player.prepare()
+            }
+            PlaybackCommand.Play -> player.play()
+            PlaybackCommand.Pause -> {
+                player.pause()
+                eventListener?.invoke(PlaybackEvent.Paused)
+            }
+            PlaybackCommand.Stop -> {
+                player.stop()
+                eventListener?.invoke(PlaybackEvent.Stopped)
+            }
+            is PlaybackCommand.SeekTo -> {
+                player.seekTo(command.positionMs.toLong())
+                eventListener?.invoke(
+                    PlaybackEvent.PositionChanged(command.positionMs, player.duration.coerceAtLeast(0).toInt())
+                )
+            }
+            is PlaybackCommand.SetMuted -> {
+                player.volume = if (command.muted) 0f else 1f
+                eventListener?.invoke(PlaybackEvent.MutedChanged(command.muted))
+            }
+            is PlaybackCommand.SetSpeed -> {
+                player.setPlaybackSpeed(command.speed.value)
+                eventListener?.invoke(PlaybackEvent.SpeedChanged(command.speed))
+            }
+            PlaybackCommand.Release -> return release()
+        }
+        PlaybackCommandResult.Executed
+    }
+
+    override fun snapshot(): PlaybackSnapshot? = if (released) {
+        null
+    } else {
+        PlaybackSnapshot(
+            currentPositionMs = player.currentPosition.coerceAtLeast(0).toInt(),
+            durationMs = player.duration.coerceAtLeast(0).toInt(),
+        )
+    }
+
+    override fun attach(view: PlayerView) {
+        view.player = player
+    }
+
+    override fun detach(view: PlayerView) {
+        if (view.player === player) {
+            view.player = null
+        }
+    }
+
+    private fun release(): PlaybackCommandResult {
+        player.removeListener(listener)
+        player.release()
+        released = true
+        eventListener?.invoke(PlaybackEvent.Released)
+        eventListener = null
+        return PlaybackCommandResult.Executed
+    }
+
+    private fun PlaybackSource.toAndroidUri(): Uri = when (this) {
+        is PlaybackSource.Local -> Uri.fromFile(path.toFile())
+        is PlaybackSource.Remote -> Uri.parse(location)
+    }
+}

--- a/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/VideoPlaybackState.kt
+++ b/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/VideoPlaybackState.kt
@@ -17,12 +17,4 @@
  */
 package com.wire.android.mediaplayer
 
-data class VideoPlaybackState(
-    val isPlaying: Boolean = false,
-    val isStarted: Boolean = false,
-    val isCompleted: Boolean = false,
-    val isBuffering: Boolean = false,
-    val isMuted: Boolean = false,
-    val currentPositionMs: Int = 0,
-    val durationMs: Int = 0,
-)
+typealias VideoPlaybackState = com.wire.media.player.PlaybackState

--- a/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/VideoPlayer.kt
+++ b/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/VideoPlayer.kt
@@ -83,7 +83,6 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.PlayerView
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
@@ -117,7 +116,7 @@ fun VideoPlayer(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     VideoPlayerContent(
-        player = viewModel.player,
+        surfaceController = viewModel.surfaceController,
         state = state,
         localPath = viewModel.localPath,
         fileName = viewModel.fileName,
@@ -132,7 +131,7 @@ fun VideoPlayer(
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 internal fun VideoPlayerContent(
-    player: ExoPlayer,
+    surfaceController: VideoPlaybackSurfaceController,
     state: VideoPlaybackState,
     localPath: String?,
     fileName: String?,
@@ -234,9 +233,9 @@ internal fun VideoPlayerContent(
         }
     }
 
-   fun stopAndNavigateBack() {
+    fun stopAndNavigateBack() {
         isExiting = true
-        player.pause()
+        if (state.isPlaying) onTogglePlayPause()
         context.findActivity()?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
         onNavigateBack()
     }
@@ -277,13 +276,13 @@ internal fun VideoPlayerContent(
                 AndroidView(
                     factory = { ctx ->
                         PlayerView(ctx).apply {
-                            setPlayer(player)
+                            surfaceController.attach(this)
                             useController = false
                             setBackgroundColor(android.graphics.Color.BLACK)
                         }
                     },
                     modifier = Modifier.fillMaxSize(),
-                    onRelease = { it.player = null },
+                    onRelease = { surfaceController.detach(it) },
                 )
             }
 
@@ -500,11 +499,15 @@ private fun Int.toTimeString(): String {
 @MultipleThemePreviews
 @Composable
 fun PreviewCellVideoViewerScreen() {
-    val context = LocalContext.current
-    val player = remember { ExoPlayer.Builder(context).build() }
+    val surfaceController = remember {
+        object : VideoPlaybackSurfaceController {
+            override fun attach(view: PlayerView) = Unit
+            override fun detach(view: PlayerView) = Unit
+        }
+    }
     WireTheme {
         VideoPlayerContent(
-            player = player,
+            surfaceController = surfaceController,
             state = VideoPlaybackState(),
             localPath = null,
             fileName = "video.mp4",

--- a/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/VideoPlayerViewModel.kt
+++ b/core/media-player/src/main/kotlin/com/wire/android/mediaplayer/VideoPlayerViewModel.kt
@@ -17,27 +17,16 @@
  */
 package com.wire.android.mediaplayer
 
-import android.content.Context
-import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.media3.common.MediaItem
-import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
-import com.wire.android.di.ApplicationContext
 import com.wire.android.di.metro.WireAssistedViewModelBinding
+import com.wire.media.player.MediaPlaybackCoordinator
+import com.wire.media.player.PlaybackSource
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
-import java.io.File
+import okio.Path.Companion.toPath
 
 /**
  * Plays a single video from either a local file ([localPath]) or a remote URL ([contentUrl]).
@@ -47,7 +36,7 @@ import java.io.File
  */
 @WireAssistedViewModelBinding(MediaPlayerManualViewModelFactoryGroup::class)
 class VideoPlayerViewModel @AssistedInject constructor(
-    @ApplicationContext context: Context,
+    sessionFactory: AndroidVideoPlaybackSessionFactory,
     @Assisted val localPath: String?,
     @Assisted val contentUrl: String?,
     @Assisted val fileName: String?,
@@ -57,120 +46,47 @@ class VideoPlayerViewModel @AssistedInject constructor(
         fun create(localPath: String?, contentUrl: String?, fileName: String?): VideoPlayerViewModel
     }
 
-    // Held in the ViewModel so playback survives configuration changes (e.g. rotating to full screen)
-    // without re-buffering the media.
-    val player: ExoPlayer = ExoPlayer.Builder(context).build()
-
-    private val _state = MutableStateFlow(
-        VideoPlaybackState(
-            isPlaying = player.isPlaying,
-            isStarted = player.currentPosition > 0L || player.isPlaying,
-            isCompleted = player.playbackState == Player.STATE_ENDED,
-            isBuffering = player.playbackState == Player.STATE_BUFFERING,
-            isMuted = player.volume == 0f,
-            currentPositionMs = player.currentPosition.toInt(),
-            durationMs = player.duration.coerceAtLeast(0).toInt(),
-        )
-    )
-    val state: StateFlow<VideoPlaybackState> = _state.asStateFlow()
-
-    private var positionPollJob: Job? = null
-
-    private val playerListener = object : Player.Listener {
-        override fun onIsPlayingChanged(playing: Boolean) {
-            _state.update { it.copy(isPlaying = playing) }
-            if (playing) startPositionPolling() else stopPositionPolling()
-        }
-
-        override fun onPlaybackStateChanged(playbackState: Int) {
-            _state.update { it.copy(isBuffering = playbackState == Player.STATE_BUFFERING) }
-            when (playbackState) {
-                Player.STATE_READY -> _state.update {
-                    it.copy(durationMs = player.duration.coerceAtLeast(0).toInt())
-                }
-
-                Player.STATE_ENDED -> _state.update { it.copy(isCompleted = true) }
-            }
-        }
-    }
+    private val playbackSession = sessionFactory.create()
+    private val coordinator = MediaPlaybackCoordinator(playbackSession.engine, viewModelScope)
+    val state: StateFlow<VideoPlaybackState> = coordinator.state
+    internal val surfaceController: VideoPlaybackSurfaceController = playbackSession.surfaceController
 
     init {
-        player.addListener(playerListener)
-        videoUri()?.let {
-            player.setMediaItem(MediaItem.fromUri(it))
-            player.prepare()
-        }
-        if (player.isPlaying) startPositionPolling()
+        playbackSource()?.let(coordinator::prepare)
     }
 
     fun play() {
-        player.play()
-        _state.update { it.copy(isStarted = true, isCompleted = false) }
+        coordinator.play()
     }
 
     fun pause() {
-        player.pause()
+        coordinator.pause()
     }
 
     fun replay() {
-        player.seekTo(0)
-        play()
+        coordinator.replay()
     }
 
     fun togglePlayPause() {
-        val current = _state.value
-        when {
-            current.isCompleted -> replay()
-            current.isPlaying -> pause()
-            else -> play()
-        }
+        coordinator.togglePlayPause()
     }
 
     fun toggleMute() {
-        val muted = !_state.value.isMuted
-        player.volume = if (muted) 0f else 1f
-        _state.update { it.copy(isMuted = muted) }
+        coordinator.toggleMute()
     }
 
     fun seekTo(positionMs: Long) {
-        player.seekTo(positionMs)
-        _state.update { it.copy(currentPositionMs = positionMs.toInt()) }
+        coordinator.seekTo(positionMs.toInt())
     }
 
-    private fun startPositionPolling() {
-        if (positionPollJob?.isActive == true) return
-        positionPollJob = viewModelScope.launch {
-            while (isActive) {
-                _state.update {
-                    it.copy(
-                        currentPositionMs = player.currentPosition.toInt(),
-                        durationMs = player.duration.coerceAtLeast(0).toInt(),
-                    )
-                }
-                delay(POSITION_POLL_MS)
-            }
-        }
-    }
-
-    private fun stopPositionPolling() {
-        positionPollJob?.cancel()
-        positionPollJob = null
-    }
-
-    private fun videoUri(): Uri? = when {
-        localPath != null -> Uri.fromFile(File(localPath))
-        contentUrl != null -> Uri.parse(contentUrl)
+    private fun playbackSource(): PlaybackSource? = when {
+        localPath != null -> PlaybackSource.Local(localPath.toPath())
+        contentUrl != null -> PlaybackSource.Remote(contentUrl)
         else -> null
     }
 
     override fun onCleared() {
+        coordinator.release()
         super.onCleared()
-        stopPositionPolling()
-        player.removeListener(playerListener)
-        player.release()
-    }
-
-    private companion object {
-        const val POSITION_POLL_MS = 200L
     }
 }

--- a/core/media-player/src/test/kotlin/com/wire/android/mediaplayer/MediaPlayerAssistedFactorySourceTest.kt
+++ b/core/media-player/src/test/kotlin/com/wire/android/mediaplayer/MediaPlayerAssistedFactorySourceTest.kt
@@ -22,13 +22,16 @@ internal class MediaPlayerAssistedFactorySourceTest {
         val graph = source("MediaPlayerViewModelGraph.kt")
 
         assertTrue(viewModel.contains("class VideoPlayerViewModel @AssistedInject constructor"))
-        assertTrue(viewModel.contains("@ApplicationContext context: Context"))
+        assertTrue(viewModel.contains("sessionFactory: AndroidVideoPlaybackSessionFactory"))
         assertTrue(viewModel.contains("@Assisted val localPath: String?"))
         assertTrue(viewModel.contains("@Assisted val contentUrl: String?"))
         assertTrue(viewModel.contains("@Assisted val fileName: String?"))
         assertTrue(viewModel.contains("@AssistedFactory\n    interface Factory"))
         assertTrue(viewModel.contains("@WireAssistedViewModelBinding(MediaPlayerManualViewModelFactoryGroup::class)"))
         assertTrue(graph.contains("@WireAssistedViewModelFactoryGroup"))
+        assertFalse(viewModel.contains("Context"))
+        assertFalse(viewModel.contains("ExoPlayer"))
+        assertFalse(viewModel.contains("java.io.File"))
         assertFalse(File("src/main/kotlin/com/wire/android/mediaplayer/MediaPlayerMetroViewModelBindings.kt").exists())
         assertFalse(File("src/main/kotlin/com/wire/android/mediaplayer/MediaPlayerViewModelFactory.kt").exists())
     }

--- a/core/media-player/src/test/kotlin/com/wire/android/mediaplayer/VideoPlayerViewModelTest.kt
+++ b/core/media-player/src/test/kotlin/com/wire/android/mediaplayer/VideoPlayerViewModelTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package com.wire.android.mediaplayer
+
+import androidx.lifecycle.ViewModel
+import com.wire.android.config.CoroutineTestExtension
+import com.wire.media.player.MediaPlaybackEngine
+import com.wire.media.player.PlaybackCommand
+import com.wire.media.player.PlaybackCommandResult
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSnapshot
+import com.wire.media.player.PlaybackSource
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(CoroutineTestExtension::class)
+class VideoPlayerViewModelTest {
+    @Test
+    fun givenLocalPath_whenCreated_thenCommonEnginePreparesLocalSource() = runTest {
+        val (arrangement, viewModel) = Arrangement(localPath = "/tmp/video.mp4").arrange()
+
+        assertEquals(
+            PlaybackSource.Local("/tmp/video.mp4".toPath()),
+            (arrangement.engine.commands.single() as PlaybackCommand.Prepare).source,
+        )
+        assertSame(arrangement.surfaceController, viewModel.surfaceController)
+    }
+
+    @Test
+    fun givenRemoteUrl_whenCreated_thenCommonEnginePreparesRemoteSource() = runTest {
+        val (arrangement, _) = Arrangement(contentUrl = "https://wire.test/video.mp4").arrange()
+
+        assertEquals(
+            PlaybackSource.Remote("https://wire.test/video.mp4"),
+            (arrangement.engine.commands.single() as PlaybackCommand.Prepare).source,
+        )
+    }
+
+    @Test
+    fun givenNativeEvents_whenControllingPlayback_thenCommonStateTracksPlayback() = runTest {
+        val (arrangement, viewModel) = Arrangement(localPath = "/tmp/video.mp4").arrange()
+        arrangement.engine.emit(PlaybackEvent.Buffering(true))
+        assertTrue(viewModel.state.value.isBuffering)
+
+        arrangement.engine.emit(PlaybackEvent.Ready(durationMs = 5_000))
+        viewModel.play()
+        viewModel.seekTo(1_250)
+        viewModel.toggleMute()
+        viewModel.pause()
+
+        assertTrue(viewModel.state.value.isPrepared)
+        assertFalse(viewModel.state.value.isPlaying)
+        assertEquals(1_250, viewModel.state.value.currentPositionMs)
+        assertEquals(5_000, viewModel.state.value.durationMs)
+        assertTrue(viewModel.state.value.isMuted)
+        assertEquals(
+            listOf(
+                PlaybackCommand.Play,
+                PlaybackCommand.SeekTo(1_250),
+                PlaybackCommand.SetMuted(true),
+                PlaybackCommand.Pause,
+            ),
+            arrangement.engine.commands.takeLast(4),
+        )
+    }
+
+    @Test
+    fun givenCompletedPlayback_whenToggled_thenReplayStartsAtBeginningAndReleaseTearsDownEngine() = runTest {
+        val (arrangement, viewModel) = Arrangement(localPath = "/tmp/video.mp4").arrange()
+        arrangement.engine.emit(PlaybackEvent.Ready(durationMs = 5_000))
+        arrangement.engine.emit(PlaybackEvent.Completed)
+
+        viewModel.togglePlayPause()
+
+        assertEquals(PlaybackCommand.SeekTo(0), arrangement.engine.commands.takeLast(2).first())
+        assertEquals(PlaybackCommand.Play, arrangement.engine.commands.last())
+        assertTrue(viewModel.state.value.isPlaying)
+
+        arrangement.clear(viewModel)
+        assertEquals(PlaybackCommand.Release, arrangement.engine.commands.last())
+        assertTrue(viewModel.state.value.isReleased)
+    }
+
+    private class Arrangement(
+        private val localPath: String? = null,
+        private val contentUrl: String? = null,
+    ) {
+        val engine = FakePlaybackEngine()
+        val surfaceController = mockk<VideoPlaybackSurfaceController>(relaxed = true)
+        private val sessionFactory = mockk<AndroidVideoPlaybackSessionFactory>()
+
+        init {
+            every { sessionFactory.create() } returns AndroidVideoPlaybackSession(engine, surfaceController)
+        }
+
+        fun arrange() = this to VideoPlayerViewModel(
+            sessionFactory = sessionFactory,
+            localPath = localPath,
+            contentUrl = contentUrl,
+            fileName = "video.mp4",
+        )
+
+        fun clear(viewModel: ViewModel) {
+            val method = ViewModel::class.java.getDeclaredMethod("onCleared")
+            method.isAccessible = true
+            method.invoke(viewModel)
+        }
+    }
+
+    private class FakePlaybackEngine : MediaPlaybackEngine {
+        val commands = mutableListOf<PlaybackCommand>()
+        private var listener: ((PlaybackEvent) -> Unit)? = null
+
+        override fun setEventListener(listener: ((PlaybackEvent) -> Unit)?) {
+            this.listener = listener
+        }
+
+        override fun execute(command: PlaybackCommand): PlaybackCommandResult {
+            commands += command
+            when (command) {
+                PlaybackCommand.Play -> emit(PlaybackEvent.Playing)
+                PlaybackCommand.Pause -> emit(PlaybackEvent.Paused)
+                PlaybackCommand.Stop -> emit(PlaybackEvent.Stopped)
+                PlaybackCommand.Release -> emit(PlaybackEvent.Released)
+                else -> Unit
+            }
+            return PlaybackCommandResult.Executed
+        }
+
+        override fun snapshot(): PlaybackSnapshot? = null
+
+        fun emit(event: PlaybackEvent) {
+            listener?.invoke(event)
+        }
+    }
+}

--- a/features/cells/build.gradle.kts
+++ b/features/cells/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(project(":core:navigation"))
     implementation(project(":core:ui-common"))
     implementation(project(":core:media-player"))
+    implementation(project(":core:media-player-kmp"))
     implementation(project(":core:content-kmp"))
     implementation(libs.compose.activity)
     implementation(libs.androidx.core)

--- a/features/cells/src/main/java/com/wire/android/feature/cells/navigation/CellsNavigation3Renderer.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/navigation/CellsNavigation3Renderer.kt
@@ -56,7 +56,6 @@ import com.wire.android.feature.cells.ui.versioning.VersionHistoryRouteScreen
 import com.wire.android.mediaplayer.VideoPlayer
 import com.wire.android.navigation.navigation3.WireNavigation3ResultType
 import com.wire.android.navigation.navigation3.WireNavigation3Runtime
-import androidx.compose.ui.platform.LocalContext
 import com.wire.android.feature.cells.ui.search.sort.SortCriteriaNavArg
 import com.wire.navigation.WireBackStackMode
 import com.wire.navigation.WireNavResult
@@ -239,7 +238,6 @@ internal fun CellsNavigation3RouteScreen(
         is AudioPlayerRoute -> CellAudioPlayerRouteScreen(
             onNavigateBack = navigateBack,
             viewModel = cellAudioPlayerViewModel(
-                LocalContext.current,
                 AudioPlayerNavArgs(route.localPath, route.contentUrl, route.fileName),
             ),
         )

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsMetroViewModelBindings.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsMetroViewModelBindings.kt
@@ -64,7 +64,7 @@ internal interface CellsManualViewModelFactory : ManualViewModelAssistedFactory 
     fun addRemoveTags(navArgs: AddRemoveTagsNavArgs): AddRemoveTagsViewModel
     fun versionHistory(navArgs: VersionHistoryNavArgs): VersionHistoryViewModel
     fun imageViewer(navArgs: CellImageViewerNavArgs): CellImageViewerViewModel
-    fun audioPlayer(context: android.content.Context, navArgs: AudioPlayerNavArgs): AudioPlayerViewModel
+    fun audioPlayer(navArgs: AudioPlayerNavArgs): AudioPlayerViewModel
 }
 
 @BindingContainer
@@ -105,7 +105,7 @@ object CellsMetroViewModelBindings {
             override fun addRemoveTags(navArgs: AddRemoveTagsNavArgs) = addRemoveTagsFactory.create(navArgs)
             override fun versionHistory(navArgs: VersionHistoryNavArgs) = versionHistoryFactory.create(navArgs)
             override fun imageViewer(navArgs: CellImageViewerNavArgs) = imageViewerFactory.create(navArgs)
-            override fun audioPlayer(context: android.content.Context, navArgs: AudioPlayerNavArgs) =
-                audioPlayerFactory.create(context, navArgs.localPath, navArgs.contentUrl, navArgs.fileName)
+            override fun audioPlayer(navArgs: AudioPlayerNavArgs) =
+                audioPlayerFactory.create(navArgs.localPath, navArgs.contentUrl, navArgs.fileName)
         }
 }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellsViewModelGraph.kt
@@ -113,9 +113,8 @@ internal fun cellImageViewerViewModel(navArgs: CellImageViewerNavArgs): CellImag
 
 @Composable
 internal fun cellAudioPlayerViewModel(
-    context: android.content.Context,
     navArgs: AudioPlayerNavArgs,
 ): AudioPlayerViewModel =
     wireAssistedMetroViewModel<AudioPlayerViewModel, CellsManualViewModelFactory> {
-        audioPlayer(context, navArgs)
+        audioPlayer(navArgs)
     }

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/audioplayer/AudioPlaybackState.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/audioplayer/AudioPlaybackState.kt
@@ -17,10 +17,4 @@
  */
 package com.wire.android.feature.cells.ui.audioplayer
 
-data class AudioPlaybackState(
-    val isPlaying: Boolean = false,
-    val isCompleted: Boolean = false,
-    val isPrepared: Boolean = false,
-    val currentPositionMs: Int = 0,
-    val durationMs: Int = 0,
-)
+typealias AudioPlaybackState = com.wire.media.player.PlaybackState

--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/audioplayer/AudioPlayerViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/audioplayer/AudioPlayerViewModel.kt
@@ -17,26 +17,19 @@
  */
 package com.wire.android.feature.cells.ui.audioplayer
 
-import android.content.Context
-import android.media.MediaPlayer
-import android.net.Uri
-import java.io.File
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.mediaplayer.AndroidMediaPlayerPlaybackEngineFactory
+import com.wire.media.player.MediaPlaybackCoordinator
+import com.wire.media.player.PlaybackSource
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
+import okio.Path.Companion.toPath
 
 class AudioPlayerViewModel @AssistedInject constructor(
-    @Assisted context: Context,
+    engineFactory: AndroidMediaPlayerPlaybackEngineFactory,
     @Assisted val localPath: String?,
     @Assisted val contentUrl: String?,
     @Assisted val fileName: String?,
@@ -44,99 +37,40 @@ class AudioPlayerViewModel @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(context: Context, localPath: String?, contentUrl: String?, fileName: String?): AudioPlayerViewModel
+        fun create(localPath: String?, contentUrl: String?, fileName: String?): AudioPlayerViewModel
     }
 
-    private val _state = MutableStateFlow(AudioPlaybackState())
-    val state: StateFlow<AudioPlaybackState> = _state.asStateFlow()
-
-    private var positionPollJob: Job? = null
-
-    private val mediaPlayer = MediaPlayer().apply {
-        setOnPreparedListener { mp ->
-            _state.update { it.copy(durationMs = mp.duration, isPrepared = true) }
-        }
-        setOnCompletionListener {
-            stopPositionPolling()
-            _state.update { it.copy(isPlaying = false, isCompleted = true) }
-        }
-    }
+    private val coordinator = MediaPlaybackCoordinator(engineFactory.create(), viewModelScope)
+    val state: StateFlow<AudioPlaybackState> = coordinator.state
 
     init {
-        try {
-            audioUri()?.let { uri ->
-                mediaPlayer.setDataSource(context, uri)
-                mediaPlayer.prepareAsync()
-            }
-        } catch (_: Exception) {
-            // handle silently — file may not exist yet
-        }
+        playbackSource()?.let(coordinator::prepare)
     }
 
     fun play() {
-        if (!_state.value.isPrepared) return
-        mediaPlayer.start()
-        _state.update { it.copy(isPlaying = true, isCompleted = false) }
-        startPositionPolling()
+        coordinator.play()
     }
 
     fun pause() {
-        if (!_state.value.isPlaying) return
-        mediaPlayer.pause()
-        stopPositionPolling()
-        _state.update { it.copy(isPlaying = false) }
+        coordinator.pause()
     }
 
     fun togglePlayPause() {
-        val current = _state.value
-        when {
-            current.isCompleted -> {
-                seekTo(0)
-                play()
-            }
-            current.isPlaying -> pause()
-            else -> play()
-        }
+        coordinator.togglePlayPause()
     }
 
     fun seekTo(positionMs: Int) {
-        mediaPlayer.seekTo(positionMs)
-        _state.update { it.copy(currentPositionMs = positionMs) }
+        coordinator.seekTo(positionMs)
     }
 
-    private fun startPositionPolling() {
-        if (positionPollJob?.isActive == true) return
-        positionPollJob = viewModelScope.launch {
-            while (isActive) {
-                _state.update { it.copy(currentPositionMs = mediaPlayer.currentPosition) }
-                delay(POSITION_POLL_MS)
-            }
-        }
-    }
-
-    private fun stopPositionPolling() {
-        positionPollJob?.cancel()
-        positionPollJob = null
-    }
-
-    private fun audioUri(): Uri? = when {
-        localPath != null -> Uri.fromFile(File(localPath))
-        contentUrl != null -> Uri.parse(contentUrl)
+    private fun playbackSource(): PlaybackSource? = when {
+        localPath != null -> PlaybackSource.Local(localPath.toPath())
+        contentUrl != null -> PlaybackSource.Remote(contentUrl)
         else -> null
     }
 
     override fun onCleared() {
+        coordinator.release()
         super.onCleared()
-        stopPositionPolling()
-        try {
-            mediaPlayer.stop()
-        } catch (_: Exception) {
-            // ignore — player may not be in a stoppable state
-        }
-        mediaPlayer.release()
-    }
-
-    private companion object {
-        const val POSITION_POLL_MS = 200L
     }
 }

--- a/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/audioplayer/AudioPlayerViewModelTest.kt
+++ b/features/cells/src/test/kotlin/com/wire/android/feature/cells/ui/audioplayer/AudioPlayerViewModelTest.kt
@@ -6,33 +6,23 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+
 package com.wire.android.feature.cells.ui.audioplayer
 
-import android.content.Context
-import android.media.MediaPlayer
-import android.net.Uri
 import androidx.lifecycle.ViewModel
 import com.wire.android.config.CoroutineTestExtension
-import io.mockk.Runs
+import com.wire.android.mediaplayer.AndroidMediaPlayerPlaybackEngineFactory
+import com.wire.media.player.MediaPlaybackEngine
+import com.wire.media.player.PlaybackCommand
+import com.wire.media.player.PlaybackCommandResult
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSnapshot
+import com.wire.media.player.PlaybackSource
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.mockkStatic
-import io.mockk.slot
-import io.mockk.unmockkAll
-import io.mockk.verify
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterEach
+import okio.Path.Companion.toPath
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -41,52 +31,37 @@ import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(CoroutineTestExtension::class)
 class AudioPlayerViewModelTest {
-
-    @AfterEach
-    fun tearDown() {
-        unmockkAll()
-    }
-
     @Test
-    fun givenLocalPath_whenInitialized_thenDataSourceIsSetWithFileUriAndPrepared() = runTest {
+    fun givenLocalPath_whenInitialized_thenCommonEnginePreparesLocalSource() = runTest {
         val (arrangement, _) = Arrangement()
             .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
             .arrange()
 
-        verify { Uri.fromFile(any()) }
-        verify { anyConstructed<MediaPlayer>().setDataSource(arrangement.context, arrangement.fileUri) }
-        verify { anyConstructed<MediaPlayer>().prepareAsync() }
+        assertEquals(
+            PlaybackSource.Local("/tmp/audio.mp3".toPath()),
+            (arrangement.engine.commands.single() as PlaybackCommand.Prepare).source,
+        )
     }
 
     @Test
-    fun givenContentUrl_whenInitialized_thenDataSourceIsSetWithParsedUri() = runTest {
+    fun givenContentUrl_whenInitialized_thenCommonEnginePreparesRemoteSource() = runTest {
         val (arrangement, _) = Arrangement()
             .withNavArgs(AudioPlayerNavArgs(contentUrl = "https://wire.com/audio.mp3"))
             .arrange()
 
-        verify { Uri.parse("https://wire.com/audio.mp3") }
-        verify { anyConstructed<MediaPlayer>().setDataSource(arrangement.context, arrangement.contentUri) }
-        verify { anyConstructed<MediaPlayer>().prepareAsync() }
+        assertEquals(
+            PlaybackSource.Remote("https://wire.com/audio.mp3"),
+            (arrangement.engine.commands.single() as PlaybackCommand.Prepare).source,
+        )
     }
 
     @Test
-    fun givenNoSource_whenInitialized_thenDataSourceIsNotSet() = runTest {
-        Arrangement()
+    fun givenNoSource_whenInitialized_thenEngineIsNotPrepared() = runTest {
+        val (arrangement, _) = Arrangement()
             .withNavArgs(AudioPlayerNavArgs())
             .arrange()
 
-        verify(exactly = 0) { anyConstructed<MediaPlayer>().setDataSource(any<Context>(), any<Uri>()) }
-        verify(exactly = 0) { anyConstructed<MediaPlayer>().prepareAsync() }
-    }
-
-    @Test
-    fun givenSetDataSourceThrows_whenInitialized_thenExceptionIsHandledSilently() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .withSetDataSourceThrowing()
-            .arrange()
-
-        assertFalse(viewModel.state.value.isPrepared)
+        assertTrue(arrangement.engine.commands.isEmpty())
     }
 
     @Test
@@ -107,225 +82,98 @@ class AudioPlayerViewModelTest {
     }
 
     @Test
-    fun givenPlayerPrepares_whenOnPrepared_thenStateHasDurationAndIsPrepared() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .withDuration(5000)
-            .arrange()
+    fun givenPlayerPrepares_whenReadyEventArrives_thenStateHasDurationAndIsPrepared() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
 
-        arrangement.triggerPrepared()
+        arrangement.engine.emit(PlaybackEvent.Ready(5_000))
 
-        assertEquals(5000, viewModel.state.value.durationMs)
+        assertEquals(5_000, viewModel.state.value.durationMs)
         assertTrue(viewModel.state.value.isPrepared)
     }
 
     @Test
-    fun givenNotPrepared_whenPlay_thenNothingHappens() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
+    fun givenNotPrepared_whenPlay_thenStateReportsFailureAndDoesNotPlay() = runTest {
+        val (_, viewModel) = Arrangement().arrange()
 
         viewModel.play()
 
-        verify(exactly = 0) { anyConstructed<MediaPlayer>().start() }
         assertFalse(viewModel.state.value.isPlaying)
+        assertEquals("not_prepared", viewModel.state.value.failureReason)
     }
 
     @Test
-    fun givenPrepared_whenPlay_thenStartsAndUpdatesStateAndPollsPosition() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .withCurrentPosition(42)
-            .arrange()
-        arrangement.triggerPrepared()
+    fun givenPrepared_whenPlayAndPause_thenCommonStateAndCommandsAreUpdated() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        arrangement.engine.emit(PlaybackEvent.Ready(5_000))
 
         viewModel.play()
+        assertTrue(viewModel.state.value.isPlaying)
+        assertEquals(PlaybackCommand.Play, arrangement.engine.commands.last())
 
-        verify { anyConstructed<MediaPlayer>().start() }
+        viewModel.pause()
+        assertFalse(viewModel.state.value.isPlaying)
+        assertEquals(PlaybackCommand.Pause, arrangement.engine.commands.last())
+    }
+
+    @Test
+    fun givenCompleted_whenTogglePlayPause_thenSeeksToStartAndPlays() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        arrangement.engine.emit(PlaybackEvent.Ready(5_000))
+        arrangement.engine.emit(PlaybackEvent.Completed)
+
+        viewModel.togglePlayPause()
+
+        assertEquals(PlaybackCommand.SeekTo(0), arrangement.engine.commands.takeLast(2).first())
+        assertEquals(PlaybackCommand.Play, arrangement.engine.commands.last())
         assertTrue(viewModel.state.value.isPlaying)
         assertFalse(viewModel.state.value.isCompleted)
-        assertEquals(42, viewModel.state.value.currentPositionMs)
 
         arrangement.clear(viewModel)
     }
 
     @Test
-    fun givenNotPlaying_whenPause_thenNothingHappens() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
+    fun whenSeekTo_thenEngineSeeksAndStateIsUpdated() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        arrangement.engine.emit(PlaybackEvent.Ready(5_000))
 
-        viewModel.pause()
+        viewModel.seekTo(1_234)
 
-        verify(exactly = 0) { anyConstructed<MediaPlayer>().pause() }
-    }
-
-    @Test
-    fun givenPlaying_whenPause_thenPausesAndUpdatesState() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
-        arrangement.triggerPrepared()
-        viewModel.play()
-
-        viewModel.pause()
-
-        verify { anyConstructed<MediaPlayer>().pause() }
-        assertFalse(viewModel.state.value.isPlaying)
-    }
-
-    @Test
-    fun givenNotPlaying_whenTogglePlayPause_thenStartsPlaying() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
-        arrangement.triggerPrepared()
-
-        viewModel.togglePlayPause()
-
-        verify { anyConstructed<MediaPlayer>().start() }
-        assertTrue(viewModel.state.value.isPlaying)
-
-        arrangement.clear(viewModel) // stop the position-polling loop before runTest drains the scheduler
-    }
-
-    @Test
-    fun givenPlaying_whenTogglePlayPause_thenPauses() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
-        arrangement.triggerPrepared()
-        viewModel.play()
-
-        viewModel.togglePlayPause()
-
-        verify { anyConstructed<MediaPlayer>().pause() }
-        assertFalse(viewModel.state.value.isPlaying)
-    }
-
-    @Test
-    fun givenCompleted_whenTogglePlayPause_thenSeeksToStartAndPlays() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
-        arrangement.triggerPrepared()
-        arrangement.triggerCompletion()
-
-        viewModel.togglePlayPause()
-
-        verify { anyConstructed<MediaPlayer>().seekTo(0) }
-        verify { anyConstructed<MediaPlayer>().start() }
-        assertTrue(viewModel.state.value.isPlaying)
-        assertFalse(viewModel.state.value.isCompleted)
-
-        arrangement.clear(viewModel) // stop the position-polling loop before runTest drains the scheduler
-    }
-
-    @Test
-    fun whenSeekTo_thenMediaPlayerSeeksAndStateUpdated() = runTest {
-        val (_, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
-
-        viewModel.seekTo(1234)
-
-        verify { anyConstructed<MediaPlayer>().seekTo(1234) }
-        assertEquals(1234, viewModel.state.value.currentPositionMs)
+        assertEquals(PlaybackCommand.SeekTo(1_234), arrangement.engine.commands.last())
+        assertEquals(1_234, viewModel.state.value.currentPositionMs)
     }
 
     @Test
     fun givenPlaying_whenCompletionFires_thenStateIsCompletedAndNotPlaying() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
-        arrangement.triggerPrepared()
+        val (arrangement, viewModel) = Arrangement().arrange()
+        arrangement.engine.emit(PlaybackEvent.Ready(5_000))
         viewModel.play()
 
-        arrangement.triggerCompletion()
+        arrangement.engine.emit(PlaybackEvent.Completed)
 
         assertFalse(viewModel.state.value.isPlaying)
         assertTrue(viewModel.state.value.isCompleted)
     }
 
     @Test
-    fun whenCleared_thenPlayerIsStoppedAndReleased() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .arrange()
+    fun whenCleared_thenCommonEngineIsReleased() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
 
         arrangement.clear(viewModel)
 
-        verify { anyConstructed<MediaPlayer>().stop() }
-        verify { anyConstructed<MediaPlayer>().release() }
-    }
-
-    @Test
-    fun givenStopThrows_whenCleared_thenReleaseIsStillCalled() = runTest {
-        val (arrangement, viewModel) = Arrangement()
-            .withNavArgs(AudioPlayerNavArgs(localPath = "/tmp/audio.mp3"))
-            .withStopThrowing()
-            .arrange()
-
-        arrangement.clear(viewModel)
-
-        verify { anyConstructed<MediaPlayer>().release() }
+        assertEquals(PlaybackCommand.Release, arrangement.engine.commands.last())
+        assertTrue(viewModel.state.value.isReleased)
     }
 
     private class Arrangement {
-
-        val context = mockk<Context>(relaxed = true)
-        val fileUri = mockk<Uri>()
-        val contentUri = mockk<Uri>()
-
-        private val preparedMp = mockk<MediaPlayer>(relaxed = true)
-        private val preparedListenerSlot = slot<MediaPlayer.OnPreparedListener>()
-        private val completionListenerSlot = slot<MediaPlayer.OnCompletionListener>()
-
+        val engine = FakePlaybackEngine()
+        private val engineFactory = mockk<AndroidMediaPlayerPlaybackEngineFactory>()
         private var navArgs = AudioPlayerNavArgs(localPath = "/tmp/audio.mp3")
 
         init {
-            mockkStatic(Uri::class)
-            every { Uri.fromFile(any()) } returns fileUri
-            every { Uri.parse(any()) } returns contentUri
-
-            mockkConstructor(MediaPlayer::class)
-            every { anyConstructed<MediaPlayer>().setOnPreparedListener(capture(preparedListenerSlot)) } just Runs
-            every { anyConstructed<MediaPlayer>().setOnCompletionListener(capture(completionListenerSlot)) } just Runs
-            every { anyConstructed<MediaPlayer>().setDataSource(any<Context>(), any<Uri>()) } just Runs
-            every { anyConstructed<MediaPlayer>().prepareAsync() } just Runs
-            every { anyConstructed<MediaPlayer>().start() } just Runs
-            every { anyConstructed<MediaPlayer>().pause() } just Runs
-            every { anyConstructed<MediaPlayer>().seekTo(any<Int>()) } just Runs
-            every { anyConstructed<MediaPlayer>().stop() } just Runs
-            every { anyConstructed<MediaPlayer>().release() } just Runs
-            every { anyConstructed<MediaPlayer>().currentPosition } returns 0
+            every { engineFactory.create() } returns engine
         }
 
         fun withNavArgs(args: AudioPlayerNavArgs) = apply { navArgs = args }
-
-        fun withDuration(durationMs: Int) = apply {
-            every { preparedMp.duration } returns durationMs
-        }
-
-        fun withCurrentPosition(positionMs: Int) = apply {
-            every { anyConstructed<MediaPlayer>().currentPosition } returns positionMs
-        }
-
-        fun withSetDataSourceThrowing() = apply {
-            every { anyConstructed<MediaPlayer>().setDataSource(any<Context>(), any<Uri>()) } throws RuntimeException("boom")
-        }
-
-        fun withStopThrowing() = apply {
-            every { anyConstructed<MediaPlayer>().stop() } throws IllegalStateException("boom")
-        }
-
-        fun triggerPrepared() {
-            preparedListenerSlot.captured.onPrepared(preparedMp)
-        }
-
-        fun triggerCompletion() {
-            completionListenerSlot.captured.onCompletion(preparedMp)
-        }
 
         fun clear(viewModel: ViewModel) {
             val method = ViewModel::class.java.getDeclaredMethod("onCleared")
@@ -333,13 +181,41 @@ class AudioPlayerViewModelTest {
             method.invoke(viewModel)
         }
 
-        fun arrange(): Pair<Arrangement, AudioPlayerViewModel> {
-            return this to AudioPlayerViewModel(
-                context = context,
-                localPath = navArgs.localPath,
-                contentUrl = navArgs.contentUrl,
-                fileName = navArgs.fileName,
-            )
+        fun arrange(): Pair<Arrangement, AudioPlayerViewModel> = this to AudioPlayerViewModel(
+            engineFactory = engineFactory,
+            localPath = navArgs.localPath,
+            contentUrl = navArgs.contentUrl,
+            fileName = navArgs.fileName,
+        )
+    }
+
+    private class FakePlaybackEngine : MediaPlaybackEngine {
+        val commands = mutableListOf<PlaybackCommand>()
+        private var listener: ((PlaybackEvent) -> Unit)? = null
+        private var prepared = false
+
+        override fun setEventListener(listener: ((PlaybackEvent) -> Unit)?) {
+            this.listener = listener
+        }
+
+        override fun execute(command: PlaybackCommand): PlaybackCommandResult {
+            commands += command
+            if (command == PlaybackCommand.Play && !prepared) return PlaybackCommandResult.Failure("not_prepared")
+            when (command) {
+                PlaybackCommand.Play -> emit(PlaybackEvent.Playing)
+                PlaybackCommand.Pause -> emit(PlaybackEvent.Paused)
+                PlaybackCommand.Stop -> emit(PlaybackEvent.Stopped)
+                PlaybackCommand.Release -> emit(PlaybackEvent.Released)
+                else -> Unit
+            }
+            return PlaybackCommandResult.Executed
+        }
+
+        override fun snapshot(): PlaybackSnapshot? = null
+
+        fun emit(event: PlaybackEvent) {
+            if (event is PlaybackEvent.Ready) prepared = true
+            listener?.invoke(event)
         }
     }
 }


### PR DESCRIPTION
## Intent
Move reusable audio and video playback state and orchestration behind a common coordinator.

## Changes
- introduce core/media-player-kmp with shared playback state, events, commands, speed, and coordination
- adapt VideoPlayer, Cells audio, conversation audio, list, and message state holders to common playback contracts
- separate ConversationAudioMessagePlayer orchestration from Android engines and services
- keep ExoPlayer, MediaPlayer, audio focus, foreground services, polling resources, and lifecycle ownership in Android adapters
- preserve prepare, buffer, seek, replay, mute, completion, next-message, speed, focus, service, and restored-position behavior

## Scope note
Current develop did not contain the referenced core/media-player-kmp module or VideoPlaybackCoordinator, so this PR introduces the focused module and coordinator instead of extending a pre-existing implementation.

## Stack
Builds on [PR 1](https://github.com/wireapp/wire-android/pull/5221), [PR 2](https://github.com/wireapp/wire-android/pull/5222), and [PR 3](https://github.com/wireapp/wire-android/pull/5223).