### PR TITLE
refactor(media): add common recording boundaries PR 5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -214,6 +214,7 @@ dependencies {
     implementationWithCoverage(projects.core.media)
     implementationWithCoverage(projects.core.mediaPlayer)
     implementation(projects.core.mediaPlayerKmp)
+    implementation(projects.core.audioRecordingKmp)
     implementation(projects.core.contentKmp)
     implementationWithCoverage(projects.core.notification)
     implementationWithCoverage(projects.core.navigation)

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/AudioState.kt
@@ -21,7 +21,6 @@ import androidx.annotation.StringRes
 import com.wire.android.R
 import com.wire.android.util.ui.UIText
 import com.wire.kalium.logic.data.id.ConversationId
-import com.wire.media.player.AudioMediaPlayingState
 import com.wire.media.player.AudioState
 
 typealias AudioSpeed = com.wire.media.player.PlaybackSpeed
@@ -54,40 +53,3 @@ val AudioSpeed.titleRes: Int
         AudioSpeed.FAST -> R.string.audio_speed_1_5
         AudioSpeed.MAX -> R.string.audio_speed_2
     }
-
-sealed class AudioMediaPlayerStateUpdate(
-    open val conversationId: ConversationId,
-    open val messageId: String
-) {
-    data class AudioMediaPlayingStateUpdate(
-        override val conversationId: ConversationId,
-        override val messageId: String,
-        val audioMediaPlayingState: AudioMediaPlayingState
-    ) : AudioMediaPlayerStateUpdate(conversationId, messageId)
-
-    data class PositionChangeUpdate(
-        override val conversationId: ConversationId,
-        override val messageId: String,
-        val position: Int
-    ) : AudioMediaPlayerStateUpdate(conversationId, messageId)
-
-    data class TotalTimeUpdate(
-        override val conversationId: ConversationId,
-        override val messageId: String,
-        val totalTimeInMs: Int
-    ) : AudioMediaPlayerStateUpdate(conversationId, messageId)
-}
-
-sealed class RecordAudioMediaPlayerStateUpdate {
-    data class RecordAudioMediaPlayingStateUpdate(
-        val audioMediaPlayingState: AudioMediaPlayingState
-    ) : RecordAudioMediaPlayerStateUpdate()
-
-    data class PositionChangeUpdate(
-        val position: Int
-    ) : RecordAudioMediaPlayerStateUpdate()
-
-    data class TotalTimeUpdate(
-        val totalTimeInMs: Int
-    ) : RecordAudioMediaPlayerStateUpdate()
-}

--- a/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
+++ b/app/src/main/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayer.kt
@@ -6,231 +6,149 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+
 package com.wire.android.media.audiomessage
 
-import android.content.Context
-import android.media.MediaPlayer
-import androidx.core.net.toUri
 import com.wire.android.di.ApplicationScope
+import com.wire.android.mediaplayer.AndroidMediaPlayerPlaybackEngineFactory
 import com.wire.media.player.AudioMediaPlayingState
 import com.wire.media.player.AudioState
+import com.wire.media.player.MediaPlaybackCoordinator
+import com.wire.media.player.PlaybackCommandResult
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSource
+import com.wire.media.recording.RecordingCapabilityResult
+import com.wire.media.recording.RecordingPreview
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import okio.Path
-import dev.zacsweers.metro.Inject
-class RecordAudioMessagePlayer @Inject constructor(
-    private val context: Context,
-    private val audioMediaPlayer: MediaPlayer,
+
+@Inject
+@ContributesBinding(AppScope::class, binding = binding<RecordingPreview>())
+class RecordAudioMessagePlayer(
+    engineFactory: AndroidMediaPlayerPlaybackEngineFactory,
     private val audioFocusHelper: AudioFocusHelper,
-    @ApplicationScope private val scope: CoroutineScope
-) {
+    @ApplicationScope private val scope: CoroutineScope,
+) : RecordingPreview {
+    private val coordinator = MediaPlaybackCoordinator(
+        engine = engineFactory.create(),
+        scope = scope,
+        positionPollIntervalMs = UPDATE_POSITION_INTERVAL_IN_MS,
+    )
+    private val mutableState = MutableStateFlow(AudioState.DEFAULT)
+    override val state: StateFlow<AudioState> = mutableState.asStateFlow()
     private var currentAudioFile: Path? = null
-    private var audioState: AudioState = AudioState.DEFAULT
+    private val playbackEventsJob: Job
 
     init {
-        audioMediaPlayer.setOnCompletionListener {
-            if (currentAudioFile != null) {
-                audioMessageStateUpdate.tryEmit(
-                    RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
-                        AudioMediaPlayingState.Completed
-                    )
-                )
-                seekToAudioPosition.tryEmit(0)
-            }
+        playbackEventsJob = scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            coordinator.events.collect(::handlePlaybackEvent)
         }
-
         audioFocusHelper.setListener(
-            onPauseCurrentAudio = { scope.launch { pause() } },
-            onResumeCurrentAudio = { scope.launch { resumeAudio() } }
+            onPauseCurrentAudio = { pause() },
+            onResumeCurrentAudio = { resume() },
         )
     }
 
-    private val audioMessageStateUpdate =
-        MutableSharedFlow<RecordAudioMediaPlayerStateUpdate>(
-            extraBufferCapacity = 1
-        )
-
-    // MediaPlayer API does not have any mechanism that would inform us about the currentPosition,
-    // in a callback manner, therefore we need to create a timer manually that ticks every 1 second
-    // and emits the current position
-    private val mediaPlayerPosition = flow {
-        while (true) {
-            delay(UPDATE_POSITION_INTERVAL_IN_MS)
-            if (currentAudioFile != null && audioMediaPlayer.isPlaying) {
-                emit(audioMediaPlayer.currentPosition)
+    override fun toggle(path: Path): RecordingCapabilityResult<Unit> {
+        val result = if (currentAudioFile == path) {
+            if (coordinator.state.value.isPlaying) {
+                audioFocusHelper.abandon()
+                coordinator.pause()
+            } else if (audioFocusHelper.request()) {
+                coordinator.play()
+            } else {
+                PlaybackCommandResult.Failure("audio_focus_denied")
             }
-        }
-    }.distinctUntilChanged()
-
-    private val seekToAudioPosition =
-        MutableSharedFlow<Int>(
-            onBufferOverflow = BufferOverflow.DROP_OLDEST,
-            extraBufferCapacity = 1
-        )
-
-    private val positionChangedUpdate = merge(mediaPlayerPosition, seekToAudioPosition)
-        .map { position ->
-            currentAudioFile?.let {
-                RecordAudioMediaPlayerStateUpdate.PositionChangeUpdate(position)
-            }
-        }.filterNotNull()
-
-    // Flow collecting the audio message state updates as well as the audio position updates.
-    // The collected value is updated for our single recorded audio.
-    // The audio position can be either updated manually by the user or from the Slider component or
-    // from the player itself.
-    val audioMessageStateFlow: Flow<AudioState> =
-        merge(positionChangedUpdate, audioMessageStateUpdate).map { audioStateUpdate ->
-            when (audioStateUpdate) {
-                is RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate -> {
-                    audioState = audioState.copy(
-                        audioMediaPlayingState = audioStateUpdate.audioMediaPlayingState
-                    )
-                }
-
-                is RecordAudioMediaPlayerStateUpdate.PositionChangeUpdate -> {
-                    audioState = audioState.copy(
-                        currentPositionInMs = audioStateUpdate.position
-                    )
-                }
-
-                is RecordAudioMediaPlayerStateUpdate.TotalTimeUpdate -> {
-                    audioState = audioState.copy(
-                        totalTimeInMs = AudioState.TotalTimeInMs.Known(
-                            value = audioStateUpdate.totalTimeInMs
-                        )
-                    )
-                }
-            }
-
-            audioState
-        }
-
-    suspend fun playAudio(
-        audioFile: Path
-    ) {
-        if (currentAudioFile != null && audioFile.name == currentAudioFile?.name) {
-            resumeOrPauseAudio()
         } else {
-            stopCurrentlyPlayingAudioMessage()
-            playAudioMessage(
-                audioFile = audioFile,
-                position = previouslyResumedPosition()
+            coordinator.stop()
+            currentAudioFile = path
+            if (audioFocusHelper.request()) {
+                coordinator.prepare(PlaybackSource.Local(path), playWhenReady = true)
+            } else {
+                currentAudioFile = null
+                PlaybackCommandResult.Failure("audio_focus_denied")
+            }
+        }
+        return result.asRecordingResult()
+    }
+
+    override fun seekTo(positionMs: Int): RecordingCapabilityResult<Unit> =
+        if (currentAudioFile == null) {
+            RecordingCapabilityResult.Failure("preview_unavailable")
+        } else {
+            coordinator.seekTo(positionMs).asRecordingResult()
+        }
+
+    override fun stop(): RecordingCapabilityResult<Unit> {
+        currentAudioFile = null
+        audioFocusHelper.abandon()
+        val result = coordinator.stop()
+        mutableState.value = AudioState.DEFAULT
+        return result.asRecordingResult()
+    }
+
+    override fun release() {
+        currentAudioFile = null
+        audioFocusHelper.abandon()
+        coordinator.release()
+        playbackEventsJob.cancel()
+        mutableState.value = AudioState.DEFAULT
+    }
+
+    private fun pause() {
+        if (currentAudioFile != null) coordinator.pause()
+    }
+
+    private fun resume() {
+        if (currentAudioFile != null) coordinator.play()
+    }
+
+    private fun handlePlaybackEvent(event: PlaybackEvent) {
+        mutableState.value = when (event) {
+            is PlaybackEvent.Ready -> mutableState.value.copy(
+                totalTimeInMs = AudioState.TotalTimeInMs.Known(event.durationMs)
             )
-        }
-    }
-
-    private fun previouslyResumedPosition(): Int =
-        if (audioState.audioMediaPlayingState == AudioMediaPlayingState.Completed) {
-            0
-        } else {
-            audioState.currentPositionInMs
-        }
-
-    private suspend fun stopCurrentlyPlayingAudioMessage() {
-        if (currentAudioFile != null) {
-            stop()
-        }
-    }
-
-    private suspend fun resumeOrPauseAudio() {
-        if (audioMediaPlayer.isPlaying) {
-            pause()
-            audioFocusHelper.abandon()
-        } else {
-            audioFocusHelper.request()
-            resumeAudio()
-        }
-    }
-
-    private suspend fun playAudioMessage(
-        audioFile: Path,
-        position: Int
-    ) {
-        currentAudioFile = audioFile
-
-        audioMediaPlayer.setDataSource(
-            context,
-            audioFile.toFile().toUri()
-        )
-        audioFocusHelper.request()
-        audioMediaPlayer.prepare()
-        audioMediaPlayer.seekTo(position)
-        audioMediaPlayer.start()
-
-        audioMessageStateUpdate.emit(
-            RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
+            PlaybackEvent.Playing -> mutableState.value.copy(
                 audioMediaPlayingState = AudioMediaPlayingState.Playing
             )
-        )
-
-        audioMessageStateUpdate.emit(
-            RecordAudioMediaPlayerStateUpdate.TotalTimeUpdate(
-                totalTimeInMs = audioMediaPlayer.duration
+            PlaybackEvent.Paused -> mutableState.value.copy(
+                audioMediaPlayingState = AudioMediaPlayingState.Paused
             )
-        )
-    }
-
-    suspend fun setPosition(position: Int) {
-        if (currentAudioFile != null) {
-            audioMediaPlayer.seekTo(position)
-            seekToAudioPosition.emit(position)
-        }
-    }
-
-    private suspend fun resumeAudio() {
-        if (currentAudioFile != null) {
-            audioMediaPlayer.start()
-            audioMessageStateUpdate.emit(
-                RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
-                    audioMediaPlayingState = AudioMediaPlayingState.Playing
+            is PlaybackEvent.PositionChanged -> mutableState.value.copy(
+                currentPositionInMs = event.positionMs,
+                totalTimeInMs = AudioState.TotalTimeInMs.Known(event.durationMs),
+            )
+            PlaybackEvent.Completed -> {
+                audioFocusHelper.abandon()
+                mutableState.value.copy(
+                    audioMediaPlayingState = AudioMediaPlayingState.Completed,
+                    currentPositionInMs = 0,
                 )
-            )
+            }
+            PlaybackEvent.Stopped -> AudioState.DEFAULT
+            is PlaybackEvent.Failed -> {
+                audioFocusHelper.abandon()
+                mutableState.value.copy(audioMediaPlayingState = AudioMediaPlayingState.Failed)
+            }
+            else -> mutableState.value
         }
     }
 
-    private suspend fun pause() {
-        if (currentAudioFile != null) {
-            audioMediaPlayer.pause()
-            audioMessageStateUpdate.emit(
-                RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
-                    AudioMediaPlayingState.Paused
-                )
-            )
-        }
-    }
-
-    suspend fun stop() {
-        currentAudioFile = null
-        audioMediaPlayer.reset()
-        audioMessageStateUpdate.emit(
-            RecordAudioMediaPlayerStateUpdate.RecordAudioMediaPlayingStateUpdate(
-                audioMediaPlayingState = AudioMediaPlayingState.Stopped
-            )
-        )
-    }
-
-    fun close() {
-        audioFocusHelper.abandon()
-        audioMediaPlayer.release()
+    private fun PlaybackCommandResult.asRecordingResult(): RecordingCapabilityResult<Unit> = when (this) {
+        PlaybackCommandResult.Executed -> RecordingCapabilityResult.Success(Unit)
+        PlaybackCommandResult.Unsupported -> RecordingCapabilityResult.Unsupported
+        is PlaybackCommandResult.Failure -> RecordingCapabilityResult.Failure(reason)
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/wire/android/platform/AndroidPlatformFeedback.kt
+++ b/app/src/main/kotlin/com/wire/android/platform/AndroidPlatformFeedback.kt
@@ -1,0 +1,36 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.android.platform
+
+import com.wire.android.R
+import com.wire.android.media.PingRinger
+import com.wire.media.player.PlatformFeedback
+import com.wire.media.player.PlatformFeedbackResult
+import com.wire.media.player.PlatformFeedbackType
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
+
+@Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class, binding = binding<PlatformFeedback>())
+class AndroidPlatformFeedback(
+    private val pingRinger: PingRinger,
+) : PlatformFeedback {
+    override fun perform(type: PlatformFeedbackType): PlatformFeedbackResult = when (type) {
+        PlatformFeedbackType.OUTGOING_PING -> {
+            pingRinger.ping(R.raw.ping_from_me, isReceivingPing = false)
+            PlatformFeedbackResult.Performed
+        }
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModel.kt
@@ -23,11 +23,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.wire.android.R
 import com.wire.android.appLogger
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.feature.analytics.model.AnalyticsEvent
-import com.wire.android.media.PingRinger
 import com.wire.android.media.audiomessage.toNormalizedLoudness
 import com.wire.android.model.SnackBarMessage
 import com.wire.android.ui.home.conversations.AssetTooLargeDialogState
@@ -77,6 +75,8 @@ import com.wire.kalium.logic.feature.message.draft.RemoveMessageDraftUseCase
 import com.wire.kalium.logic.feature.message.linkpreview.DetectLinkPreviewTargetUseCase
 import com.wire.kalium.logic.feature.message.linkpreview.GenerateLinkPreviewUseCase
 import com.wire.kalium.logic.feature.message.linkpreview.LinkPreviewTarget
+import com.wire.media.player.PlatformFeedback
+import com.wire.media.player.PlatformFeedbackType
 import com.wire.kalium.logic.data.message.linkpreview.MessageLinkPreview
 import com.wire.kalium.logic.data.message.mention.MessageMention
 import dev.zacsweers.metro.Assisted
@@ -107,7 +107,7 @@ class SendMessageViewModel @AssistedInject constructor(
     private val assetImporter: AssetImporter,
     private val sendKnock: SendKnockUseCase,
     private val sendTypingEvent: SendTypingEventUseCase,
-    private val pingRinger: PingRinger,
+    private val platformFeedback: PlatformFeedback,
     private val mediaMetadataReader: MediaMetadataReader,
     private val setUserInformedAboutVerification: SetUserInformedAboutVerificationUseCase,
     private val observeDegradedConversationNotified: ObserveDegradedConversationNotifiedUseCase,
@@ -331,7 +331,7 @@ class SendMessageViewModel @AssistedInject constructor(
             }
 
             is Ping -> {
-                pingRinger.ping(R.raw.ping_from_me, isReceivingPing = false)
+                platformFeedback.perform(PlatformFeedbackType.OUTGOING_PING)
                 sendKnock(conversationId = messageBundle.conversationId, hotKnock = false)
                     .toEither()
                     .handleLegalHoldFailureAfterSendingMessage(messageBundle.conversationId)

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/AudioMediaRecorder.kt
@@ -22,19 +22,29 @@ import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaCodec
 import android.media.MediaCodecInfo
-import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.media.MediaMuxer
 import android.media.MediaRecorder
 import android.os.ParcelFileDescriptor
 import com.wire.android.appLogger
+import com.wire.android.di.metro.MetroSessionScope
+import com.wire.android.media.audiomessage.AudioFocusHelper
 import com.wire.android.util.dispatchers.DispatcherProvider
 import com.wire.android.util.fileDateTime
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase.AssetSizeLimits.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import com.wire.kalium.util.DateTimeUtil
+import com.wire.media.recording.AudioRecorder
+import com.wire.media.recording.AudioRecorderEvent
+import com.wire.media.recording.AudioRecordingFiles
+import com.wire.media.recording.RecordingCapabilityResult
+import com.wire.media.recording.RecordingInterruption
+import com.wire.media.recording.RecordingSizePolicy
+import dev.zacsweers.metro.ContributesBinding
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.binding
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
@@ -47,17 +57,20 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import okio.Path
 import okio.buffer
-import java.io.File
 import java.io.FileInputStream
 import java.io.IOException
 import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
-import dev.zacsweers.metro.Inject
-class AudioMediaRecorder @Inject constructor(
+
+@Inject
+@ContributesBinding(MetroSessionScope::class, binding = binding<AudioRecorder>())
+@Suppress("TooManyFunctions") // Native recording and codec lifecycle stay together at the Android boundary.
+class AudioMediaRecorder(
     private val kaliumFileSystem: KaliumFileSystem,
-    private val dispatcherProvider: DispatcherProvider
-) {
+    private val dispatcherProvider: DispatcherProvider,
+    private val audioFocusHelper: AudioFocusHelper,
+) : AudioRecorder {
 
     private val scope by lazy {
         CoroutineScope(SupervisorJob() + dispatcherProvider.io())
@@ -66,18 +79,91 @@ class AudioMediaRecorder @Inject constructor(
     private var audioRecorder: AudioRecord? = null
     private var recordingJob: Job? = null
     private var isRecording = false
-    private var assetLimitInMB: Long = ASSET_SIZE_DEFAULT_LIMIT_BYTES
+    private var assetLimitInBytes: Long = ASSET_SIZE_DEFAULT_LIMIT_BYTES
 
-    var originalOutputPath: Path? = null
-    var m4aOutputPath: Path? = null
+    private var originalOutputPath: Path? = null
+    private var m4aOutputPath: Path? = null
 
-    private val _maxFileSizeReached = MutableSharedFlow<RecordAudioDialogState>()
-    fun getMaxFileSizeReached(): Flow<RecordAudioDialogState> =
-        _maxFileSizeReached.asSharedFlow()
+    private val mutableEvents = MutableSharedFlow<AudioRecorderEvent>(extraBufferCapacity = 1)
+    override val events: Flow<AudioRecorderEvent> = mutableEvents.asSharedFlow()
+
+    init {
+        audioFocusHelper.setListener(
+            onPauseCurrentAudio = {
+                mutableEvents.tryEmit(AudioRecorderEvent.Interrupted(RecordingInterruption.AUDIO_FOCUS))
+            },
+            onResumeCurrentAudio = {},
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun start(maximumSizeBytes: Long): RecordingCapabilityResult<AudioRecordingFiles> =
+        withContext(dispatcherProvider.default()) {
+            if (!audioFocusHelper.requestExclusive()) {
+                return@withContext RecordingCapabilityResult.Failure("audio_focus_denied")
+            }
+
+            try {
+                setUp(maximumSizeBytes)
+                if (startRecording()) {
+                    val original = originalOutputPath
+                    val encoded = m4aOutputPath
+                    if (original != null && encoded != null) {
+                        RecordingCapabilityResult.Success(AudioRecordingFiles(original, encoded))
+                    } else {
+                        cleanupFailedStart()
+                        RecordingCapabilityResult.Failure("recording_paths_unavailable")
+                    }
+                } else {
+                    cleanupFailedStart()
+                    RecordingCapabilityResult.Failure("recording_start_failed")
+                }
+            } catch (cancelled: CancellationException) {
+                cleanupFailedStart()
+                throw cancelled
+            } catch (error: Exception) {
+                appLogger.e("[RecordAudio] start failed", error)
+                cleanupFailedStart()
+                RecordingCapabilityResult.Failure(error.message ?: "recording_start_failed")
+            }
+        }
+
+    override suspend fun stop(): RecordingCapabilityResult<Unit> = withContext(dispatcherProvider.default()) {
+        try {
+            stopNativeRecording()
+            RecordingCapabilityResult.Success(Unit)
+        } catch (error: IllegalStateException) {
+            appLogger.e("[RecordAudio] stop: ${error.message}", error)
+            RecordingCapabilityResult.Failure(error.message)
+        } finally {
+            releaseNativeRecorder()
+            audioFocusHelper.abandonExclusive()
+        }
+    }
+
+    override suspend fun encode(source: Path, destination: Path): RecordingCapabilityResult<Path> = try {
+        if (convertWavToM4a(source, destination)) {
+            RecordingCapabilityResult.Success(destination)
+        } else {
+            deleteIfExists(destination)
+            RecordingCapabilityResult.Failure("audio_encoding_failed")
+        }
+    } catch (cancelled: CancellationException) {
+        deleteIfExists(destination)
+        throw cancelled
+    }
+
+    override fun release() {
+        isRecording = false
+        recordingJob?.cancel()
+        recordingJob = null
+        releaseNativeRecorder()
+        audioFocusHelper.abandonExclusive()
+    }
 
     @SuppressLint("MissingPermission")
-    fun setUp(assetLimitInMegabyte: Long) {
-        assetLimitInMB = assetLimitInMegabyte
+    private fun setUp(maximumSizeBytes: Long) {
+        assetLimitInBytes = maximumSizeBytes
         if (audioRecorder == null) {
             val bufferSize = AudioRecord.getMinBufferSize(
                 SAMPLING_RATE,
@@ -101,18 +187,16 @@ class AudioMediaRecorder @Inject constructor(
         }
     }
 
-    fun startRecording(): Boolean = try {
+    private fun startRecording(): Boolean = try {
         audioRecorder?.startRecording()
         isRecording = true
         recordingJob = scope.launch { writeAudioDataToFile() }
         true
-    } catch (e: IllegalStateException) {
-        e.printStackTrace()
-        appLogger.e("[RecordAudio] startRecording: IllegalStateException - ${e.message}")
+    } catch (error: IllegalStateException) {
+        appLogger.e("[RecordAudio] startRecording: IllegalStateException - ${error.message}", error)
         false
-    } catch (e: IOException) {
-        e.printStackTrace()
-        appLogger.e("[RecordAudio] startRecording: IOException - ${e.message}")
+    } catch (error: IOException) {
+        appLogger.e("[RecordAudio] startRecording: IOException - ${error.message}", error)
         false
     }
 
@@ -163,14 +247,19 @@ class AudioMediaRecorder @Inject constructor(
         appLogger.i("Updated WAV Header: Chunk Size = ${fileSize - CHUNK_ID_SIZE}, Data Size = $dataSize")
     }
 
-    suspend fun stop() {
+    private suspend fun stopNativeRecording() {
         isRecording = false
-        audioRecorder?.stop()
-        recordingJob?.cancelAndJoin()
-        recordingJob = null
+        try {
+            if (audioRecorder != null) {
+                audioRecorder?.stop()
+            }
+        } finally {
+            recordingJob?.cancelAndJoin()
+            recordingJob = null
+        }
     }
 
-    fun release() {
+    private fun releaseNativeRecorder() {
         audioRecorder?.release()
         audioRecorder = null
     }
@@ -192,43 +281,40 @@ class AudioMediaRecorder @Inject constructor(
                                 }
 
                                 // Check if the file size exceeds the limit
-                                val currentSize = originalOutputPath!!.toFile().length()
-                                if (currentSize > (assetLimitInMB * SIZE_OF_1MB)) {
+                                val currentSize = kaliumFileSystem.size(originalOutputPath!!) ?: 0L
+                                if (RecordingSizePolicy.hasReachedLimit(currentSize, assetLimitInBytes)) {
                                     isRecording = false
-                                    _maxFileSizeReached.emit(
-                                        RecordAudioDialogState.MaxFileSizeReached(
-                                            maxSize = assetLimitInMB / SIZE_OF_1MB
-                                        )
+                                    mutableEvents.emit(
+                                        AudioRecorderEvent.MaxFileSizeReached(assetLimitInBytes)
                                     )
                                     break
                                 }
                             }
+                            it.flush()
                             updateWavHeader(originalOutputPath!!)
                         }
                 }
-            } catch (e: IOException) {
-                e.printStackTrace()
-                appLogger.e("[RecordAudio] writeAudioDataToFile: IOException - ${e.message}")
+            } catch (error: IOException) {
+                appLogger.e("[RecordAudio] writeAudioDataToFile: IOException - ${error.message}", error)
             }
         }
     }
 
     @Suppress("LongMethod", "CyclomaticComplexMethod", "TooGenericExceptionCaught")
-    suspend fun convertWavToM4a(inputFilePath: String): Boolean = withContext(Dispatchers.IO) {
+    private suspend fun convertWavToM4a(inputFilePath: Path, outputFilePath: Path): Boolean = withContext(dispatcherProvider.io()) {
         var codec: MediaCodec? = null
         var muxer: MediaMuxer? = null
+        var codecStarted = false
+        var muxerStarted = false
         var success = true
 
         try {
-            FileInputStream(File(inputFilePath)).use { fileInputStream ->
-                m4aOutputPath?.toFile()?.let { outputFile ->
+            FileInputStream(inputFilePath.toFile()).use { fileInputStream ->
+                outputFilePath.toFile().let { outputFile ->
                     ParcelFileDescriptor.open(
                         outputFile,
                         ParcelFileDescriptor.MODE_READ_WRITE or ParcelFileDescriptor.MODE_CREATE
                     ).use { parcelFileDescriptor ->
-
-                        val mediaExtractor = MediaExtractor()
-                        mediaExtractor.setDataSource(inputFilePath)
 
                         val format = MediaFormat.createAudioFormat(
                             MediaFormat.MIMETYPE_AUDIO_AAC,
@@ -242,6 +328,7 @@ class AudioMediaRecorder @Inject constructor(
                         val mediaCodec = codec!!
                         mediaCodec.configure(format, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
                         mediaCodec.start()
+                        codecStarted = true
 
                         val bufferInfo = MediaCodec.BufferInfo()
                         muxer = MediaMuxer(parcelFileDescriptor.fileDescriptor, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
@@ -283,6 +370,7 @@ class AudioMediaRecorder @Inject constructor(
                                     val newFormat = mediaCodec.outputFormat
                                     trackIndex = mediaMuxer.addTrack(newFormat)
                                     mediaMuxer.start()
+                                    muxerStarted = true
                                     retryCount = 0
                                 }
 
@@ -323,42 +411,71 @@ class AudioMediaRecorder @Inject constructor(
                             success = false
                         }
                     }
-                } ?: run {
-                    appLogger.e("[RecordAudio] convertWavToM4a: m4aOutputPath is null")
+                }
+            }
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (e: Exception) {
+            appLogger.e("Could not convert wav to m4a: ${e.message}", throwable = e)
+            success = false
+        } finally {
+            muxer?.let { safeMuxer ->
+                if (muxerStarted) {
+                    try {
+                        safeMuxer.stop()
+                    } catch (error: Exception) {
+                        appLogger.e("Could not stop MediaMuxer: ${error.message}", throwable = error)
+                        success = false
+                    }
+                }
+                try {
+                    safeMuxer.release()
+                } catch (error: Exception) {
+                    appLogger.e("Could not release MediaMuxer: ${error.message}", throwable = error)
                     success = false
                 }
             }
-        } catch (e: Exception) {
-            appLogger.e("Could not convert wav to m4a: ${e.message}", throwable = e)
-        } finally {
-            try {
-                muxer?.let { safeMuxer ->
-                    safeMuxer.stop()
-                    safeMuxer.release()
-                }
-            } catch (e: Exception) {
-                appLogger.e("Could not stop or release MediaMuxer: ${e.message}", throwable = e)
-                success = false
-            }
 
-            try {
-                codec?.let { safeCodec ->
-                    safeCodec.stop()
-                    safeCodec.release()
+            codec?.let { safeCodec ->
+                if (codecStarted) {
+                    try {
+                        safeCodec.stop()
+                    } catch (error: Exception) {
+                        appLogger.e("Could not stop MediaCodec: ${error.message}", throwable = error)
+                        success = false
+                    }
                 }
-            } catch (e: Exception) {
-                appLogger.e("Could not stop or release MediaCodec: ${e.message}", throwable = e)
-                success = false
+                try {
+                    safeCodec.release()
+                } catch (error: Exception) {
+                    appLogger.e("Could not release MediaCodec: ${error.message}", throwable = error)
+                    success = false
+                }
             }
         }
         success
+    }
+
+    private fun cleanupFailedStart() {
+        isRecording = false
+        recordingJob?.cancel()
+        recordingJob = null
+        releaseNativeRecorder()
+        audioFocusHelper.abandonExclusive()
+        originalOutputPath?.let(::deleteIfExists)
+        m4aOutputPath?.let(::deleteIfExists)
+        originalOutputPath = null
+        m4aOutputPath = null
+    }
+
+    private fun deleteIfExists(path: Path) {
+        if (kaliumFileSystem.exists(path)) kaliumFileSystem.delete(path)
     }
 
     companion object {
         fun getRecordingAudioFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.wav"
         fun getRecordingM4aAudioFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}.m4a"
 
-        const val SIZE_OF_1MB = 1024 * 1024
         const val AUDIO_CHANNELS = 1 // Mono
         const val SAMPLING_RATE = 16000
         const val BUFFER_SIZE = 1024

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/GenerateAudioFileWithEffectsUseCase.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/GenerateAudioFileWithEffectsUseCase.kt
@@ -20,45 +20,69 @@ package com.wire.android.ui.home.messagecomposer.recordaudio
 import android.content.Context
 import com.waz.audioeffect.AudioEffect
 import com.wire.android.appLogger
+import com.wire.android.di.ApplicationContext
+import com.wire.android.di.metro.MetroSessionScope
 import com.wire.android.util.dispatchers.DispatcherProvider
-import kotlinx.coroutines.withContext
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.media.recording.AudioEffectsProcessor
+import com.wire.media.recording.AudioEffectsRequest
+import com.wire.media.recording.RecordingCapabilityResult
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.binding
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withContext
+import okio.Path
 
-@SingleIn(AppScope::class)
-class GenerateAudioFileWithEffectsUseCase @Inject constructor(
+@Inject
+@SingleIn(MetroSessionScope::class)
+@ContributesBinding(MetroSessionScope::class, binding = binding<AudioEffectsProcessor>())
+class GenerateAudioFileWithEffectsUseCase(
+    @ApplicationContext private val context: Context,
     private val dispatchers: DispatcherProvider,
-) {
+    private val fileSystem: KaliumFileSystem,
+) : AudioEffectsProcessor {
     /**
      * Note: This UseCase can't be tested as we cannot mock `AudioEffect` from AVS.
      * Generates audio file with effects on received path from the original file path.
      *
-     * @return Unit, as the content of audio with effects will be saved directly to received file path.
+     * @return the generated path, or an explicit failure after cleaning a partial output.
      */
-    suspend operator fun invoke(
-        context: Context,
-        originalFilePath: String,
-        effectsFilePath: String
-    ) = withContext(dispatchers.io()) {
-        appLogger.i("[$TAG] -> Start generating audio file with effects")
+    @Suppress("TooGenericExceptionCaught")
+    override suspend fun process(request: AudioEffectsRequest): RecordingCapabilityResult<Path> =
+        withContext(dispatchers.io()) {
+            appLogger.i("[$TAG] -> Start generating audio file with effects")
 
-        val audioEffect = AudioEffect(context)
-        val effectType = AudioEffect.AVS_AUDIO_EFFECT_VOCODER_MED
-        val reduceNoise = true
+            try {
+                val audioEffect = AudioEffect(context)
+                val audioEffectsResult = audioEffect.applyEffectWav(
+                    request.source.toString(),
+                    request.destination.toString(),
+                    AudioEffect.AVS_AUDIO_EFFECT_VOCODER_MED,
+                    true,
+                )
 
-        val audioEffectsResult = audioEffect.applyEffectWav(
-            originalFilePath,
-            effectsFilePath,
-            effectType,
-            reduceNoise
-        )
-
-        if (audioEffectsResult > -1) {
-            appLogger.i("[$TAG] -> Audio file with effects generated successfully.")
-        } else {
-            appLogger.w("[$TAG] -> There was an issue with generating audio file with effects.")
+                if (audioEffectsResult > -1) {
+                    appLogger.i("[$TAG] -> Audio file with effects generated successfully.")
+                    RecordingCapabilityResult.Success(request.destination)
+                } else {
+                    appLogger.w("[$TAG] -> There was an issue with generating audio file with effects.")
+                    deleteOutput(request.destination)
+                    RecordingCapabilityResult.Failure("audio_effect_failed")
+                }
+            } catch (cancelled: CancellationException) {
+                deleteOutput(request.destination)
+                throw cancelled
+            } catch (error: Exception) {
+                appLogger.e("[$TAG] -> Audio effect generation failed", error)
+                deleteOutput(request.destination)
+                RecordingCapabilityResult.Failure(error.message)
+            }
         }
+
+    private fun deleteOutput(path: Path) {
+        if (fileSystem.exists(path)) fileSystem.delete(path)
     }
 
     private companion object {

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioComponent.kt
@@ -43,7 +43,9 @@ import com.wire.android.ui.home.conversations.recordAudioViewModel
 import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.ui.theme.wireColorScheme
 import com.wire.android.util.extension.openAppInfoScreen
+import com.wire.android.util.pathToUri
 import com.wire.android.util.permission.rememberRecordAudioPermissionFlow
+import com.wire.media.recording.RecordingAction
 
 @Composable
 fun RecordAudioComponent(
@@ -91,10 +93,17 @@ fun RecordAudioComponent(
 
     HandleActions(viewModel.actions) { action ->
         when (action) {
-            RecordAudioViewActions.Discarded -> onCloseRecordAudio()
+            RecordingAction.Discarded -> onCloseRecordAudio()
 
-            is RecordAudioViewActions.Recorded -> {
-                onAudioRecorded(action.uriAsset)
+            is RecordingAction.Recorded -> {
+                onAudioRecorded(
+                    UriAsset(
+                        uri = context.pathToUri(action.recording.path, null),
+                        mimeType = action.recording.mimeType,
+                        saveToDeviceIfInvalid = false,
+                        audioWavesMask = action.recording.audioWavesMask,
+                    )
+                )
                 onCloseRecordAudio()
             }
         }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioState.kt
@@ -17,59 +17,6 @@
  */
 package com.wire.android.ui.home.messagecomposer.recordaudio
 
-import com.wire.media.player.AudioState
-import okio.Path
-
-data class RecordAudioState(
-    val buttonState: RecordAudioButtonState = RecordAudioButtonState.ENABLED,
-    val discardDialogState: RecordAudioDialogState = RecordAudioDialogState.Hidden,
-    val permissionsDeniedDialogState: RecordAudioDialogState = RecordAudioDialogState.Hidden,
-    val maxFileSizeReachedDialogState: RecordAudioDialogState = RecordAudioDialogState.Hidden,
-    val originalOutputFile: Path? = null,
-    val effectsOutputFile: Path? = null,
-    val shouldApplyEffects: Boolean = false,
-    val audioState: AudioState = AudioState.DEFAULT,
-    val wavesMask: List<Int>? = null
-)
-
-enum class RecordAudioButtonState {
-    /**
-     * ENABLED: Button for starting an audio message will be shown.
-     * Start Recording or Ask permissions
-     */
-    ENABLED,
-
-    /**
-     * RECORDING: Is shown when a recording is in place.
-     */
-    RECORDING,
-
-    /**
-     * READY_TO_SEND: When User finished recording its audio message.
-     */
-    READY_TO_SEND,
-
-    /**
-     * ENCODING: When recorded audio is encoding
-     */
-    ENCODING
-}
-
-sealed class RecordAudioDialogState {
-    /**
-     * Dialog is shown to user
-     */
-    object Shown : RecordAudioDialogState()
-
-    /**
-     * Dialog is hidden from user
-     */
-    object Hidden : RecordAudioDialogState()
-
-    /**
-     * Max File Size dialog is shown with dynamic max file size
-     */
-    data class MaxFileSizeReached(
-        val maxSize: Long
-    ) : RecordAudioDialogState()
-}
+typealias RecordAudioState = com.wire.media.recording.AudioRecordingState
+typealias RecordAudioButtonState = com.wire.media.recording.RecordingButtonState
+typealias RecordAudioDialogState = com.wire.media.recording.RecordingDialogState

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModel.kt
@@ -6,153 +6,83 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+
 package com.wire.android.ui.home.messagecomposer.recordaudio
 
-import com.wire.android.di.ApplicationContext
-import dev.zacsweers.metro.Inject
-
-import android.content.Context
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
-import com.wire.android.appLogger
 import com.wire.android.datastore.GlobalDataStore
-import com.wire.android.media.audiomessage.AudioFocusHelper
-import com.wire.android.media.audiomessage.RecordAudioMessagePlayer
-import com.wire.android.media.audiomessage.toWavesMask
 import com.wire.android.ui.common.ActionsViewModel
-import com.wire.android.ui.home.conversations.model.UriAsset
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
-import com.wire.android.util.SUPPORTED_AUDIO_MIME_TYPE
-import com.wire.android.util.dispatchers.DispatcherProvider
-import com.wire.android.util.fileDateTime
-import com.wire.android.util.getAudioLengthInMs
-import com.wire.android.util.pathToUri
 import com.wire.android.util.ui.UIText
+import com.wire.content.media.MediaMetadataReader
 import com.wire.kalium.logic.data.asset.KaliumFileSystem
 import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
-import com.wire.kalium.util.DateTimeUtil
-import com.wire.media.player.AudioMediaPlayingState
-import com.wire.media.player.AudioState
+import com.wire.media.recording.AudioEffectsProcessor
+import com.wire.media.recording.AudioRecorder
+import com.wire.media.recording.AudioRecordingCoordinator
+import com.wire.media.recording.RecordingAction
+import com.wire.media.recording.RecordingAvailability
+import com.wire.media.recording.RecordingButtonState
+import com.wire.media.recording.RecordingCapabilityResult
+import com.wire.media.recording.RecordingPreview
+import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import okio.Path
-import java.io.IOException
 
 @Suppress("TooManyFunctions", "LongParameterList")
 class RecordAudioViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val recordAudioMessagePlayer: RecordAudioMessagePlayer,
     private val observeEstablishedCalls: ObserveEstablishedCallsUseCase,
     private val getAssetSizeLimit: GetAssetSizeLimitUseCase,
-    private val generateAudioFileWithEffects: GenerateAudioFileWithEffectsUseCase,
     private val currentScreenManager: CurrentScreenManager,
-    private val audioMediaRecorder: AudioMediaRecorder,
+    audioRecorder: AudioRecorder,
+    recordingPreview: RecordingPreview,
+    effectsProcessor: AudioEffectsProcessor,
+    mediaMetadataReader: MediaMetadataReader,
     private val globalDataStore: GlobalDataStore,
-    private val audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder,
-    private val audioFocusHelper: AudioFocusHelper,
-    private val dispatchers: DispatcherProvider,
-    private val kaliumFileSystem: KaliumFileSystem
-) : ActionsViewModel<RecordAudioViewActions>() {
+    audioNormalizedLoudnessBuilder: AudioNormalizedLoudnessBuilder,
+    kaliumFileSystem: KaliumFileSystem,
+) : ActionsViewModel<RecordingAction>() {
+    private val recordingCoordinator = AudioRecordingCoordinator(
+        audioRecorder = audioRecorder,
+        recordingPreview = recordingPreview,
+        effectsProcessor = effectsProcessor,
+        metadataReader = mediaMetadataReader,
+        fileSystem = kaliumFileSystem,
+        loudnessBuilder = audioNormalizedLoudnessBuilder,
+        scope = viewModelScope,
+    )
 
-    var state: RecordAudioState by mutableStateOf(RecordAudioState())
-        private set
+    val state: RecordAudioState
+        get() = recordingCoordinator.state
 
-    private var hasOngoingCall: Boolean = false
-
+    private var hasOngoingCall = false
     private val infoMessage = MutableSharedFlow<UIText>()
 
-    private val tag = "RecordAudioViewModel"
+    init {
+        observeEffectsCheckbox()
+        observeScreenState()
+        observeUserIsInCall()
+        observeRecordingIssues()
+    }
 
     fun getInfoMessage(): SharedFlow<UIText> = infoMessage.asSharedFlow()
 
     fun setApplyEffectsAndPlayAudio(enabled: Boolean) {
-        setShouldApplyEffects(enabled = enabled)
-        if (state.audioState.isPlaying()) {
-            onPlayAudio()
-        }
-    }
-
-    fun getPlayableAudioFile(): Path? = if (state.shouldApplyEffects) {
-        state.effectsOutputFile
-    } else {
-        state.originalOutputFile
-    }
-
-    init {
-        observeAudioPlayerState()
-        observeEffectsCheckbox()
-
+        val wasPlaying = state.audioState.isPlaying()
         viewModelScope.launch {
-            launch {
-                observeAudioFileSize()
-            }
-            launch {
-                observeScreenState()
-            }
-            launch {
-                observeUserIsInCall()
-            }
+            setShouldApplyEffectsInternal(enabled)
+            if (wasPlaying) recordingCoordinator.togglePreview()
         }
     }
 
-    private suspend fun observeAudioFileSize() {
-        audioMediaRecorder.getMaxFileSizeReached().collect { recordAudioDialogState ->
-            stopRecording()
-            state = state.copy(
-                maxFileSizeReachedDialogState = recordAudioDialogState
-            )
-        }
-    }
-
-    private suspend fun observeUserIsInCall() {
-        observeEstablishedCalls().collect {
-            hasOngoingCall = it.isNotEmpty()
-        }
-    }
-
-    private suspend fun observeScreenState() {
-        currentScreenManager.observeCurrentScreen(viewModelScope).collect { currentScreen ->
-            if (state.buttonState == RecordAudioButtonState.RECORDING &&
-                currentScreen == CurrentScreen.InBackground
-            ) {
-                stopRecording()
-            }
-        }
-    }
-
-    private fun observeAudioPlayerState() {
-        viewModelScope.launch {
-            recordAudioMessagePlayer.audioMessageStateFlow.collect {
-                state = state.copy(
-                    audioState = it
-                )
-            }
-        }
-    }
-
-    private fun observeEffectsCheckbox() {
-        viewModelScope.launch {
-            globalDataStore.isRecordAudioEffectsCheckboxEnabled().collect {
-                state = state.copy(shouldApplyEffects = it)
-            }
-        }
-    }
+    fun getPlayableAudioFile(): Path? = recordingCoordinator.playablePath()
 
     fun startRecording() {
         if (hasOngoingCall) {
@@ -160,265 +90,114 @@ class RecordAudioViewModel @Inject constructor(
                 infoMessage.emit(RecordAudioInfoMessageType.UnableToRecordAudioCall.uiText)
             }
         } else {
-            audioFocusHelper.requestExclusive()
-            viewModelScope.launch(dispatchers.default()) {
-                val assetSizeLimit = getAssetSizeLimit(false)
-                if (state.shouldApplyEffects && state.effectsOutputFile == null) {
-                    state = state.copy(
-                        effectsOutputFile = kaliumFileSystem
-                            .tempFilePath(getRecordingAudioEffectsFileName())
-                    )
+            viewModelScope.launch {
+                recordingCoordinator.startRecording(getAssetSizeLimit(false))
+            }
+        }
+    }
+
+    fun stopRecording() {
+        viewModelScope.launch {
+            recordingCoordinator.stopRecording()
+        }
+    }
+
+    fun showDiscardRecordingDialog() {
+        if (state.buttonState == RecordingButtonState.ENABLED) {
+            sendAction(RecordingAction.Discarded)
+        } else {
+            recordingCoordinator.showDiscardDialog()
+        }
+    }
+
+    fun onDismissDiscardDialog() = recordingCoordinator.dismissDiscardDialog()
+
+    fun showPermissionsDeniedDialog() = recordingCoordinator.showPermissionsDeniedDialog()
+
+    fun onDismissPermissionsDeniedDialog() = recordingCoordinator.dismissPermissionsDeniedDialog()
+
+    fun onDismissMaxFileSizeReachedDialog() = recordingCoordinator.dismissMaxFileSizeDialog()
+
+    fun discardRecording() {
+        viewModelScope.launch {
+            sendAction(recordingCoordinator.discard())
+        }
+    }
+
+    fun sendRecording() {
+        viewModelScope.launch {
+            when (val result = recordingCoordinator.finish()) {
+                is RecordingCapabilityResult.Success -> sendAction(RecordingAction.Recorded(result.value))
+                RecordingCapabilityResult.Unsupported,
+                is RecordingCapabilityResult.Failure ->
+                    infoMessage.emit(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText)
+            }
+        }
+    }
+
+    fun onPlayAudio() {
+        recordingCoordinator.togglePreview()
+    }
+
+    fun onSliderPositionChange(position: Int) {
+        recordingCoordinator.seekPreview(position)
+    }
+
+    fun setShouldApplyEffects(enabled: Boolean) {
+        viewModelScope.launch {
+            setShouldApplyEffectsInternal(enabled)
+        }
+    }
+
+    override fun onCleared() {
+        recordingCoordinator.release()
+        super.onCleared()
+    }
+
+    private fun observeEffectsCheckbox() {
+        viewModelScope.launch {
+            globalDataStore.isRecordAudioEffectsCheckboxEnabled().collect { enabled ->
+                recordingCoordinator.setEffectsEnabled(enabled)
+            }
+        }
+    }
+
+    private fun observeScreenState() {
+        viewModelScope.launch {
+            currentScreenManager.observeCurrentScreen(viewModelScope).collect { currentScreen ->
+                if (
+                    state.buttonState == RecordingButtonState.RECORDING &&
+                    currentScreen == CurrentScreen.InBackground
+                ) {
+                    recordingCoordinator.stopRecording()
                 }
-                audioMediaRecorder.setUp(assetSizeLimit)
-                if (audioMediaRecorder.startRecording()) {
-                    state = state.copy(
-                        originalOutputFile = audioMediaRecorder.originalOutputPath!!,
-                        buttonState = RecordAudioButtonState.RECORDING
-                    )
-                } else {
+            }
+        }
+    }
+
+    private fun observeUserIsInCall() {
+        viewModelScope.launch {
+            observeEstablishedCalls().collect { calls ->
+                hasOngoingCall = calls.isNotEmpty()
+                if (hasOngoingCall && state.buttonState == RecordingButtonState.RECORDING) {
+                    recordingCoordinator.stopRecording()
+                }
+            }
+        }
+    }
+
+    private fun observeRecordingIssues() {
+        viewModelScope.launch {
+            recordingCoordinator.issues.collect { issue ->
+                if (issue is RecordingAvailability.Failed || issue is RecordingAvailability.Unsupported) {
                     infoMessage.emit(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText)
                 }
             }
         }
     }
 
-    fun stopRecording() {
-        audioFocusHelper.abandonExclusive()
-        viewModelScope.launch(dispatchers.default()) {
-            if (state.buttonState == RecordAudioButtonState.RECORDING) {
-                appLogger.i("[$tag] -> Stopping audioMediaRecorder")
-                audioMediaRecorder.stop()
-            }
-            appLogger.i("[$tag] -> Releasing audioMediaRecorder")
-            audioMediaRecorder.release()
-
-            if (state.originalOutputFile != null) {
-                state = state.copy(
-                    buttonState = RecordAudioButtonState.ENCODING,
-                    audioState = state.audioState.copy(audioMediaPlayingState = AudioMediaPlayingState.Fetching)
-                )
-                if (state.shouldApplyEffects && state.effectsOutputFile != null) {
-                    generateAudioFileWithEffects(
-                        context = context,
-                        originalFilePath = state.originalOutputFile!!.toString(),
-                        effectsFilePath = state.effectsOutputFile!!.toString()
-                    )
-                }
-
-                val playableAudioFile = getPlayableAudioFile()
-                state = state.copy(
-                    buttonState = RecordAudioButtonState.READY_TO_SEND,
-                    audioState = AudioState.DEFAULT.copy(
-                        totalTimeInMs = AudioState.TotalTimeInMs.Known(
-                            playableAudioFile?.let {
-                                getAudioLengthInMs(
-                                    dataPath = it,
-                                    mimeType = SUPPORTED_AUDIO_MIME_TYPE
-                                ).toInt()
-                            } ?: 0
-                        ),
-                    ),
-                    wavesMask = playableAudioFile?.let { audioNormalizedLoudnessBuilder(it.toString()) }?.toWavesMask() ?: listOf()
-                )
-            }
-        }
+    private suspend fun setShouldApplyEffectsInternal(enabled: Boolean) {
+        globalDataStore.setRecordAudioEffectsCheckboxEnabled(enabled)
+        recordingCoordinator.setEffectsEnabled(enabled)
     }
-
-    fun showDiscardRecordingDialog() {
-        when (state.buttonState) {
-            RecordAudioButtonState.ENABLED -> sendAction(RecordAudioViewActions.Discarded)
-            RecordAudioButtonState.RECORDING,
-            RecordAudioButtonState.READY_TO_SEND,
-            RecordAudioButtonState.ENCODING -> {
-                state = state.copy(
-                    discardDialogState = RecordAudioDialogState.Shown
-                )
-            }
-        }
-    }
-
-    fun onDismissDiscardDialog() {
-        state = state.copy(
-            discardDialogState = RecordAudioDialogState.Hidden
-        )
-    }
-
-    fun showPermissionsDeniedDialog() {
-        state = state.copy(
-            permissionsDeniedDialogState = RecordAudioDialogState.Shown
-        )
-    }
-
-    fun onDismissPermissionsDeniedDialog() {
-        state = state.copy(
-            permissionsDeniedDialogState = RecordAudioDialogState.Hidden
-        )
-    }
-
-    fun onDismissMaxFileSizeReachedDialog() {
-        state = state.copy(
-            maxFileSizeReachedDialogState = RecordAudioDialogState.Hidden
-        )
-    }
-
-    fun discardRecording() {
-        viewModelScope.launch {
-            state.originalOutputFile?.let(::deleteIfExists)
-            state.effectsOutputFile?.let(::deleteIfExists)
-            recordAudioMessagePlayer.stop()
-            state = state.copy(
-                buttonState = RecordAudioButtonState.ENABLED,
-                discardDialogState = RecordAudioDialogState.Hidden,
-                originalOutputFile = null,
-                effectsOutputFile = null
-            )
-            sendAction(RecordAudioViewActions.Discarded)
-        }
-    }
-
-    fun sendRecording() {
-        viewModelScope.launch {
-            recordAudioMessagePlayer.stop()
-
-            val outputFile = state.originalOutputFile
-            val effectsFile = state.effectsOutputFile
-            val wavesMask = state.wavesMask
-            state = state.copy(
-                buttonState = RecordAudioButtonState.ENCODING, audioState = AudioState.DEFAULT,
-                originalOutputFile = null,
-                effectsOutputFile = null
-            )
-
-            val didSucceed = if (state.shouldApplyEffects) {
-                audioMediaRecorder.convertWavToM4a(effectsFile!!.toString())
-            } else {
-                audioMediaRecorder.convertWavToM4a(outputFile!!.toString())
-            }
-
-            try {
-                when {
-                    didSucceed -> {
-                        outputFile?.let(::deleteIfExists)
-                        effectsFile?.let(::deleteIfExists)
-                    }
-
-                    state.shouldApplyEffects -> {
-                        outputFile?.let(::deleteIfExists)
-                    }
-
-                    !state.shouldApplyEffects -> {
-                        effectsFile?.let(::deleteIfExists)
-                    }
-                }
-            } catch (exception: IOException) {
-                appLogger.e("[$tag] -> Couldn't delete audio files")
-            }
-            sendAction(
-                RecordAudioViewActions.Recorded(
-                    uriAsset = UriAsset(
-                        uri = if (didSucceed) {
-                            context.pathToUri(audioMediaRecorder.m4aOutputPath!!, null)
-                        } else {
-                            if (state.shouldApplyEffects) {
-                                context.pathToUri(effectsFile!!, null)
-                            } else {
-                                context.pathToUri(outputFile!!, null)
-                            }
-                        },
-                        mimeType = if (didSucceed) {
-                            "audio/mp4"
-                        } else {
-                            "audio/wav"
-                        },
-                        saveToDeviceIfInvalid = false,
-                        audioWavesMask = wavesMask
-                    )
-                )
-            )
-        }
-    }
-
-    fun onPlayAudio() {
-        getPlayableAudioFile()?.let { audioFile ->
-            viewModelScope.launch {
-                recordAudioMessagePlayer.playAudio(
-                    audioFile = audioFile
-                )
-            }
-        }
-    }
-
-    fun onSliderPositionChange(position: Int) {
-        viewModelScope.launch {
-            recordAudioMessagePlayer.setPosition(
-                position = position
-            )
-        }
-    }
-
-    fun setShouldApplyEffects(enabled: Boolean) {
-        viewModelScope.launch {
-            globalDataStore.setRecordAudioEffectsCheckboxEnabled(enabled)
-            if (enabled && state.effectsOutputFile == null) {
-                val effectsFile = kaliumFileSystem
-                    .tempFilePath(getRecordingAudioEffectsFileName())
-                if (state.buttonState == RecordAudioButtonState.READY_TO_SEND) {
-                    state = state.copy(
-                        buttonState = RecordAudioButtonState.ENCODING,
-                        audioState = state.audioState.copy(audioMediaPlayingState = AudioMediaPlayingState.Fetching)
-                    )
-
-                    generateAudioFileWithEffects(
-                        context = context,
-                        originalFilePath = state.originalOutputFile!!.toString(),
-                        effectsFilePath = effectsFile.toString()
-                    )
-
-                    state = state.copy(
-                        effectsOutputFile = effectsFile,
-                        buttonState = RecordAudioButtonState.READY_TO_SEND,
-                        audioState = AudioState(
-                            audioMediaPlayingState = AudioMediaPlayingState.Stopped,
-                            currentPositionInMs = 0,
-                            AudioState.TotalTimeInMs.Known(
-                                getAudioLengthInMs(
-                                    dataPath = effectsFile,
-                                    mimeType = SUPPORTED_AUDIO_MIME_TYPE
-                                ).toInt()
-                            ),
-                        ),
-                        wavesMask = state.wavesMask,
-                        shouldApplyEffects = true
-                    )
-                } else {
-                    state = state.copy(
-                        effectsOutputFile = effectsFile,
-                        shouldApplyEffects = true
-                    )
-                }
-            } else {
-                state = state.copy(
-                    shouldApplyEffects = enabled
-                )
-            }
-        }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        recordAudioMessagePlayer.close()
-    }
-
-    private fun deleteIfExists(path: Path) {
-        if (kaliumFileSystem.exists(path)) kaliumFileSystem.delete(path)
-    }
-
-    companion object {
-        fun getRecordingAudioEffectsFileName(): String = "wire-audio-${DateTimeUtil.currentInstant().fileDateTime()}-filter.wav"
-    }
-}
-
-sealed interface RecordAudioViewActions {
-    data object Discarded : RecordAudioViewActions
-    data class Recorded(val uriAsset: UriAsset) : RecordAudioViewActions
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordedAudioDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordedAudioDialogs.kt
@@ -24,6 +24,7 @@ import com.wire.android.ui.common.WireDialog
 import com.wire.android.ui.common.WireDialogButtonProperties
 import com.wire.android.ui.common.WireDialogButtonType
 import com.wire.android.ui.common.button.WireButtonState
+import com.wire.media.recording.RecordingDialogState
 
 @Composable
 fun DiscardRecordedAudioDialog(
@@ -31,7 +32,7 @@ fun DiscardRecordedAudioDialog(
     onDiscard: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    if (dialogState is RecordAudioDialogState.Shown) {
+    if (dialogState is RecordingDialogState.Shown) {
         WireDialog(
             title = stringResource(id = R.string.record_audio_discard_dialog_title),
             text = stringResource(id = R.string.record_audio_discard_dialog_text),
@@ -57,7 +58,7 @@ fun MicrophonePermissionsDeniedDialog(
     onDismiss: () -> Unit,
     onOpenSettings: () -> Unit
 ) {
-    if (dialogState is RecordAudioDialogState.Shown) {
+    if (dialogState is RecordingDialogState.Shown) {
         WireDialog(
             title = stringResource(id = R.string.record_audio_permission_denied_dialog_title),
             text = stringResource(id = R.string.record_audio_permission_denied_dialog_text),
@@ -82,7 +83,7 @@ fun RecordedAudioMaxFileSizeReachedDialog(
     dialogState: RecordAudioDialogState,
     onDismiss: () -> Unit
 ) {
-    if (dialogState is RecordAudioDialogState.MaxFileSizeReached) {
+    if (dialogState is RecordingDialogState.MaxFileSizeReached) {
         WireDialog(
             title = stringResource(id = R.string.record_audio_max_file_size_reached_title),
             text = stringResource(

--- a/app/src/test/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayerTest.kt
+++ b/app/src/test/kotlin/com/wire/android/media/audiomessage/RecordAudioMessagePlayerTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.android.media.audiomessage
+
+import com.wire.android.mediaplayer.AndroidMediaPlayerPlaybackEngineFactory
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
+import com.wire.media.player.MediaPlaybackEngine
+import com.wire.media.player.PlaybackCommand
+import com.wire.media.player.PlaybackCommandResult
+import com.wire.media.player.PlaybackEvent
+import com.wire.media.player.PlaybackSnapshot
+import com.wire.media.player.PlaybackSource
+import com.wire.media.recording.RecordingCapabilityResult
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RecordAudioMessagePlayerTest {
+    @Test
+    fun `preview coordinates focus playback seek completion and release`() = runTest {
+        val engine = FakeEngine()
+        val factory = mockk<AndroidMediaPlayerPlaybackEngineFactory> {
+            every { create() } returns engine
+        }
+        val pauseCallback = slot<() -> Unit>()
+        val resumeCallback = slot<() -> Unit>()
+        val focus = mockk<AudioFocusHelper>(relaxUnitFun = true) {
+            every { request() } returns true
+            every { setListener(capture(pauseCallback), capture(resumeCallback)) } returns Unit
+        }
+        val player = RecordAudioMessagePlayer(factory, focus, backgroundScope)
+        val path = "/tmp/preview.wav".toPath()
+
+        assertEquals(RecordingCapabilityResult.Success(Unit), player.toggle(path))
+        assertEquals(
+            PlaybackCommand.Prepare(PlaybackSource.Local(path), playWhenReady = true),
+            engine.commands.last(),
+        )
+        engine.emit(PlaybackEvent.Ready(DURATION_MS))
+        runCurrent()
+        assertEquals(AudioMediaPlayingState.Playing, player.state.value.audioMediaPlayingState)
+        assertEquals(AudioState.TotalTimeInMs.Known(DURATION_MS), player.state.value.totalTimeInMs)
+
+        pauseCallback.captured()
+        runCurrent()
+        assertEquals(AudioMediaPlayingState.Paused, player.state.value.audioMediaPlayingState)
+        resumeCallback.captured()
+        runCurrent()
+        assertEquals(AudioMediaPlayingState.Playing, player.state.value.audioMediaPlayingState)
+
+        player.seekTo(500)
+        runCurrent()
+        assertEquals(500, player.state.value.currentPositionInMs)
+        engine.emit(PlaybackEvent.Completed)
+        runCurrent()
+        assertEquals(AudioMediaPlayingState.Completed, player.state.value.audioMediaPlayingState)
+        assertEquals(0, player.state.value.currentPositionInMs)
+        verify(atLeast = 1) { focus.abandon() }
+
+        player.release()
+        assertTrue(engine.commands.last() is PlaybackCommand.Release)
+        verify(atLeast = 1) { focus.request() }
+        verify(atLeast = 1) { focus.abandon() }
+    }
+
+    private class FakeEngine : MediaPlaybackEngine {
+        val commands = mutableListOf<PlaybackCommand>()
+        private var listener: ((PlaybackEvent) -> Unit)? = null
+
+        override fun setEventListener(listener: ((PlaybackEvent) -> Unit)?) {
+            this.listener = listener
+        }
+
+        override fun execute(command: PlaybackCommand): PlaybackCommandResult {
+            commands += command
+            when (command) {
+                PlaybackCommand.Play -> emit(PlaybackEvent.Playing)
+                PlaybackCommand.Pause -> emit(PlaybackEvent.Paused)
+                PlaybackCommand.Stop -> emit(PlaybackEvent.Stopped)
+                is PlaybackCommand.SeekTo -> emit(PlaybackEvent.PositionChanged(command.positionMs, DURATION_MS))
+                PlaybackCommand.Release -> emit(PlaybackEvent.Released)
+                else -> Unit
+            }
+            return PlaybackCommandResult.Executed
+        }
+
+        override fun snapshot(): PlaybackSnapshot = PlaybackSnapshot(0, DURATION_MS)
+
+        fun emit(event: PlaybackEvent) {
+            listener?.invoke(event)
+        }
+    }
+
+    private companion object {
+        const val DURATION_MS = 1_000
+    }
+}

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelArrangement.kt
@@ -22,7 +22,6 @@ import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.config.mockUri
 import com.wire.android.feature.analytics.AnonymousAnalyticsManager
 import com.wire.android.framework.FakeKaliumFileSystem
-import com.wire.android.media.PingRinger
 import com.wire.android.ui.home.conversations.ConversationNavArgs
 import com.wire.android.ui.home.conversations.MessageSharedState
 import com.wire.android.ui.home.conversations.model.AssetBundle
@@ -58,6 +57,8 @@ import com.wire.kalium.logic.feature.message.linkpreview.DetectLinkPreviewTarget
 import com.wire.kalium.logic.feature.message.linkpreview.GenerateLinkPreviewUseCase
 import com.wire.kalium.logic.feature.message.linkpreview.LinkPreviewTarget
 import com.wire.kalium.logic.sync.ObserveSyncStateUseCase
+import com.wire.media.player.PlatformFeedback
+import com.wire.media.player.PlatformFeedbackResult
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.every
@@ -80,7 +81,7 @@ internal class SendMessageViewModelArrangement {
         coEvery { observeOngoingCallsUseCase() } returns flowOf(listOf())
         coEvery { observeEstablishedCallsUseCase() } returns flowOf(listOf())
         coEvery { observeSyncState() } returns flowOf(SyncState.Live)
-        every { pingRinger.ping(any(), any()) } returns Unit
+        every { platformFeedback.perform(any()) } returns PlatformFeedbackResult.Performed
         coEvery { sendKnockUseCase(any(), any()) } returns MessageOperationResult.Success
         coEvery { setUserInformedAboutVerificationUseCase(any()) } returns Unit
         coEvery { observeDegradedConversationNotifiedUseCase(any()) } returns flowOf(true)
@@ -129,7 +130,7 @@ internal class SendMessageViewModelArrangement {
     private lateinit var observeSyncState: ObserveSyncStateUseCase
 
     @MockK
-    lateinit var pingRinger: PingRinger
+    lateinit var platformFeedback: PlatformFeedback
 
     @MockK
     lateinit var mediaMetadataReader: MediaMetadataReader
@@ -188,7 +189,7 @@ internal class SendMessageViewModelArrangement {
             kaliumFileSystem = fakeKaliumFileSystem,
             assetImporter = assetImporter,
             mediaMetadataReader = mediaMetadataReader,
-            pingRinger = pingRinger,
+            platformFeedback = platformFeedback,
             sendKnock = sendKnockUseCase,
             retryFailedMessage = retryFailedMessageUseCase,
             sendTypingEvent = sendTypingEvent,

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/sendmessage/SendMessageViewModelTest.kt
@@ -39,6 +39,7 @@ import com.wire.kalium.logic.failure.LegalHoldEnabledForConversationFailure
 import com.wire.kalium.logic.feature.asset.upload.AssetUploadParams
 import com.wire.kalium.logic.feature.asset.upload.ScheduleNewAssetMessageResult
 import com.wire.kalium.logic.feature.message.linkpreview.LinkPreviewTarget
+import com.wire.media.player.PlatformFeedbackType
 import io.mockk.coVerify
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
@@ -487,7 +488,7 @@ class SendMessageViewModelTest {
         }
 
     @Test
-    fun `given that a user sends an ping message, when invoked, then sendKnockUseCase and pingRinger are called`() =
+    fun `given that a user sends a ping message, when invoked, then send and platform feedback are called`() =
         runTest {
             // Given
             val (arrangement, viewModel) = SendMessageViewModelArrangement()
@@ -502,7 +503,7 @@ class SendMessageViewModelTest {
             advanceUntilIdle()
             // Then
             coVerify(exactly = 1) { arrangement.sendKnockUseCase.invoke(any(), any()) }
-            verify(exactly = 1) { arrangement.pingRinger.ping(any(), isReceivingPing = false) }
+            verify(exactly = 1) { arrangement.platformFeedback.perform(PlatformFeedbackType.OUTGOING_PING) }
             verify(exactly = 1) {
                 arrangement.analyticsManager.sendEvent(
                     match {

--- a/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/messagecomposer/recordaudio/RecordAudioViewModelTest.kt
@@ -6,467 +6,315 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+
 package com.wire.android.ui.home.messagecomposer.recordaudio
 
-import android.content.Context
 import app.cash.turbine.test
 import com.wire.android.config.CoroutineTestExtension
-import com.wire.android.config.TestDispatcherProvider
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.framework.FakeKaliumFileSystem
-import com.wire.android.media.audiomessage.AudioFocusHelper
-import com.wire.android.media.audiomessage.RecordAudioMessagePlayer
-import com.wire.android.ui.home.messagecomposer.recordaudio.RecordAudioViewModelTest.Arrangement.Companion.ASSET_SIZE_LIMIT
 import com.wire.android.util.CurrentScreen
 import com.wire.android.util.CurrentScreenManager
+import com.wire.content.external.PlatformResult
+import com.wire.content.media.MediaMetadataReader
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.ConversationId
+import com.wire.kalium.logic.data.message.AssetContent
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
 import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase
-import com.wire.media.player.AudioState
-import com.wire.kalium.logic.feature.asset.GetAssetSizeLimitUseCase.AssetSizeLimits.ASSET_SIZE_DEFAULT_LIMIT_BYTES
 import com.wire.kalium.logic.feature.call.usecase.ObserveEstablishedCallsUseCase
+import com.wire.media.player.AudioState
+import com.wire.media.recording.AudioEffectsProcessor
+import com.wire.media.recording.AudioRecorder
+import com.wire.media.recording.AudioRecorderEvent
+import com.wire.media.recording.AudioRecordingFiles
+import com.wire.media.recording.M4A_AUDIO_MIME_TYPE
+import com.wire.media.recording.RecordingAction
+import com.wire.media.recording.RecordingAvailability
+import com.wire.media.recording.RecordingButtonState
+import com.wire.media.recording.RecordingCapability
+import com.wire.media.recording.RecordingCapabilityResult
+import com.wire.media.recording.RecordingDialogState
+import com.wire.media.recording.RecordingPreview
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class)
 class RecordAudioViewModelTest {
-
     @Test
-    fun `given user is in a call, when start recording audio, then a info message will be shown`() =
-        runTest {
-            // given
-            val (_, viewModel) = Arrangement()
-                .withEstablishedCall()
-                .withFilterEnabled(false)
-                .arrange()
+    fun `ongoing call prevents recording and shows call message`() = runTest {
+        val (arrangement, viewModel) = Arrangement().withEstablishedCall().arrange()
 
-            viewModel.getInfoMessage().test {
-                // when
-                viewModel.startRecording()
-
-                // then
-                val result = awaitItem()
-                assertEquals(
-                    RecordAudioInfoMessageType.UnableToRecordAudioCall.uiText,
-                    result
-                )
-            }
-        }
-
-    @Test
-    fun `given user is not in a call, when start recording audio, then recording screen is shown`() =
-        runTest {
-            // given
-            val (arrangement, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
-
-            // when
+        viewModel.getInfoMessage().test {
             viewModel.startRecording()
+            runCurrent()
 
-            // then
+            assertEquals(RecordAudioInfoMessageType.UnableToRecordAudioCall.uiText, awaitItem())
+            coVerify(exactly = 0) { arrangement.audioRecorder.start(any()) }
+        }
+    }
+
+    @Test
+    fun `successful start exposes common recording state`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+
+        viewModel.startRecording()
+        runCurrent()
+
+        assertEquals(RecordingButtonState.RECORDING, viewModel.state.buttonState)
+        assertEquals(arrangement.originalPath, viewModel.state.originalOutputFile)
+        coVerify(exactly = 1) { arrangement.getAssetSizeLimit(false) }
+        coVerify(exactly = 1) { arrangement.audioRecorder.start(ASSET_SIZE_LIMIT) }
+    }
+
+    @Test
+    fun `unsupported recorder remains explicit and reports an error`() = runTest {
+        val (_, viewModel) = Arrangement()
+            .withStartResult(RecordingCapabilityResult.Unsupported)
+            .arrange()
+
+        viewModel.getInfoMessage().test {
+            viewModel.startRecording()
+            runCurrent()
+
             assertEquals(
-                RecordAudioButtonState.RECORDING,
-                viewModel.state.buttonState
+                RecordingAvailability.Unsupported(RecordingCapability.RECORDING),
+                viewModel.state.availability,
             )
-            coVerify(exactly = 1) { arrangement.getAssetSizeLimit(false) }
-            verify(exactly = 1) { arrangement.audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) }
-            verify(exactly = 1) { arrangement.audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) }
-            verify(exactly = 1) { arrangement.audioMediaRecorder.startRecording() }
+            assertEquals(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText, awaitItem())
         }
+    }
 
     @Test
-    fun `given user is recording audio without filter, when stopping the recording, then send audio button is shown`() =
-        runTest {
-            // given
-            val (arrangement, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
+    fun `stopping filtered recording delegates effects and exposes ready state`() = runTest {
+        val (arrangement, viewModel) = Arrangement().withEffectsEnabled(true).arrange()
+        runCurrent()
+        viewModel.startRecording()
+        runCurrent()
 
-            viewModel.startRecording()
+        viewModel.stopRecording()
+        runCurrent()
 
-            // when
-            viewModel.stopRecording()
-
-            // then
-            coVerify(exactly = 0) {
-                arrangement.generateAudioFileWithEffects(
-                    context = any(),
-                    originalFilePath = any(),
-                    effectsFilePath = any()
-                )
-            }
-            assertEquals(
-                RecordAudioButtonState.READY_TO_SEND,
-                viewModel.state.buttonState
-            )
-        }
+        assertEquals(RecordingButtonState.READY_TO_SEND, viewModel.state.buttonState)
+        assertEquals(arrangement.effectsPath, viewModel.getPlayableAudioFile())
+        coVerify(exactly = 1) { arrangement.effectsProcessor.process(any()) }
+        assertEquals(AudioState.TotalTimeInMs.Known(DURATION_MS), viewModel.state.audioState.totalTimeInMs)
+    }
 
     @Test
-    fun `given user is recording audio with filter, when stopping the recording, then send audio button is shown`() =
-        runTest {
-            // given
-            val (arrangement, viewModel) = Arrangement()
-                .withFilterEnabled(true)
-                .arrange()
+    fun `background transition stops active recording`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        viewModel.startRecording()
+        runCurrent()
 
-            viewModel.startRecording()
+        arrangement.currentScreen.value = CurrentScreen.InBackground
+        runCurrent()
 
-            // when
-            viewModel.stopRecording()
+        coVerify(exactly = 1) { arrangement.audioRecorder.stop() }
+        assertEquals(RecordingButtonState.READY_TO_SEND, viewModel.state.buttonState)
+    }
 
-            // then
+    @Test
+    fun `call starting while recording stops it`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        viewModel.startRecording()
+        runCurrent()
+
+        arrangement.calls.value = listOf(DUMMY_CALL.copy(status = CallStatus.ESTABLISHED))
+        runCurrent()
+
+        coVerify(exactly = 1) { arrangement.audioRecorder.stop() }
+        assertEquals(RecordingButtonState.READY_TO_SEND, viewModel.state.buttonState)
+    }
+
+    @Test
+    fun `maximum size event stops and shows size dialog`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        viewModel.startRecording()
+        runCurrent()
+
+        arrangement.recorderEvents.emit(AudioRecorderEvent.MaxFileSizeReached(ASSET_SIZE_LIMIT))
+        runCurrent()
+
+        assertEquals(RecordingDialogState.MaxFileSizeReached(5), viewModel.state.maxFileSizeReachedDialogState)
+        coVerify(exactly = 1) { arrangement.audioRecorder.stop() }
+    }
+
+    @Test
+    fun `discard returns common action`() = runTest {
+        val (_, viewModel) = Arrangement().arrange()
+        viewModel.startRecording()
+        runCurrent()
+
+        viewModel.actions.test {
+            viewModel.discardRecording()
+            runCurrent()
+
+            assertEquals(RecordingAction.Discarded, awaitItem())
+            assertEquals(RecordingButtonState.ENABLED, viewModel.state.buttonState)
+        }
+    }
+
+    @Test
+    fun `send returns common path result without Android uri`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        viewModel.startRecording()
+        runCurrent()
+        viewModel.stopRecording()
+        runCurrent()
+
+        viewModel.actions.test {
+            viewModel.sendRecording()
+            runCurrent()
+
+            val action = awaitItem() as RecordingAction.Recorded
+            assertEquals(arrangement.encodedPath, action.recording.path)
+            assertEquals(M4A_AUDIO_MIME_TYPE, action.recording.mimeType)
             coVerify(exactly = 1) {
-                arrangement.generateAudioFileWithEffects(
-                    context = any(),
-                    originalFilePath = any(),
-                    effectsFilePath = any(),
-                )
-            }
-            assertEquals(
-                RecordAudioButtonState.READY_TO_SEND,
-                viewModel.state.buttonState
-            )
-        }
-
-    @Test
-    fun `given user is recording audio without filter, when applying filter after recording, then effects file is generated`() =
-        runTest {
-            // given
-            val (arrangement, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
-
-            viewModel.startRecording()
-            viewModel.stopRecording()
-            assertEquals(null, viewModel.state.effectsOutputFile)
-            coVerify(exactly = 0) {
-                arrangement.generateAudioFileWithEffects(
-                    context = any(),
-                    originalFilePath = any(),
-                    effectsFilePath = any()
-                )
-            }
-
-            // when
-            viewModel.setShouldApplyEffects(true)
-
-            // then
-            coVerify(exactly = 1) {
-                arrangement.generateAudioFileWithEffects(
-                    context = any(),
-                    originalFilePath = any(),
-                    effectsFilePath = any()
-                )
-            }
-            assert(viewModel.state.effectsOutputFile != null)
-            assertEquals(
-                RecordAudioButtonState.READY_TO_SEND,
-                viewModel.state.buttonState
-            )
-        }
-
-    @Test
-    fun `given user is not recording, when closing audio recording view, then verify that close recording view is called`() =
-        runTest {
-            // given
-            val (_, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
-
-            viewModel.actions.test {
-                // when
-                viewModel.showDiscardRecordingDialog()
-                // then
-                assertEquals(
-                    RecordAudioDialogState.Hidden,
-                    viewModel.state.discardDialogState
-                )
-                assertEquals(
-                    RecordAudioViewActions.Discarded,
-                    awaitItem()
-                )
+                arrangement.audioRecorder.encode(arrangement.originalPath, arrangement.encodedPath)
             }
         }
+    }
 
     @Test
-    fun `given user is recording, when closing audio recording view, then discard audio recording dialog is shown`() =
-        runTest {
-            // given
-            val (_, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
+    fun `preview actions use narrow preview capability`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
+        viewModel.startRecording()
+        runCurrent()
+        viewModel.stopRecording()
+        runCurrent()
 
-            viewModel.startRecording()
+        viewModel.onPlayAudio()
+        viewModel.onSliderPositionChange(123)
 
-            viewModel.actions.test {
-                // when
-                viewModel.showDiscardRecordingDialog()
-                // then
-                assertEquals(
-                    RecordAudioDialogState.Shown,
-                    viewModel.state.discardDialogState
-                )
-                expectNoEvents()
-            }
-        }
+        verify(exactly = 1) { arrangement.recordingPreview.toggle(arrangement.originalPath) }
+        verify(exactly = 1) { arrangement.recordingPreview.seekTo(123) }
+    }
 
     @Test
-    fun `given discard audio dialog is shown, when dismissing the dialog, then audio recording dialog is hidden`() =
-        runTest {
-            // given
-            val (_, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
+    fun `effects preference is persisted through semantic coordinator action`() = runTest {
+        val (arrangement, viewModel) = Arrangement().arrange()
 
-            // when
-            viewModel.onDismissDiscardDialog()
+        viewModel.setShouldApplyEffects(true)
+        runCurrent()
 
-            // then
-            assertEquals(
-                RecordAudioDialogState.Hidden,
-                viewModel.state.discardDialogState
-            )
-        }
-
-    @Test
-    fun `given user doesn't have audio permissions, when starting to record audio, then permissions dialog is shown`() =
-        runTest {
-            // given
-            val (_, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
-
-            // when
-            viewModel.showPermissionsDeniedDialog()
-
-            // then
-            assertEquals(
-                RecordAudioDialogState.Shown,
-                viewModel.state.permissionsDeniedDialogState
-            )
-        }
-
-    @Test
-    fun `given permissions dialog is shown, when user dismiss the dialog, then permissions dialog is hidden`() =
-        runTest {
-            // given
-            val (_, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
-
-            // when
-            viewModel.onDismissPermissionsDeniedDialog()
-
-            // then
-            assertEquals(
-                RecordAudioDialogState.Hidden,
-                viewModel.state.permissionsDeniedDialogState
-            )
-        }
-
-    @Test
-    fun `given user recorded an audio, when discarding the audio, then file is deleted`() =
-        runTest {
-            // given
-            val (arrangement, viewModel) = Arrangement()
-                .withFilterEnabled(false)
-                .arrange()
-
-            viewModel.startRecording()
-            viewModel.stopRecording()
-
-            viewModel.actions.test {
-                // when
-                viewModel.discardRecording()
-                // then
-                assertEquals(
-                    RecordAudioButtonState.ENABLED,
-                    viewModel.state.buttonState
-                )
-                assertEquals(
-                    RecordAudioDialogState.Hidden,
-                    viewModel.state.discardDialogState
-                )
-                assertEquals(
-                    null,
-                    viewModel.state.originalOutputFile
-                )
-                assertEquals(
-                    RecordAudioViewActions.Discarded,
-                    awaitItem()
-                )
-
-                verify(exactly = 1) { arrangement.audioFocusHelper.requestExclusive() }
-                verify(exactly = 2) { arrangement.audioFocusHelper.abandonExclusive() } // 1 before start recording, 1 after
-            }
-        }
-
-    @Test
-    fun `given start recording succeeded, when recording audio, then recording screen is shown`() =
-        runTest {
-            // given
-            val (_, viewModel) = Arrangement()
-                .withStartRecordingSuccessful()
-                .withFilterEnabled(false)
-                .arrange()
-
-            viewModel.getInfoMessage().test {
-                // when
-                viewModel.startRecording()
-                // then
-                assertEquals(RecordAudioButtonState.RECORDING, viewModel.state.buttonState)
-                expectNoEvents()
-            }
-        }
-
-    @Test
-    fun `given start recording failed, when recording audio, then info message is shown`() =
-        runTest {
-            // given
-            val (arrangement, viewModel) = Arrangement()
-                .withStartRecordingFailed()
-                .withFilterEnabled(false)
-                .arrange()
-
-            viewModel.getInfoMessage().test {
-                // when
-                viewModel.startRecording()
-                // then
-                assertEquals(RecordAudioButtonState.ENABLED, viewModel.state.buttonState)
-                assertEquals(RecordAudioInfoMessageType.UnableToRecordAudioError.uiText, awaitItem())
-
-                verify(exactly = 1) { arrangement.audioFocusHelper.requestExclusive() }
-            }
-        }
+        coVerify(exactly = 1) { arrangement.globalDataStore.setRecordAudioEffectsCheckboxEnabled(true) }
+        assertTrue(viewModel.state.shouldApplyEffects)
+    }
 
     private class Arrangement {
-
-        val recordAudioMessagePlayer = mockk<RecordAudioMessagePlayer>()
-        val audioMediaRecorder = mockk<AudioMediaRecorder>()
+        val audioRecorder = mockk<AudioRecorder>()
+        val recordingPreview = mockk<RecordingPreview>()
+        val effectsProcessor = mockk<AudioEffectsProcessor>()
+        val mediaMetadataReader = mockk<MediaMetadataReader>()
         val observeEstablishedCalls = mockk<ObserveEstablishedCallsUseCase>()
         val currentScreenManager = mockk<CurrentScreenManager>()
         val getAssetSizeLimit = mockk<GetAssetSizeLimitUseCase>()
         val globalDataStore = mockk<GlobalDataStore>()
-        val generateAudioFileWithEffects = mockk<GenerateAudioFileWithEffectsUseCase>()
-        val context = mockk<Context>()
-        val dispatchers = TestDispatcherProvider()
-        val fakeKaliumFileSystem = FakeKaliumFileSystem()
         val audioNormalizedLoudnessBuilder = mockk<AudioNormalizedLoudnessBuilder>()
-        val audioFocusHelper = mockk<AudioFocusHelper>()
+        val fileSystem = FakeKaliumFileSystem()
+        val recorderEvents = MutableSharedFlow<AudioRecorderEvent>(extraBufferCapacity = 1)
+        val previewState = MutableStateFlow(AudioState.DEFAULT)
+        val currentScreen = MutableStateFlow<CurrentScreen>(CurrentScreen.Conversation(DUMMY_CALL.conversationId))
+        val calls = MutableStateFlow<List<Call>>(emptyList())
+        val effectsEnabled = MutableStateFlow(false)
+        val originalPath = "/tmp/recording.wav".toPath()
+        val encodedPath = "/tmp/recording.m4a".toPath()
+        val effectsPath = "/tmp/recording-filter.wav".toPath()
+        private var startResult: RecordingCapabilityResult<AudioRecordingFiles> =
+            RecordingCapabilityResult.Success(AudioRecordingFiles(originalPath, encodedPath))
 
-        val viewModel by lazy {
+        private val viewModel by lazy {
             RecordAudioViewModel(
-                context = context,
-                recordAudioMessagePlayer = recordAudioMessagePlayer,
                 observeEstablishedCalls = observeEstablishedCalls,
-                currentScreenManager = currentScreenManager,
-                audioMediaRecorder = audioMediaRecorder,
                 getAssetSizeLimit = getAssetSizeLimit,
-                generateAudioFileWithEffects = generateAudioFileWithEffects,
+                currentScreenManager = currentScreenManager,
+                audioRecorder = audioRecorder,
+                recordingPreview = recordingPreview,
+                effectsProcessor = effectsProcessor,
+                mediaMetadataReader = mediaMetadataReader,
                 globalDataStore = globalDataStore,
-                dispatchers = dispatchers,
                 audioNormalizedLoudnessBuilder = audioNormalizedLoudnessBuilder,
-                kaliumFileSystem = fakeKaliumFileSystem,
-                audioFocusHelper = audioFocusHelper
+                kaliumFileSystem = fileSystem,
             )
         }
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
-
-            coEvery { getAssetSizeLimit.invoke(false) } returns ASSET_SIZE_LIMIT
-            every { audioMediaRecorder.setUp(ASSET_SIZE_LIMIT) } returns Unit
-            every { audioMediaRecorder.startRecording() } returns true
-            coEvery { audioMediaRecorder.stop() } returns Unit
-            every { audioMediaRecorder.release() } returns Unit
+            coEvery { getAssetSizeLimit(false) } returns ASSET_SIZE_LIMIT
+            every { audioRecorder.events } returns recorderEvents
+            coEvery { audioRecorder.start(any()) } answers { startResult }
+            coEvery { audioRecorder.stop() } returns RecordingCapabilityResult.Success(Unit)
+            coEvery { audioRecorder.encode(any(), any()) } returns RecordingCapabilityResult.Success(encodedPath)
+            every { audioRecorder.release() } returns Unit
+            every { recordingPreview.state } returns previewState
+            every { recordingPreview.toggle(any()) } returns RecordingCapabilityResult.Success(Unit)
+            every { recordingPreview.seekTo(any()) } returns RecordingCapabilityResult.Success(Unit)
+            every { recordingPreview.stop() } returns RecordingCapabilityResult.Success(Unit)
+            every { recordingPreview.release() } returns Unit
+            coEvery { effectsProcessor.process(any()) } answers {
+                RecordingCapabilityResult.Success(firstArg<com.wire.media.recording.AudioEffectsRequest>().destination)
+            }
+            coEvery { mediaMetadataReader.read(any(), any()) } returns PlatformResult.Success(
+                AssetContent.AssetMetadata.Audio(DURATION_MS.toLong(), null)
+            )
+            coEvery { audioNormalizedLoudnessBuilder(any()) } returns byteArrayOf(1, 2)
+            coEvery { observeEstablishedCalls() } returns calls
+            coEvery { currentScreenManager.observeCurrentScreen(any()) } returns currentScreen
+            every { globalDataStore.isRecordAudioEffectsCheckboxEnabled() } returns effectsEnabled
             coEvery { globalDataStore.setRecordAudioEffectsCheckboxEnabled(any()) } returns Unit
-            every { audioMediaRecorder.originalOutputPath } returns fakeKaliumFileSystem
-                .tempFilePath("temp_recording.wav")
-            coEvery { audioMediaRecorder.getMaxFileSizeReached() } returns flowOf(
-                RecordAudioDialogState.MaxFileSizeReached(
-                    maxSize = ASSET_SIZE_DEFAULT_LIMIT_BYTES
-                )
-            )
-            coEvery { generateAudioFileWithEffects(any(), any(), any()) } returns Unit
-
-            coEvery { currentScreenManager.observeCurrentScreen(any()) } returns MutableStateFlow(
-                CurrentScreen.Conversation(id = DUMMY_CALL.conversationId)
-            )
-
-            coEvery { recordAudioMessagePlayer.audioMessageStateFlow } returns flowOf(
-                AudioState.DEFAULT
-            )
-            coEvery { recordAudioMessagePlayer.stop() } returns Unit
-            coEvery { recordAudioMessagePlayer.close() } returns Unit
-
-            coEvery { observeEstablishedCalls() } returns flowOf(listOf())
-
-            coEvery { audioNormalizedLoudnessBuilder(any<String>()) } returns byteArrayOf()
-
-            every { audioFocusHelper.requestExclusive() } returns true
-            every { audioFocusHelper.abandonExclusive() } returns Unit
         }
 
         fun withEstablishedCall() = apply {
-            coEvery { observeEstablishedCalls() } returns flowOf(
-                listOf(
-                    DUMMY_CALL.copy(status = CallStatus.ESTABLISHED)
-                )
-            )
+            calls.value = listOf(DUMMY_CALL.copy(status = CallStatus.ESTABLISHED))
         }
 
-        fun withStartRecordingSuccessful() = apply { every { audioMediaRecorder.startRecording() } returns true }
-        fun withStartRecordingFailed() = apply { every { audioMediaRecorder.startRecording() } returns false }
+        fun withEffectsEnabled(enabled: Boolean) = apply {
+            effectsEnabled.value = enabled
+        }
 
-        fun withFilterEnabled(isEnabled: Boolean) = apply {
-            every { globalDataStore.isRecordAudioEffectsCheckboxEnabled() } returns flowOf(isEnabled)
+        fun withStartResult(result: RecordingCapabilityResult<AudioRecordingFiles>) = apply {
+            startResult = result
         }
 
         fun arrange() = this to viewModel
+    }
 
-        companion object {
-            const val ASSET_SIZE_LIMIT = 5L
-            val DUMMY_CALL = Call(
-                conversationId = ConversationId(
-                    value = "conversationId",
-                    domain = "conversationDomain"
-                ),
-                status = CallStatus.CLOSED,
-                callerId = UserId("caller", "domain"),
-                participants = listOf(),
-                isMuted = true,
-                isCameraOn = false,
-                isCbrEnabled = false,
-                maxParticipants = 0,
-                conversationName = "ONE_ON_ONE Name",
-                conversationType = Conversation.Type.OneOnOne,
-                callerName = "otherUsername",
-                callerTeamName = "team_1"
-            )
-        }
+    private companion object {
+        const val ASSET_SIZE_LIMIT = 5L * 1_024L * 1_024L
+        const val DURATION_MS = 1_234
+        val DUMMY_CALL = Call(
+            conversationId = ConversationId("conversationId", "conversationDomain"),
+            status = CallStatus.CLOSED,
+            callerId = UserId("caller", "domain"),
+            participants = emptyList(),
+            isMuted = true,
+            isCameraOn = false,
+            isCbrEnabled = false,
+            maxParticipants = 0,
+            conversationName = "ONE_ON_ONE Name",
+            conversationType = Conversation.Type.OneOnOne,
+            callerName = "otherUsername",
+            callerTeamName = "team_1",
+        )
     }
 }

--- a/core/audio-recording-kmp/build.gradle.kts
+++ b/core/audio-recording-kmp/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+    id(libs.plugins.wire.kmp.library.get().pluginId)
+}
+
+kotlin {
+    android {
+        namespace = "com.wire.media.recording"
+        withHostTest {}
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":core:content-kmp"))
+                api(project(":core:media-player-kmp"))
+                api("com.wire.kalium:kalium-logic")
+                api(libs.coroutines.core)
+                api(libs.okio.core)
+                implementation(libs.jetbrains.compose.runtime)
+            }
+        }
+
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.coroutines.test)
+                implementation(libs.okio.fakeFileSystem)
+            }
+        }
+    }
+}

--- a/core/audio-recording-kmp/src/commonMain/kotlin/com/wire/media/recording/AudioRecordingCoordinator.kt
+++ b/core/audio-recording-kmp/src/commonMain/kotlin/com/wire/media/recording/AudioRecordingCoordinator.kt
@@ -1,0 +1,334 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.recording
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.wire.content.external.PlatformResult
+import com.wire.content.media.MediaMetadataReader
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
+import com.wire.media.player.AudioMediaPlayingState
+import com.wire.media.player.AudioState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okio.Path
+import okio.Path.Companion.toPath
+
+@Suppress("TooManyFunctions")
+class AudioRecordingCoordinator(
+    private val audioRecorder: AudioRecorder,
+    private val recordingPreview: RecordingPreview,
+    private val effectsProcessor: AudioEffectsProcessor,
+    private val metadataReader: MediaMetadataReader,
+    private val fileSystem: KaliumFileSystem,
+    private val loudnessBuilder: AudioNormalizedLoudnessBuilder,
+    scope: CoroutineScope,
+) {
+    var state: AudioRecordingState by mutableStateOf(AudioRecordingState())
+        private set
+
+    private val mutableIssues = MutableSharedFlow<RecordingAvailability>(extraBufferCapacity = 1)
+    val issues: SharedFlow<RecordingAvailability> = mutableIssues.asSharedFlow()
+
+    private val operationMutex = Mutex()
+    private var recordingFiles: AudioRecordingFiles? = null
+    private var effectsPath: Path? = null
+
+    init {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            recordingPreview.state.collect { previewState ->
+                state = state.copy(audioState = previewState)
+            }
+        }
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
+            audioRecorder.events.collect(::handleRecorderEvent)
+        }
+    }
+
+    suspend fun startRecording(maximumSizeBytes: Long): RecordingCapabilityResult<Unit> = operationMutex.withLock {
+        if (state.buttonState != RecordingButtonState.ENABLED) {
+            return@withLock RecordingCapabilityResult.Failure("invalid_recording_state")
+        }
+        when (val result = audioRecorder.start(maximumSizeBytes)) {
+            is RecordingCapabilityResult.Success -> {
+                recordingFiles = result.value
+                effectsPath = result.value.originalWav.effectsPath()
+                state = state.copy(
+                    buttonState = RecordingButtonState.RECORDING,
+                    originalOutputFile = result.value.originalWav,
+                    effectsOutputFile = effectsPath.takeIf { state.shouldApplyEffects },
+                    availability = RecordingAvailability.Available,
+                )
+                RecordingCapabilityResult.Success(Unit)
+            }
+            RecordingCapabilityResult.Unsupported -> unsupported(RecordingCapability.RECORDING)
+            is RecordingCapabilityResult.Failure -> failed(RecordingCapability.RECORDING, result.reason)
+        }
+    }
+
+    suspend fun stopRecording(): RecordingCapabilityResult<Unit> = operationMutex.withLock {
+        stopRecordingLocked()
+    }
+
+    suspend fun setEffectsEnabled(enabled: Boolean): RecordingCapabilityResult<Unit> = operationMutex.withLock {
+        state = state.copy(shouldApplyEffects = enabled)
+        if (!enabled || state.buttonState != RecordingButtonState.READY_TO_SEND) {
+            return@withLock RecordingCapabilityResult.Success(Unit)
+        }
+
+        val existingEffects = effectsPath?.takeIf(fileSystem::exists)
+        if (existingEffects != null) {
+            state = state.copy(effectsOutputFile = existingEffects)
+            return@withLock RecordingCapabilityResult.Success(Unit)
+        }
+
+        state = state.copy(
+            buttonState = RecordingButtonState.ENCODING,
+            audioState = state.audioState.copy(audioMediaPlayingState = AudioMediaPlayingState.Fetching),
+        )
+        val result = processEffectsLocked()
+        updateReadyState(playablePath())
+        result
+    }
+
+    fun playablePath(): Path? = if (state.shouldApplyEffects) {
+        state.effectsOutputFile
+    } else {
+        state.originalOutputFile
+    }
+
+    fun togglePreview(): RecordingCapabilityResult<Unit> {
+        val path = playablePath() ?: return RecordingCapabilityResult.Failure("recording_unavailable")
+        return recordingPreview.toggle(path).recordPreviewAvailability()
+    }
+
+    fun seekPreview(positionMs: Int): RecordingCapabilityResult<Unit> =
+        recordingPreview.seekTo(positionMs).recordPreviewAvailability()
+
+    fun stopPreview(): RecordingCapabilityResult<Unit> = recordingPreview.stop().recordPreviewAvailability()
+
+    suspend fun discard(): RecordingAction = operationMutex.withLock {
+        recordingPreview.stop()
+        if (state.buttonState == RecordingButtonState.RECORDING) audioRecorder.stop() else audioRecorder.release()
+        cleanupPaths()
+        resetState()
+        RecordingAction.Discarded
+    }
+
+    suspend fun finish(): RecordingCapabilityResult<RecordedAudio> = operationMutex.withLock {
+        val source = playablePath() ?: return@withLock RecordingCapabilityResult.Failure("recording_unavailable")
+        val destination = recordingFiles?.encodedM4a
+            ?: return@withLock RecordingCapabilityResult.Failure("encoding_destination_unavailable")
+        recordingPreview.stop()
+        state = state.copy(buttonState = RecordingButtonState.ENCODING, audioState = AudioState.DEFAULT)
+
+        val output = when (val encoding = audioRecorder.encode(source, destination)) {
+            is RecordingCapabilityResult.Success -> encoding.value
+            RecordingCapabilityResult.Unsupported -> {
+                markUnsupported(RecordingCapability.ENCODING)
+                deleteIfExists(destination)
+                state = state.copy(buttonState = RecordingButtonState.READY_TO_SEND)
+                return@withLock RecordingCapabilityResult.Unsupported
+            }
+            is RecordingCapabilityResult.Failure -> {
+                markFailed(RecordingCapability.ENCODING, encoding.reason)
+                deleteIfExists(destination)
+                source
+            }
+        }
+        val mimeType = if (output == destination) M4A_AUDIO_MIME_TYPE else WAV_AUDIO_MIME_TYPE
+        val recorded = RecordedAudio(output, mimeType, state.wavesMask.orEmpty())
+        cleanupPaths(except = output)
+        val availability = state.availability
+        resetState(availability)
+        RecordingCapabilityResult.Success(recorded)
+    }
+
+    fun showDiscardDialog() {
+        state = state.copy(discardDialogState = RecordingDialogState.Shown)
+    }
+
+    fun dismissDiscardDialog() {
+        state = state.copy(discardDialogState = RecordingDialogState.Hidden)
+    }
+
+    fun showPermissionsDeniedDialog() {
+        state = state.copy(permissionsDeniedDialogState = RecordingDialogState.Shown)
+    }
+
+    fun dismissPermissionsDeniedDialog() {
+        state = state.copy(permissionsDeniedDialogState = RecordingDialogState.Hidden)
+    }
+
+    fun dismissMaxFileSizeDialog() {
+        state = state.copy(maxFileSizeReachedDialogState = RecordingDialogState.Hidden)
+    }
+
+    fun release() {
+        recordingPreview.release()
+        audioRecorder.release()
+        cleanupPaths()
+        recordingFiles = null
+        effectsPath = null
+    }
+
+    private suspend fun stopRecordingLocked(): RecordingCapabilityResult<Unit> {
+        if (state.buttonState != RecordingButtonState.RECORDING) return RecordingCapabilityResult.Success(Unit)
+        state = state.copy(
+            buttonState = RecordingButtonState.ENCODING,
+            audioState = state.audioState.copy(audioMediaPlayingState = AudioMediaPlayingState.Fetching),
+        )
+        val stopResult = audioRecorder.stop()
+        when (stopResult) {
+            RecordingCapabilityResult.Unsupported -> markUnsupported(RecordingCapability.RECORDING)
+            is RecordingCapabilityResult.Failure -> markFailed(RecordingCapability.RECORDING, stopResult.reason)
+            is RecordingCapabilityResult.Success -> Unit
+        }
+        if (state.shouldApplyEffects) processEffectsLocked()
+        updateReadyState(playablePath())
+        return stopResult
+    }
+
+    private suspend fun processEffectsLocked(): RecordingCapabilityResult<Unit> {
+        val source = state.originalOutputFile ?: return RecordingCapabilityResult.Failure("recording_unavailable")
+        val destination = effectsPath ?: source.effectsPath().also { effectsPath = it }
+        return when (val result = effectsProcessor.process(AudioEffectsRequest(source, destination))) {
+            is RecordingCapabilityResult.Success -> {
+                state = state.copy(effectsOutputFile = result.value)
+                RecordingCapabilityResult.Success(Unit)
+            }
+            RecordingCapabilityResult.Unsupported -> {
+                deleteIfExists(destination)
+                state = state.copy(shouldApplyEffects = false, effectsOutputFile = null)
+                unsupported(RecordingCapability.EFFECTS)
+            }
+            is RecordingCapabilityResult.Failure -> {
+                deleteIfExists(destination)
+                state = state.copy(shouldApplyEffects = false, effectsOutputFile = null)
+                failed(RecordingCapability.EFFECTS, result.reason)
+            }
+        }
+    }
+
+    private suspend fun updateReadyState(path: Path?) {
+        val durationMs = path?.let { readDuration(it) } ?: 0
+        val waves = path?.let { buildWaves(it) }.orEmpty()
+        state = state.copy(
+            buttonState = RecordingButtonState.READY_TO_SEND,
+            audioState = AudioState.DEFAULT.copy(
+                totalTimeInMs = AudioState.TotalTimeInMs.Known(durationMs),
+            ),
+            wavesMask = waves,
+        )
+    }
+
+    private suspend fun readDuration(path: Path): Int =
+        when (val result = metadataReader.read(path, WAV_AUDIO_MIME_TYPE)) {
+            is PlatformResult.Success ->
+                ((result.value as? AssetContent.AssetMetadata.Audio)?.durationMs ?: 0L).toInt()
+            else -> 0
+        }
+
+    private suspend fun buildWaves(path: Path): List<Int> = try {
+        loudnessBuilder(path.toString())?.map { it.toUByte().toInt() }.orEmpty()
+    } catch (cancelled: CancellationException) {
+        throw cancelled
+    } catch (_: Exception) {
+        emptyList()
+    }
+
+    private suspend fun handleRecorderEvent(event: AudioRecorderEvent) {
+        when (event) {
+            is AudioRecorderEvent.MaxFileSizeReached -> {
+                stopRecording()
+                state = state.copy(
+                    maxFileSizeReachedDialogState = RecordingDialogState.MaxFileSizeReached(
+                        RecordingSizePolicy.megabytes(event.maximumSizeBytes)
+                    )
+                )
+            }
+            is AudioRecorderEvent.Interrupted -> {
+                stopRecording()
+            }
+        }
+    }
+
+    private fun <T> unsupported(capability: RecordingCapability): RecordingCapabilityResult<T> {
+        markUnsupported(capability)
+        return RecordingCapabilityResult.Unsupported
+    }
+
+    private fun <T> failed(capability: RecordingCapability, reason: String?): RecordingCapabilityResult<T> {
+        markFailed(capability, reason)
+        return RecordingCapabilityResult.Failure(reason)
+    }
+
+    private fun markUnsupported(capability: RecordingCapability) {
+        val issue = RecordingAvailability.Unsupported(capability)
+        state = state.copy(availability = issue)
+        mutableIssues.tryEmit(issue)
+    }
+
+    private fun markFailed(capability: RecordingCapability, reason: String?) {
+        val issue = RecordingAvailability.Failed(capability, reason)
+        state = state.copy(availability = issue)
+        mutableIssues.tryEmit(issue)
+    }
+
+    private fun RecordingCapabilityResult<Unit>.recordPreviewAvailability(): RecordingCapabilityResult<Unit> = also {
+        when (it) {
+            RecordingCapabilityResult.Unsupported -> markUnsupported(RecordingCapability.PREVIEW)
+            is RecordingCapabilityResult.Failure -> markFailed(RecordingCapability.PREVIEW, it.reason)
+            is RecordingCapabilityResult.Success -> Unit
+        }
+    }
+
+    private fun cleanupPaths(except: Path? = null) {
+        val paths = buildSet {
+            recordingFiles?.let {
+                add(it.originalWav)
+                add(it.encodedM4a)
+            }
+            effectsPath?.let(::add)
+            state.originalOutputFile?.let(::add)
+            state.effectsOutputFile?.let(::add)
+        }
+        paths.filterNot { it == except }.forEach(::deleteIfExists)
+        recordingFiles = null
+        effectsPath = null
+    }
+
+    private fun deleteIfExists(path: Path) {
+        if (fileSystem.exists(path)) fileSystem.delete(path)
+    }
+
+    private fun resetState(availability: RecordingAvailability = RecordingAvailability.Available) {
+        state = AudioRecordingState(
+            shouldApplyEffects = state.shouldApplyEffects,
+            availability = availability,
+        )
+    }
+
+    private fun Path.effectsPath(): Path {
+        val stem = name.substringBeforeLast('.', name)
+        return parent?.resolve("$stem-filter.wav") ?: "$stem-filter.wav".toPath()
+    }
+}

--- a/core/audio-recording-kmp/src/commonMain/kotlin/com/wire/media/recording/RecordingModels.kt
+++ b/core/audio-recording-kmp/src/commonMain/kotlin/com/wire/media/recording/RecordingModels.kt
@@ -1,0 +1,155 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.recording
+
+import com.wire.media.player.AudioState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import okio.Path
+
+data class AudioRecordingState(
+    val buttonState: RecordingButtonState = RecordingButtonState.ENABLED,
+    val discardDialogState: RecordingDialogState = RecordingDialogState.Hidden,
+    val permissionsDeniedDialogState: RecordingDialogState = RecordingDialogState.Hidden,
+    val maxFileSizeReachedDialogState: RecordingDialogState = RecordingDialogState.Hidden,
+    val originalOutputFile: Path? = null,
+    val effectsOutputFile: Path? = null,
+    val shouldApplyEffects: Boolean = false,
+    val audioState: AudioState = AudioState.DEFAULT,
+    val wavesMask: List<Int>? = null,
+    val availability: RecordingAvailability = RecordingAvailability.Available,
+)
+
+enum class RecordingButtonState {
+    ENABLED,
+    RECORDING,
+    READY_TO_SEND,
+    ENCODING,
+}
+
+sealed interface RecordingDialogState {
+    data object Shown : RecordingDialogState
+    data object Hidden : RecordingDialogState
+    data class MaxFileSizeReached(val maxSize: Long) : RecordingDialogState
+}
+
+enum class RecordingCapability {
+    RECORDING,
+    PREVIEW,
+    EFFECTS,
+    ENCODING,
+}
+
+sealed interface RecordingAvailability {
+    data object Available : RecordingAvailability
+    data class Unsupported(val capability: RecordingCapability) : RecordingAvailability
+    data class Failed(val capability: RecordingCapability, val reason: String? = null) : RecordingAvailability
+}
+
+data class AudioRecordingFiles(
+    val originalWav: Path,
+    val encodedM4a: Path,
+)
+
+data class RecordedAudio(
+    val path: Path,
+    val mimeType: String,
+    val audioWavesMask: List<Int>,
+)
+
+sealed interface RecordingAction {
+    data object Discarded : RecordingAction
+    data class Recorded(val recording: RecordedAudio) : RecordingAction
+}
+
+sealed interface RecordingCapabilityResult<out T> {
+    data class Success<T>(val value: T) : RecordingCapabilityResult<T>
+    data object Unsupported : RecordingCapabilityResult<Nothing>
+    data class Failure(val reason: String? = null) : RecordingCapabilityResult<Nothing>
+}
+
+sealed interface AudioRecorderEvent {
+    data class MaxFileSizeReached(val maximumSizeBytes: Long) : AudioRecorderEvent
+    data class Interrupted(val reason: RecordingInterruption) : AudioRecorderEvent
+}
+
+enum class RecordingInterruption {
+    AUDIO_FOCUS,
+}
+
+interface AudioRecorder {
+    val events: Flow<AudioRecorderEvent>
+
+    suspend fun start(maximumSizeBytes: Long): RecordingCapabilityResult<AudioRecordingFiles>
+    suspend fun stop(): RecordingCapabilityResult<Unit>
+    suspend fun encode(source: Path, destination: Path): RecordingCapabilityResult<Path>
+    fun release()
+}
+
+interface RecordingPreview {
+    val state: StateFlow<AudioState>
+
+    fun toggle(path: Path): RecordingCapabilityResult<Unit>
+    fun seekTo(positionMs: Int): RecordingCapabilityResult<Unit>
+    fun stop(): RecordingCapabilityResult<Unit>
+    fun release()
+}
+
+data class AudioEffectsRequest(
+    val source: Path,
+    val destination: Path,
+)
+
+fun interface AudioEffectsProcessor {
+    suspend fun process(request: AudioEffectsRequest): RecordingCapabilityResult<Path>
+}
+
+object UnsupportedAudioRecorder : AudioRecorder {
+    override val events: Flow<AudioRecorderEvent> = emptyFlow()
+
+    override suspend fun start(maximumSizeBytes: Long): RecordingCapabilityResult<AudioRecordingFiles> =
+        RecordingCapabilityResult.Unsupported
+
+    override suspend fun stop(): RecordingCapabilityResult<Unit> = RecordingCapabilityResult.Unsupported
+
+    override suspend fun encode(source: Path, destination: Path): RecordingCapabilityResult<Path> =
+        RecordingCapabilityResult.Unsupported
+
+    override fun release() = Unit
+}
+
+object UnsupportedRecordingPreview : RecordingPreview {
+    override val state: StateFlow<AudioState> = MutableStateFlow(AudioState.DEFAULT)
+
+    override fun toggle(path: Path): RecordingCapabilityResult<Unit> = RecordingCapabilityResult.Unsupported
+    override fun seekTo(positionMs: Int): RecordingCapabilityResult<Unit> = RecordingCapabilityResult.Unsupported
+    override fun stop(): RecordingCapabilityResult<Unit> = RecordingCapabilityResult.Unsupported
+    override fun release() = Unit
+}
+
+object UnsupportedAudioEffectsProcessor : AudioEffectsProcessor {
+    override suspend fun process(request: AudioEffectsRequest): RecordingCapabilityResult<Path> =
+        RecordingCapabilityResult.Unsupported
+}
+
+object RecordingSizePolicy {
+    const val BYTES_PER_MEGABYTE: Long = 1_024L * 1_024L
+
+    fun hasReachedLimit(currentSizeBytes: Long, maximumSizeBytes: Long): Boolean =
+        currentSizeBytes > maximumSizeBytes
+
+    fun megabytes(maximumSizeBytes: Long): Long = maximumSizeBytes / BYTES_PER_MEGABYTE
+}
+
+const val WAV_AUDIO_MIME_TYPE: String = "audio/wav"
+const val M4A_AUDIO_MIME_TYPE: String = "audio/mp4"

--- a/core/audio-recording-kmp/src/commonTest/kotlin/com/wire/media/recording/AudioRecordingCoordinatorTest.kt
+++ b/core/audio-recording-kmp/src/commonTest/kotlin/com/wire/media/recording/AudioRecordingCoordinatorTest.kt
@@ -1,0 +1,303 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.recording
+
+import com.wire.content.external.PlatformResult
+import com.wire.content.media.MediaMetadataReader
+import com.wire.kalium.logic.data.asset.KaliumFileSystem
+import com.wire.kalium.logic.data.message.AssetContent
+import com.wire.kalium.logic.feature.asset.AudioNormalizedLoudnessBuilder
+import com.wire.media.player.AudioState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.Sink
+import okio.Source
+import okio.buffer
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AudioRecordingCoordinatorTest {
+    @Test
+    fun `recording with effects produces ready common state`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.effects.result = RecordingCapabilityResult.Success(arrangement.effectsPath)
+
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+        arrangement.coordinator.setEffectsEnabled(true)
+        arrangement.coordinator.stopRecording()
+
+        assertEquals(RecordingButtonState.READY_TO_SEND, arrangement.coordinator.state.buttonState)
+        assertEquals(arrangement.effectsPath, arrangement.coordinator.playablePath())
+        assertEquals(AudioState.TotalTimeInMs.Known(DURATION_MS), arrangement.coordinator.state.audioState.totalTimeInMs)
+        assertEquals(listOf(1, 255), arrangement.coordinator.state.wavesMask)
+        assertEquals(AudioEffectsRequest(arrangement.originalPath, arrangement.effectsPath), arrangement.effects.requests.single())
+    }
+
+    @Test
+    fun `maximum size event stops recording and exposes size in megabytes`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+
+        arrangement.recorder.mutableEvents.emit(AudioRecorderEvent.MaxFileSizeReached(MAXIMUM_SIZE_BYTES))
+        runCurrent()
+
+        assertEquals(1, arrangement.recorder.stopCount)
+        assertEquals(
+            RecordingDialogState.MaxFileSizeReached(5),
+            arrangement.coordinator.state.maxFileSizeReachedDialogState,
+        )
+        assertEquals(RecordingButtonState.READY_TO_SEND, arrangement.coordinator.state.buttonState)
+    }
+
+    @Test
+    fun `audio focus interruption stops an active recording`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+
+        arrangement.recorder.mutableEvents.emit(AudioRecorderEvent.Interrupted(RecordingInterruption.AUDIO_FOCUS))
+        runCurrent()
+
+        assertEquals(1, arrangement.recorder.stopCount)
+        assertEquals(RecordingButtonState.READY_TO_SEND, arrangement.coordinator.state.buttonState)
+    }
+
+    @Test
+    fun `encoding failure keeps wav fallback and removes partial output`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.recorder.encodeResult = RecordingCapabilityResult.Failure("codec_failed")
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+        arrangement.coordinator.stopRecording()
+        arrangement.fileSystem.write(arrangement.encodedPath)
+
+        val result = arrangement.coordinator.finish()
+
+        val recorded = assertIs<RecordingCapabilityResult.Success<RecordedAudio>>(result).value
+        assertEquals(arrangement.originalPath, recorded.path)
+        assertEquals(WAV_AUDIO_MIME_TYPE, recorded.mimeType)
+        assertTrue(arrangement.fileSystem.exists(arrangement.originalPath))
+        assertFalse(arrangement.fileSystem.exists(arrangement.encodedPath))
+        assertIs<RecordingAvailability.Failed>(arrangement.coordinator.state.availability)
+    }
+
+    @Test
+    fun `unsupported encoding stays explicit and keeps the recording ready`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.recorder.encodeResult = RecordingCapabilityResult.Unsupported
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+        arrangement.coordinator.stopRecording()
+        arrangement.fileSystem.write(arrangement.encodedPath)
+
+        val result = arrangement.coordinator.finish()
+
+        assertEquals(RecordingCapabilityResult.Unsupported, result)
+        assertTrue(arrangement.fileSystem.exists(arrangement.originalPath))
+        assertFalse(arrangement.fileSystem.exists(arrangement.encodedPath))
+        assertEquals(RecordingButtonState.READY_TO_SEND, arrangement.coordinator.state.buttonState)
+        assertEquals(
+            RecordingAvailability.Unsupported(RecordingCapability.ENCODING),
+            arrangement.coordinator.state.availability,
+        )
+    }
+
+    @Test
+    fun `successful encoding keeps only encoded output`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.recorder.encodeResult = RecordingCapabilityResult.Success(arrangement.encodedPath)
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+        arrangement.coordinator.stopRecording()
+        arrangement.fileSystem.write(arrangement.encodedPath)
+
+        val result = arrangement.coordinator.finish()
+
+        val recorded = assertIs<RecordingCapabilityResult.Success<RecordedAudio>>(result).value
+        assertEquals(arrangement.encodedPath, recorded.path)
+        assertEquals(M4A_AUDIO_MIME_TYPE, recorded.mimeType)
+        assertFalse(arrangement.fileSystem.exists(arrangement.originalPath))
+        assertTrue(arrangement.fileSystem.exists(arrangement.encodedPath))
+    }
+
+    @Test
+    fun `discard stops recording and removes every session file`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+        arrangement.fileSystem.write(arrangement.effectsPath)
+        arrangement.fileSystem.write(arrangement.encodedPath)
+
+        val action = arrangement.coordinator.discard()
+
+        assertEquals(RecordingAction.Discarded, action)
+        assertEquals(1, arrangement.recorder.stopCount)
+        assertFalse(arrangement.fileSystem.exists(arrangement.originalPath))
+        assertFalse(arrangement.fileSystem.exists(arrangement.effectsPath))
+        assertFalse(arrangement.fileSystem.exists(arrangement.encodedPath))
+    }
+
+    @Test
+    fun `unsupported recorder remains explicit in common state`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.recorder.startResult = RecordingCapabilityResult.Unsupported
+
+        val result = arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+
+        assertEquals(RecordingCapabilityResult.Unsupported, result)
+        assertEquals(
+            RecordingAvailability.Unsupported(RecordingCapability.RECORDING),
+            arrangement.coordinator.state.availability,
+        )
+        assertEquals(RecordingButtonState.ENABLED, arrangement.coordinator.state.buttonState)
+    }
+
+    @Test
+    fun `effects failure falls back to original recording`() = runTest {
+        val arrangement = Arrangement(backgroundScope)
+        arrangement.effects.result = RecordingCapabilityResult.Failure("effect_failed")
+        arrangement.coordinator.setEffectsEnabled(true)
+        arrangement.coordinator.startRecording(MAXIMUM_SIZE_BYTES)
+
+        arrangement.coordinator.stopRecording()
+
+        assertEquals(arrangement.originalPath, arrangement.coordinator.playablePath())
+        assertFalse(arrangement.coordinator.state.shouldApplyEffects)
+        assertFalse(arrangement.fileSystem.exists(arrangement.effectsPath))
+        assertIs<RecordingAvailability.Failed>(arrangement.coordinator.state.availability)
+    }
+
+    @Test
+    fun `size policy uses byte limit without multiplying it again`() {
+        assertFalse(RecordingSizePolicy.hasReachedLimit(MAXIMUM_SIZE_BYTES, MAXIMUM_SIZE_BYTES))
+        assertTrue(RecordingSizePolicy.hasReachedLimit(MAXIMUM_SIZE_BYTES + 1, MAXIMUM_SIZE_BYTES))
+        assertEquals(5, RecordingSizePolicy.megabytes(MAXIMUM_SIZE_BYTES))
+    }
+
+    private class Arrangement(scope: CoroutineScope) {
+        val fileSystem = TestKaliumFileSystem()
+        val originalPath = "/cache/wire-audio.wav".toPath()
+        val encodedPath = "/cache/wire-audio.m4a".toPath()
+        val effectsPath = "/cache/wire-audio-filter.wav".toPath()
+        val recorder = FakeAudioRecorder(fileSystem, AudioRecordingFiles(originalPath, encodedPath))
+        val preview = FakeRecordingPreview()
+        val effects = FakeEffectsProcessor(fileSystem)
+        val coordinator = AudioRecordingCoordinator(
+            audioRecorder = recorder,
+            recordingPreview = preview,
+            effectsProcessor = effects,
+            metadataReader = MediaMetadataReader { _, _ ->
+                PlatformResult.Success(AssetContent.AssetMetadata.Audio(DURATION_MS.toLong(), null))
+            },
+            fileSystem = fileSystem,
+            loudnessBuilder = AudioNormalizedLoudnessBuilder { byteArrayOf(1, -1) },
+            scope = scope,
+        )
+    }
+
+    private class FakeAudioRecorder(
+        private val fileSystem: TestKaliumFileSystem,
+        private val files: AudioRecordingFiles,
+    ) : AudioRecorder {
+        val mutableEvents = MutableSharedFlow<AudioRecorderEvent>(extraBufferCapacity = 1)
+        override val events: Flow<AudioRecorderEvent> = mutableEvents
+        var startResult: RecordingCapabilityResult<AudioRecordingFiles> = RecordingCapabilityResult.Success(files)
+        var encodeResult: RecordingCapabilityResult<Path> = RecordingCapabilityResult.Success(files.encodedM4a)
+        var stopCount = 0
+
+        override suspend fun start(maximumSizeBytes: Long): RecordingCapabilityResult<AudioRecordingFiles> {
+            if (startResult is RecordingCapabilityResult.Success) fileSystem.write(files.originalWav)
+            return startResult
+        }
+
+        override suspend fun stop(): RecordingCapabilityResult<Unit> {
+            stopCount++
+            return RecordingCapabilityResult.Success(Unit)
+        }
+
+        override suspend fun encode(source: Path, destination: Path): RecordingCapabilityResult<Path> = encodeResult
+
+        override fun release() = Unit
+    }
+
+    private class FakeRecordingPreview : RecordingPreview {
+        override val state: StateFlow<AudioState> = MutableStateFlow(AudioState.DEFAULT)
+        override fun toggle(path: Path): RecordingCapabilityResult<Unit> = RecordingCapabilityResult.Success(Unit)
+        override fun seekTo(positionMs: Int): RecordingCapabilityResult<Unit> = RecordingCapabilityResult.Success(Unit)
+        override fun stop(): RecordingCapabilityResult<Unit> = RecordingCapabilityResult.Success(Unit)
+        override fun release() = Unit
+    }
+
+    private class FakeEffectsProcessor(
+        private val fileSystem: TestKaliumFileSystem,
+    ) : AudioEffectsProcessor {
+        val requests = mutableListOf<AudioEffectsRequest>()
+        var result: RecordingCapabilityResult<Path> = RecordingCapabilityResult.Failure()
+
+        override suspend fun process(request: AudioEffectsRequest): RecordingCapabilityResult<Path> {
+            requests += request
+            if (result is RecordingCapabilityResult.Success) fileSystem.write(request.destination)
+            return result
+        }
+    }
+
+    private class TestKaliumFileSystem : KaliumFileSystem {
+        private val delegate = FakeFileSystem()
+        override val rootCachePath: Path = "/cache".toPath()
+        override val rootDBPath: Path = "/db".toPath()
+
+        init {
+            delegate.createDirectories(rootCachePath)
+            delegate.createDirectories(rootDBPath)
+        }
+
+        fun write(path: Path) {
+            delegate.sink(path).buffer().use { it.writeUtf8("audio") }
+        }
+
+        override fun sink(outputPath: Path, mustCreate: Boolean): Sink = delegate.sink(outputPath, mustCreate)
+        override fun source(inputPath: Path): Source = delegate.source(inputPath)
+        override fun createDirectories(dir: Path) = delegate.createDirectories(dir)
+        override fun createDirectory(dir: Path, mustCreate: Boolean) = delegate.createDirectory(dir, mustCreate)
+        override fun delete(path: Path, mustExist: Boolean) = delegate.delete(path, mustExist)
+        override fun deleteContents(dir: Path, mustExist: Boolean) {
+            delegate.deleteRecursively(dir, mustExist)
+            delegate.createDirectories(dir)
+        }
+        override fun exists(path: Path): Boolean = delegate.exists(path)
+        override fun copy(sourcePath: Path, targetPath: Path) {
+            delegate.source(sourcePath).use { source ->
+                delegate.sink(targetPath).buffer().use { sink -> sink.writeAll(source) }
+            }
+        }
+        override fun tempFilePath(pathString: String?): Path = rootCachePath.resolve(pathString ?: "temp")
+        override fun providePersistentAssetPath(assetName: String): Path = rootCachePath.resolve(assetName)
+        override fun selfUserAvatarPath(): Path = rootCachePath.resolve("avatar")
+        override suspend fun readByteArray(inputPath: Path): ByteArray = source(inputPath).buffer().use { it.readByteArray() }
+        override suspend fun writeData(outputSink: Sink, dataSource: Source): Long =
+            outputSink.buffer().use { it.writeAll(dataSource) }
+        override suspend fun listDirectories(dir: Path): List<Path> = delegate.list(dir)
+        override fun size(path: Path): Long? = delegate.metadataOrNull(path)?.size
+    }
+
+    private companion object {
+        const val DURATION_MS = 4_321
+        const val MAXIMUM_SIZE_BYTES = 5L * 1_024L * 1_024L
+    }
+}

--- a/core/audio-recording-kmp/src/commonTest/kotlin/com/wire/media/recording/UnsupportedRecordingCapabilitiesTest.kt
+++ b/core/audio-recording-kmp/src/commonTest/kotlin/com/wire/media/recording/UnsupportedRecordingCapabilitiesTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.recording
+
+import kotlinx.coroutines.test.runTest
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UnsupportedRecordingCapabilitiesTest {
+    @Test
+    fun `unsupported platform adapters never report fake success`() = runTest {
+        val path = "/tmp/audio.wav".toPath()
+
+        assertEquals(RecordingCapabilityResult.Unsupported, UnsupportedAudioRecorder.start(1))
+        assertEquals(RecordingCapabilityResult.Unsupported, UnsupportedAudioRecorder.stop())
+        assertEquals(RecordingCapabilityResult.Unsupported, UnsupportedAudioRecorder.encode(path, path))
+        assertEquals(RecordingCapabilityResult.Unsupported, UnsupportedRecordingPreview.toggle(path))
+        assertEquals(RecordingCapabilityResult.Unsupported, UnsupportedAudioEffectsProcessor.process(AudioEffectsRequest(path, path)))
+    }
+}

--- a/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/PlatformFeedback.kt
+++ b/core/media-player-kmp/src/commonMain/kotlin/com/wire/media/player/PlatformFeedback.kt
@@ -1,0 +1,29 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.player
+
+enum class PlatformFeedbackType {
+    OUTGOING_PING,
+}
+
+sealed interface PlatformFeedbackResult {
+    data object Performed : PlatformFeedbackResult
+    data object Unsupported : PlatformFeedbackResult
+    data class Failure(val reason: String? = null) : PlatformFeedbackResult
+}
+
+fun interface PlatformFeedback {
+    fun perform(type: PlatformFeedbackType): PlatformFeedbackResult
+}
+
+object UnsupportedPlatformFeedback : PlatformFeedback {
+    override fun perform(type: PlatformFeedbackType): PlatformFeedbackResult = PlatformFeedbackResult.Unsupported
+}

--- a/core/media-player-kmp/src/commonTest/kotlin/com/wire/media/player/PlatformFeedbackTest.kt
+++ b/core/media-player-kmp/src/commonTest/kotlin/com/wire/media/player/PlatformFeedbackTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.media.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlatformFeedbackTest {
+    @Test
+    fun `unsupported feedback remains explicit`() {
+        assertEquals(
+            PlatformFeedbackResult.Unsupported,
+            UnsupportedPlatformFeedback.perform(PlatformFeedbackType.OUTGOING_PING),
+        )
+    }
+}


### PR DESCRIPTION
## Intent
Extract recording orchestration and platform feedback into common semantic capabilities.

## Changes
- add common recording state, actions, coordinator, recorder, encoder, metadata, effects, and preview capabilities using okio.Path
- keep Android MediaRecorder, MediaCodec, effects, focus, preview playback, interruptions, and cleanup in narrow adapters
- replace direct PingRinger use in SendMessageViewModel with semantic PlatformFeedback
- expose explicit Unsupported results for unavailable platform behavior instead of fake success
- preserve limits, call and background interruptions, conversion failures, cleanup, and feedback invocation

## Stack
Builds on [PR 1](https://github.com/wireapp/wire-android/pull/5221), [PR 2](https://github.com/wireapp/wire-android/pull/5222), [PR 3](https://github.com/wireapp/wire-android/pull/5223), and [PR 4](https://github.com/wireapp/wire-android/pull/5224).