### PR TITLE
chore: revert to build dev-debug back on develop PRs [WPB-8645]

### DIFF
--- a/.github/workflows/build-develop-pr.yml
+++ b/.github/workflows/build-develop-pr.yml
@@ -30,10 +30,10 @@ jobs:
       build-config: |
         [
           {
-            "flavor": "Alpha",
-            "variant": "Compat",
-            "keystore-type": "internal",
-            "build-type": "both",
+            "flavor": "Dev",
+            "variant": "Debug",
+            "keystore-type": "debug",
+            "build-type": "apk",
             "generate-version-file": false,
             "deployment-targets": [
               {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-8645
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

For testing purposes, the build type for develop PRs was temporarily changed to `alpha-compat`, but it made its way into the develop branch. In this PR, it has been reverted so that `dev-debug` builds are built again.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
