### PR TITLE
chore: better accessibility action descriptions (WPB-15174)

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1762,8 +1762,8 @@ registriert. Bitte versuchen Sie es mit einer anderen.</string>
     <string name="personal_to_team_migration_error_message_unknown_error">Wire konnte die Erstellung Ihres Teams aufgrund eines unbekannten Fehlers nicht abschließen.</string>
     <string name="reaction_sender_self">Sie</string>
     <string name="emoji_picker_select_reaction">Reaktion auswählen</string>
-    <string name="content_description_add_this_reaction">Doppeltippen, um diese Reaktion hinzuzufügen</string>
-    <string name="content_description_remove_your_reaction">Doppeltippen, um die Reaktion zu entfernen</string>
+    <string name="content_description_add_this_reaction">Diese Reaktion hinzufügen</string>
+    <string name="content_description_remove_your_reaction">Ihre Reaktion entfernen</string>
     <!-- Move to Folder -->
     <string name="move_to_folder_success">„%1$s“ wurde nach ‚%2$s‘ verschoben</string>
     <string name="move_to_folder_failed">“%1$s” konnte nicht verschoben werden</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1880,8 +1880,8 @@
     <string name="personal_to_team_migration_error_message_unknown_error">Wire не удалось завершить создание вашей команды из-за неизвестной ошибки.</string>
     <string name="reaction_sender_self">Вы</string>
     <string name="emoji_picker_select_reaction">Выбрать реакцию</string>
-    <string name="content_description_add_this_reaction">Нажмите дважды, чтобы добавить эту реакцию</string>
-    <string name="content_description_remove_your_reaction">Нажмите дважды, чтобы удалить реакцию</string>
+    <string name="content_description_add_this_reaction">Добавить эту реакцию</string>
+    <string name="content_description_remove_your_reaction">Удалить вашу реакцию</string>
     <string name="label_user_database_profile">Журнал базы данных</string>
     <!-- Move to Folder -->
     <string name="move_to_folder_success">“%1$s” был перемещен в “%2$s”</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1878,8 +1878,8 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="personal_to_team_migration_error_message_unknown_error">Wire could not complete your team creation due to an unknown error.</string>
     <string name="reaction_sender_self">You</string>
     <string name="emoji_picker_select_reaction">Select Reaction</string>
-    <string name="content_description_add_this_reaction">Double tap to add this reaction</string>
-    <string name="content_description_remove_your_reaction">Double tap to remove reaction</string>
+    <string name="content_description_add_this_reaction">Add this reaction</string>
+    <string name="content_description_remove_your_reaction">Remove your reaction</string>
     <string name="label_user_database_profile">Database Logger</string>
 
     <!-- Move to Folder -->

--- a/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireButton.kt
+++ b/core/ui-common/src/main/kotlin/com/wire/android/ui/common/button/WireButton.kt
@@ -128,7 +128,7 @@ fun WireButton(
                     }
                 }
                 .semantics {
-                    onClickDescription?.let { onClick(it) { false } }
+                    onClickDescription?.let { onClick(label = it, action = null) }
                     description?.let { contentDescription = description }
                 },
             enabled = state != WireButtonState.Disabled,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-15174
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-15174
----

# What's new in this PR?

### Issues

Talkback is incorrectly announcing actions. For example: "Double-tap to Double tap to remove reaction"

### Solutions

Updated reaction accessibility labels to announce whether activating a reaction will add or remove it. The custom semantics now provide only the action label while preserving the button’s real click action, and TalkBack supplies the appropriate “Double tap to…” instruction.