### PR TITLE
fix(user-profile): show user name in folder toast [WPB-28423]

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationAuxNavigation3Mappers.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/conversations/ConversationAuxNavigation3Mappers.kt
@@ -19,6 +19,7 @@ import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.id.GroupID
 import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.kalium.logic.data.mls.CipherSuite
+import com.wire.navigation.WireSessionId
 import kotlinx.datetime.Instant
 
 internal fun ConversationAuxId.toQualifiedId() = QualifiedID(value, domain)
@@ -26,6 +27,13 @@ internal fun QualifiedID.toConversationAuxId() = ConversationAuxId(value, domain
 
 internal fun ConversationFoldersRoute.toViewModelArgs() = ConversationFoldersNavArgs(
     conversationId = conversationId.toQualifiedId(),
+    conversationName = conversationName,
+    currentFolderId = currentFolderId,
+)
+
+internal fun ConversationFoldersNavArgs.toNavigation3Route(sessionId: WireSessionId) = ConversationFoldersRoute(
+    sessionId = sessionId,
+    conversationId = conversationId.toConversationAuxId(),
     conversationName = conversationName,
     currentFolderId = currentFolderId,
 )

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileNavigation3Entries.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/UserProfileNavigation3Entries.kt
@@ -24,9 +24,8 @@ import com.wire.android.navigation.navigation3.WireNavigation3ResultType
 import com.wire.android.navigation.navigation3.WireNavigation3Runtime
 import com.wire.android.navigation.navigation3.wireEntry
 import com.wire.android.ui.common.snackbar.LocalSnackbarHostState
-import com.wire.android.ui.home.conversations.ConversationAuxId
 import com.wire.android.ui.home.conversations.ConversationFoldersNavigation3ResultType
-import com.wire.android.ui.home.conversations.ConversationFoldersRoute
+import com.wire.android.ui.home.conversations.toNavigation3Route
 import com.wire.android.ui.legalhold.dialog.requested.LegalHoldRequestedViewModel
 import com.wire.android.ui.miscViewModel
 import com.wire.android.ui.home.settings.otherUserProfileScreenViewModel
@@ -278,14 +277,9 @@ private fun OtherUserProfileNavigation3Entry(
         onOpenConversationMedia = {
             actions.openConversationMedia(it.toNavigationId())
         },
-        onMoveToFolder = { conversationId, _ ->
+        onMoveToFolder = { arguments ->
             folderRequestIdValue = runtime.navigateForResult(
-                ConversationFoldersRoute(
-                    route.sessionId,
-                    ConversationAuxId(conversationId.value, conversationId.domain),
-                    "",
-                    null,
-                ),
+                arguments.toNavigation3Route(route.sessionId),
                 ConversationFoldersNavigation3ResultType,
             )?.value
         },

--- a/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/userprofile/other/OtherUserProfileScreen.kt
@@ -104,7 +104,7 @@ internal fun OtherUserProfileRouteScreen(
     onOpenDeviceDetails: (Device) -> Unit,
     onSearchConversationMessages: (ConversationId) -> Unit,
     onOpenConversationMedia: (ConversationId) -> Unit,
-    onMoveToFolder: (ConversationId, (String) -> Unit) -> Unit,
+    onMoveToFolder: (ConversationFoldersNavArgs) -> Unit,
     onOpenConversationDebugMenu: (ConversationId) -> Unit,
 ) {
     val snackbarHostState = LocalSnackbarHostState.current
@@ -133,11 +133,7 @@ internal fun OtherUserProfileRouteScreen(
             viewModel.state.activeOneOnOneConversationId?.let(onOpenConversationMedia)
         },
         onLegalHoldLearnMoreClick = remember { { legalHoldSubjectDialogState.show(Unit) } },
-        onMoveToFolder = { arguments ->
-            onMoveToFolder(arguments.conversationId) { message ->
-                scope.launch { snackbarHostState.showSnackbar(message) }
-            }
-        },
+        onMoveToFolder = onMoveToFolder,
         openConversationDebugMenu = onOpenConversationDebugMenu,
     )
 

--- a/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationAuxNavigation3Test.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/conversations/ConversationAuxNavigation3Test.kt
@@ -10,6 +10,8 @@
 
 package com.wire.android.ui.home.conversations
 
+import com.wire.android.ui.home.conversations.folder.ConversationFoldersNavArgs
+import com.wire.kalium.logic.data.id.QualifiedID
 import com.wire.navigation.WireNavEntryId
 import com.wire.navigation.WireSessionId
 import kotlinx.serialization.encodeToString
@@ -66,6 +68,21 @@ class ConversationAuxNavigation3Test {
 
         assertNotEquals(first.entryId, second.entryId)
         assertEquals(first.routeId, second.routeId)
+    }
+
+    @Test
+    fun givenConversationFolderArguments_whenRouteIsRestored_thenAllArgumentsSurvive() {
+        val arguments = ConversationFoldersNavArgs(
+            conversationId = QualifiedID("conversation", "wire.example"),
+            conversationName = "Dudley Reichert",
+            currentFolderId = "current-folder",
+        )
+
+        val restoredArguments = Json.decodeFromString<ConversationFoldersRoute>(
+            Json.encodeToString(arguments.toNavigation3Route(session))
+        ).toViewModelArgs()
+
+        assertEquals(arguments, restoredArguments)
     }
 
     private inline fun <reified T> assertRoundTrip(value: T) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28423
<!--jira-description-action-hidden-marker-end-->
# What's new in this PR?

### Issues

Moving a 1:1 conversation to a newly created folder from User Profile displays a confirmation toast without the user's name.

### Causes

The Navigation 3 migration reduced the move-to-folder callback to the conversation ID. User Profile then created the folder route with an empty conversation name and no current folder ID, so the empty name reached the toast formatter.

### Solutions

- Forward the complete `ConversationFoldersNavArgs` from the conversation options sheet.
- Map those arguments to the typed Navigation 3 route without dropping the conversation name or current folder ID.
- Cover the mapping and route serialization round trip with a regression test.

### Testing

#### Test Coverage

- [x] I have added automated test to this contribution

#### How to Test

1. Open a 1:1 conversation and the other user's profile.
2. Select **More options**, then **Move to Folder...**.
3. Create a new folder and move the conversation to it.
4. Verify that the confirmation toast contains both the user's name and the folder name.
