### PR TITLE
fix: handling federation conflict when creating MLS conversation (WPB-26348)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -83,6 +83,7 @@ class NewConversationViewModel @Inject constructor(
     )
 
     private var pendingMLSGroupCreation: PendingMLSGroupCreation? = null
+    private var failedMLSGroupCreationId: ConversationId? = null
 
     var newGroupNameTextState: TextFieldState = TextFieldState()
     var newGroupState: GroupMetadataState by mutableStateOf(GroupMetadataState())
@@ -129,6 +130,7 @@ class NewConversationViewModel @Inject constructor(
         newGroupNameTextState.clearText()
         newGroupState = GroupMetadataState()
         pendingMLSGroupCreation = null
+        failedMLSGroupCreationId = null
         loadDefaultProtocol()
         observeAllowanceOfAppsUsageInitialState()
         createGroupState = CreateGroupState.Default
@@ -205,12 +207,32 @@ class NewConversationViewModel @Inject constructor(
         createGroupState = CreateGroupState.Default
     }
 
+    fun discardGroupCreation() {
+        val conversationId = failedMLSGroupCreationId
+        if (conversationId == null) {
+            createGroupState = CreateGroupState.Discarded
+            return
+        }
+
+        createGroupState = CreateGroupState.Discarding
+        viewModelScope.launch {
+            if (createRegularGroup.discardPendingMLSGroupCreation(conversationId)) {
+                failedMLSGroupCreationId = null
+                pendingMLSGroupCreation = null
+                createGroupState = CreateGroupState.Discarded
+            } else {
+                createGroupState = CreateGroupState.Error.Unknown
+            }
+        }
+    }
+
     fun retryPendingMLSGroupCreation() {
         val pendingCreation = pendingMLSGroupCreation ?: return
         createGroupState = CreateGroupState.Error.PendingMLSCreation(isRetrying = true)
         viewModelScope.launch {
             when (val result = createRegularGroup.retryPendingMLSGroupCreation(pendingCreation.conversationId)) {
                 is ConversationCreationResult.Success,
+                is ConversationCreationResult.BackendConflictFailure,
                 is ConversationCreationResult.PendingMLSGroupCreation ->
                     handleNewGroupCreationResult(result, pendingCreation.attempt)
 
@@ -376,6 +398,7 @@ class NewConversationViewModel @Inject constructor(
         return when (result) {
             is ConversationCreationResult.Success -> {
                 pendingMLSGroupCreation = null
+                failedMLSGroupCreationId = null
                 newGroupState = newGroupState.copy(isLoading = false)
                 createGroupState = CreateGroupState.Created(result.conversation.id)
             }
@@ -410,6 +433,8 @@ class NewConversationViewModel @Inject constructor(
             }
 
             is ConversationCreationResult.BackendConflictFailure -> {
+                pendingMLSGroupCreation = null
+                failedMLSGroupCreationId = result.conversationId
                 groupOptionsState = groupOptionsState.copy(isLoading = false)
                 newGroupState = newGroupState.copy(isLoading = false)
                 createGroupState = CreateGroupState.Error.ConflictedBackends(result.domains)

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupState.kt
@@ -22,6 +22,8 @@ import com.wire.kalium.logic.data.id.ConversationId
 sealed interface CreateGroupState {
 
     data object Default : CreateGroupState
+    data object Discarding : CreateGroupState
+    data object Discarded : CreateGroupState
 
     sealed interface Error : CreateGroupState {
         data object Unknown : Error

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -89,8 +89,10 @@ internal fun GroupOptionRouteScreen(
     onNavigateBack: () -> Unit,
 ) {
     LaunchedEffect(newConversationViewModel.createGroupState) {
-        (newConversationViewModel.createGroupState as? CreateGroupState.Created)?.let {
-            onConversationCreated(it.conversationId)
+        when (val state = newConversationViewModel.createGroupState) {
+            is CreateGroupState.Created -> onConversationCreated(state.conversationId)
+            CreateGroupState.Discarded -> onDiscard()
+            else -> Unit
         }
     }
 
@@ -118,8 +120,7 @@ internal fun GroupOptionRouteScreen(
             onEditParticipants()
         },
         onDiscardGroupCreationClick = {
-            newConversationViewModel.onCreateGroupErrorDismiss()
-            onDiscard()
+            newConversationViewModel.discardGroupCreation()
         },
         onRetryPendingCreation = newConversationViewModel::retryPendingMLSGroupCreation,
         onErrorDismissed = newConversationViewModel::onCreateGroupErrorDismiss,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
@@ -47,8 +47,10 @@ internal fun NewGroupNameRouteScreen(
         newConversationViewModel.observeGroupNameChanges()
     }
     LaunchedEffect(newConversationViewModel.createGroupState) {
-        (newConversationViewModel.createGroupState as? CreateGroupState.Created)?.let {
-            onConversationCreated(it.conversationId)
+        when (val state = newConversationViewModel.createGroupState) {
+            is CreateGroupState.Created -> onConversationCreated(state.conversationId)
+            CreateGroupState.Discarded -> onDiscard()
+            else -> Unit
         }
     }
     GroupNameScreen(
@@ -70,16 +72,14 @@ internal fun NewGroupNameRouteScreen(
             onDismiss = newConversationViewModel::onCreateGroupErrorDismiss,
             onRetryPendingCreation = newConversationViewModel::retryPendingMLSGroupCreation,
             onPendingCreationAcknowledged = {
-                newConversationViewModel.onCreateGroupErrorDismiss()
-                onDiscard()
+                newConversationViewModel.discardGroupCreation()
             },
             onEditParticipantsList = {
                 newConversationViewModel.onCreateGroupErrorDismiss()
                 onEditParticipants()
             },
             onCancel = {
-                newConversationViewModel.onCreateGroupErrorDismiss()
-                onDiscard()
+                newConversationViewModel.discardGroupCreation()
             },
         )
     }

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -60,6 +60,7 @@ internal class NewConversationViewModelArrangement {
         // Default empty values
         coEvery { isMLSEnabledUseCase() } returns true
         coEvery { createRegularGroup(any(), any(), any()) } returns ConversationCreationResult.Success(CONVERSATION)
+        coEvery { createRegularGroup.discardPendingMLSGroupCreation(any()) } returns true
         coEvery { observeChannelsCreationPermissionUseCase() } returns flowOf(ChannelCreationPermission.Forbidden)
         coEvery { getDefaultProtocol() } returns SupportedProtocol.PROTEUS
         coEvery { isWireCellsEnabled() } returns false
@@ -189,6 +190,16 @@ internal class NewConversationViewModelArrangement {
         )
     }
 
+    fun withBackendConflictOnCreatingGroup(domains: List<String>) = apply {
+        coEvery { createRegularGroup(any(), any(), any()) } returns
+            ConversationCreationResult.BackendConflictFailure(domains)
+    }
+
+    fun withBackendConflictCleanupFallbackOnCreatingGroup(domains: List<String>) = apply {
+        coEvery { createRegularGroup(any(), any(), any()) } returns
+            ConversationCreationResult.BackendConflictFailure(domains, CONVERSATION_ID)
+    }
+
     fun withPendingMLSGroupCreation() = apply {
         coEvery { createRegularGroup(any(), any(), any()) } returns ConversationCreationResult.PendingMLSGroupCreation(
             CONVERSATION_ID,
@@ -201,6 +212,11 @@ internal class NewConversationViewModelArrangement {
     fun withPendingMLSGroupCreationRetryFailure() = apply {
         coEvery { createRegularGroup.retryPendingMLSGroupCreation(CONVERSATION_ID) } returns
             ConversationCreationResult.UnknownFailure(CoreFailure.Unknown(UnsupportedOperationException("retry failed")))
+    }
+
+    fun withPendingMLSGroupCreationRetryBackendConflict(domains: List<String>) = apply {
+        coEvery { createRegularGroup.retryPendingMLSGroupCreation(CONVERSATION_ID) } returns
+            ConversationCreationResult.BackendConflictFailure(domains)
     }
 
     fun withConflictingBackendsFailure() = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -89,6 +89,49 @@ class NewConversationViewModelTest {
     }
 
     @Test
+    fun `given backend conflict, when creating group, then should show conflicting backends error`() = runTest {
+        val domains = listOf("backend-a.example", "backend-b.example")
+        val (arrangement, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withDefaultProtocol(SupportedProtocol.MLS)
+            .withBackendConflictOnCreatingGroup(domains)
+            .arrange()
+
+        viewModel.createGroup()
+        advanceUntilIdle()
+
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Error.ConflictedBackends(domains)
+
+        viewModel.discardGroupCreation()
+        advanceUntilIdle()
+
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Discarded
+        coVerify(exactly = 0) {
+            arrangement.createRegularGroup.discardPendingMLSGroupCreation(NewConversationViewModelArrangement.CONVERSATION_ID)
+        }
+    }
+
+    @Test
+    fun `given backend conflict cleanup fallback, when discarding, then should retry cleanup`() = runTest {
+        val domains = listOf("backend-a.example", "backend-b.example")
+        val (arrangement, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withDefaultProtocol(SupportedProtocol.MLS)
+            .withBackendConflictCleanupFallbackOnCreatingGroup(domains)
+            .arrange()
+
+        viewModel.createGroup()
+        advanceUntilIdle()
+        viewModel.discardGroupCreation()
+        advanceUntilIdle()
+
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Discarded
+        coVerify(exactly = 1) {
+            arrangement.createRegularGroup.discardPendingMLSGroupCreation(NewConversationViewModelArrangement.CONVERSATION_ID)
+        }
+    }
+
+    @Test
     fun `given MLS establish fails after creation, when retrying, then existing conversation is reused`() = runTest {
         val (arrangement, viewModel) = NewConversationViewModelArrangement()
             .withGetSelfUser(isTeamMember = true)
@@ -128,6 +171,30 @@ class NewConversationViewModelTest {
         advanceUntilIdle()
 
         viewModel.createGroupState shouldBeEqualTo CreateGroupState.Error.PendingMLSCreation()
+    }
+
+    @Test
+    fun `given pending MLS creation, when retry finds backend conflict, then should show conflicting backends error`() = runTest {
+        val domains = listOf("backend-a.example", "backend-b.example")
+        val (arrangement, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withDefaultProtocol(SupportedProtocol.MLS)
+            .withPendingMLSGroupCreation()
+            .withPendingMLSGroupCreationRetryBackendConflict(domains)
+            .arrange()
+        advanceUntilIdle()
+
+        viewModel.createGroup()
+        advanceUntilIdle()
+        viewModel.retryPendingMLSGroupCreation()
+        advanceUntilIdle()
+
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Error.ConflictedBackends(domains)
+        viewModel.retryPendingMLSGroupCreation()
+        advanceUntilIdle()
+        coVerify(exactly = 1) {
+            arrangement.createRegularGroup.retryPendingMLSGroupCreation(NewConversationViewModelArrangement.CONVERSATION_ID)
+        }
     }
 
     @Test


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26348
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26348

----

# What's new in this PR?

### Issues

Federation conflicts during initial or retried MLS group creation were not handled consistently, and Discard could close the flow while leaving a pending local conversation.

### Solutions

Route initial and retry conflicts to the existing “Conversation can’t be created” dialog. Clear pending creation state, retry local cleanup only when Kalium returns a fallback conversation ID, and close the creation flow only after discard succeeds.