### PR TITLE
fix: refactor for file logging with kermit-io no logcat proc - cycle 4.22 (WPB-28172)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -181,6 +181,8 @@ if (!project.hasProperty("skip.aboutlibraries")) {
 }
 
 dependencies {
+    implementation(libs.kermit.io)
+
     implementation("com.wire.kalium:kalium-logic")
     implementation("com.wire.kalium:kalium-util")
     implementation("com.wire.kalium:kalium-cells")

--- a/app/src/main/kotlin/com/wire/android/WireApplication.kt
+++ b/app/src/main/kotlin/com/wire/android/WireApplication.kt
@@ -26,6 +26,7 @@ import android.os.StrictMode
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration
 import androidx.work.WorkManager
+import co.touchlab.kermit.LogWriter
 import co.touchlab.kermit.platformLogWriter
 import com.wire.android.analytics.ObserveCurrentSessionAnalyticsUseCase
 import com.wire.android.datastore.GlobalDataStore
@@ -303,21 +304,15 @@ class WireApplication : BaseApp() {
     private suspend fun initializeApplicationLoggingFrameworks() {
         // 1. Datadog should be initialized first
         ExternalLoggerManager.initDatadogLogger(applicationContext)
-        // 2. Initialize our internal logging framework
         val isLoggingEnabled = globalDataStore.get().isLoggingEnabled().first()
-        val config = if (isLoggingEnabled) {
-            KaliumLogger.Config(
-                KaliumLogLevel.VERBOSE,
-                listOf(DataDogLogger, platformLogWriter())
-            )
-        } else {
-            KaliumLogger.Config.DISABLED
-        }
-        // 2. Initialize our internal logging framework
+        val fileWriter = logFileWriter.get()
+        val config = fullLoggerConfig(isLoggingEnabled, fileWriter.logWriter)
+
+        // 2. Initialize the application and Kalium logging framework.
         AppLogger.init(config)
         CoreLogger.init(config)
-        // 3. Initialize our internal FILE logging framework
-        logFileWriter.get().start()
+        // 3. Initialize direct file logging after its directory exists.
+        fileWriter.start()
         // 4. Everything ready, now we can log device info
         appLogger.i("Logger enabled")
         logDeviceInformation()
@@ -416,7 +411,19 @@ class WireApplication : BaseApp() {
         }
     }
 
-    private companion object {
+    internal companion object {
+        fun fullLoggerConfig(isLoggingEnabled: Boolean, fileLogWriter: LogWriter?) = if (isLoggingEnabled) {
+            KaliumLogger.Config(
+                KaliumLogLevel.VERBOSE,
+                listOfNotNull(DataDogLogger, platformLogWriter(), fileLogWriter)
+            )
+        } else {
+            KaliumLogger.Config(
+                KaliumLogLevel.WARN,
+                listOfNotNull(platformLogWriter(), fileLogWriter)
+            )
+        }
+
         enum class MemoryLevel(val level: Int) {
             TRIM_MEMORY_BACKGROUND(ComponentCallbacks2.TRIM_MEMORY_BACKGROUND),
             TRIM_MEMORY_COMPLETE(ComponentCallbacks2.TRIM_MEMORY_COMPLETE),

--- a/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/LogManagementViewModel.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.AppLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.util.logging.LogFileWriter
 import com.wire.kalium.common.logger.CoreLogger
@@ -56,16 +57,18 @@ class LogManagementViewModel @Inject constructor(
             globalDataStore.setLoggingEnabled(isEnabled)
             if (isEnabled) {
                 logFileWriter.start()
+                AppLogger.setLogLevel(level = KaliumLogLevel.VERBOSE)
                 CoreLogger.setLoggingLevel(level = KaliumLogLevel.VERBOSE)
             } else {
                 logFileWriter.stop()
+                AppLogger.setLogLevel(level = KaliumLogLevel.WARN)
                 CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED)
             }
         }
     }
 
     fun deleteLogs() {
-        logFileWriter.deleteAllLogFiles()
+        viewModelScope.launch { logFileWriter.deleteAllLogFiles() }
     }
 
     fun flushLogs(): Deferred<Unit> {

--- a/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/debug/UserDebugViewModel.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.wire.android.AppLogger
 import com.wire.android.datastore.GlobalDataStore
 import com.wire.android.di.CurrentAccount
 import com.wire.android.util.EMPTY
@@ -86,7 +87,7 @@ class UserDebugViewModel
     }
 
     fun deleteLogs() {
-        logFileWriter.deleteAllLogFiles()
+        viewModelScope.launch { logFileWriter.deleteAllLogFiles() }
     }
 
     fun flushLogs(): Deferred<Unit> {
@@ -100,9 +101,11 @@ class UserDebugViewModel
             globalDataStore.setLoggingEnabled(isEnabled)
             if (isEnabled) {
                 logFileWriter.start()
+                AppLogger.setLogLevel(level = KaliumLogLevel.VERBOSE)
                 CoreLogger.setLoggingLevel(level = KaliumLogLevel.VERBOSE)
             } else {
                 logFileWriter.stop()
+                AppLogger.setLogLevel(level = KaliumLogLevel.WARN)
                 CoreLogger.setLoggingLevel(level = KaliumLogLevel.DISABLED)
             }
         }

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriter.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriter.kt
@@ -19,6 +19,7 @@
 package com.wire.android.util.logging
 
 import android.content.Context
+import co.touchlab.kermit.LogWriter
 import java.io.File
 
 /**
@@ -26,6 +27,10 @@ import java.io.File
  * between different implementations.
  */
 interface LogFileWriter {
+
+    /** The Kermit sink used by the app and Kalium logging configuration. */
+    val logWriter: LogWriter?
+        get() = null
 
     /**
      * The active logging file where logs are currently being written
@@ -51,7 +56,7 @@ interface LogFileWriter {
      * Deletes all log files including active and compressed files
      *
      */
-    fun deleteAllLogFiles()
+    suspend fun deleteAllLogFiles()
 
     companion object {
         fun logsDirectory(context: Context) = File(context.cacheDir, "logs")

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Config.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Config.kt
@@ -1,0 +1,27 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.android.util.logging
+
+data class LogFileWriterV1Config(
+    val rollOnSizeBytes: Long = DEFAULT_ROLL_ON_SIZE_BYTES,
+    val maxLogFiles: Int = DEFAULT_MAX_LOG_FILES,
+    val flushTimeoutMs: Long = DEFAULT_FLUSH_TIMEOUT_MS,
+) {
+    companion object {
+        private const val DEFAULT_ROLL_ON_SIZE_BYTES = 25 * 1024 * 1024L
+
+        // RollingFileLogWriter counts the active file, so this retains ten rolls.
+        private const val DEFAULT_MAX_LOG_FILES = 11
+        private const val DEFAULT_FLUSH_TIMEOUT_MS = 5000L
+
+        fun default() = LogFileWriterV1Config()
+    }
+}

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Impl.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Impl.kt
@@ -104,28 +104,20 @@ class LogFileWriterV1Impl(
         val legacySnapshot = File(logsDirectory, LEGACY_SNAPSHOT_FILE_NAME)
         val legacySnapshotTemp = File(logsDirectory, "$LEGACY_SNAPSHOT_FILE_NAME.tmp")
 
-        if (!legacyActiveFile.exists()) {
-            if (legacySnapshot.isFile && isReadableGzip(legacySnapshot)) {
+        when {
+            !legacyActiveFile.exists() && legacySnapshot.isFile && isReadableGzip(legacySnapshot) -> {
                 deleteLegacyLogFiles(keepSnapshot = true)
-                return
             }
-            legacySnapshotTemp.delete()
-            return
-        }
-
-        if (legacySnapshot.exists()) {
-            if (legacySnapshot.isFile && isReadableGzip(legacySnapshot)) {
+            !legacyActiveFile.exists() -> legacySnapshotTemp.delete()
+            legacySnapshot.isFile && isReadableGzip(legacySnapshot) -> {
                 deleteLegacyLogFiles(keepSnapshot = true)
-                return
             }
-            if (!legacySnapshot.delete()) return
+            legacySnapshot.exists() && !legacySnapshot.delete() -> Unit
+            legacySnapshotTemp.exists() && !legacySnapshotTemp.delete() -> Unit
+            createLegacySnapshot(legacyActiveFile, legacySnapshotTemp, legacySnapshot) -> {
+                deleteLegacyLogFiles(keepSnapshot = true)
+            }
         }
-
-        if (legacySnapshotTemp.exists() && !legacySnapshotTemp.delete()) return
-
-        if (!createLegacySnapshot(legacyActiveFile, legacySnapshotTemp, legacySnapshot)) return
-
-        deleteLegacyLogFiles(keepSnapshot = true)
     }
 
     private fun createLegacySnapshot(source: File, temporarySnapshot: File, finalSnapshot: File): Boolean = runCatching {

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Impl.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Impl.kt
@@ -1,203 +1,125 @@
 /*
  * Wire
- * Copyright (C) 2024 Wire Swiss GmbH
+ * Copyright (C) 2026 Wire Swiss GmbH
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see http://www.gnu.org/licenses/.
  */
 
 package com.wire.android.util.logging
 
-import com.wire.android.appLogger
-import kotlinx.coroutines.CoroutineScope
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+import co.touchlab.kermit.io.RollingFileLogWriter
+import co.touchlab.kermit.io.RollingFileLogWriterConfig
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.files.Path
 import java.io.File
-import java.io.FileWriter
 import java.io.IOException
-import java.io.PrintWriter
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.zip.GZIPOutputStream
+import java.util.UUID
 
-@Suppress("TooGenericExceptionCaught")
-class LogFileWriterV1Impl(private val logsDirectory: File) : LogFileWriter {
+/** Persists diagnostics directly from Kermit instead of reading device logcat. */
+class LogFileWriterV1Impl(
+    private val logsDirectory: File,
+    private val config: LogFileWriterV1Config = LogFileWriterV1Config.default(),
+) : LogFileWriter {
 
-    private val logFileTimeFormat = SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", Locale.US)
+    override val activeLoggingFile = File(logsDirectory, "$LOG_FILE_NAME.log")
 
-    override val activeLoggingFile = File(logsDirectory, ACTIVE_LOGGING_FILE_NAME)
+    private var rollingWriter: RollingFileLogWriter? = null
+    private val gatedWriter = GatedLogWriter { rollingWriter }
 
-    private val fileWriterCoroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-    private var writingJob: Job? = null
+    override val logWriter: LogWriter = gatedWriter
 
-    /**
-     * Initializes logging, waiting until the logger is actually initialized before returning.
-     * ```kotlin
-     * logFileWriter.start()
-     * logger.i("something") // Is guaranteed to be recorded in the log file
-     * ```
-     */
-    override suspend fun start() {
-        appLogger.i("KaliumFileWritter.start called")
-        val isWriting = writingJob?.isActive ?: false
-        if (isWriting) {
-            appLogger.d("KaliumFileWriter.init called but job was already active. Ignoring call")
-            return
+    override suspend fun start() = withContext(Dispatchers.IO) {
+        ensureLogDirectoryExists()
+        if (rollingWriter == null) {
+            rollingWriter = RollingFileLogWriter(
+                RollingFileLogWriterConfig(
+                    logFileName = LOG_FILE_NAME,
+                    logFilePath = Path(logsDirectory.absolutePath),
+                    rollOnSize = config.rollOnSizeBytes,
+                    maxLogFiles = config.maxLogFiles,
+                )
+            )
         }
-        ensureLogDirectoryAndFileExistence()
-        val waitInitializationJob = Job()
-
-        writingJob = fileWriterCoroutineScope.launch {
-            observeLogCatWritingToLoggingFile().catch {
-                appLogger.e("Write to file failed :$it", it)
-            }.onEach {
-                waitInitializationJob.complete()
-            }.filter {
-                it > LOG_FILE_MAX_SIZE_THRESHOLD
-            }.collect {
-                ensureActive()
-                compress()
-                clearActiveLoggingFileContent()
-                deleteOldCompressedFiles()
-            }
-        }
-        appLogger.i("KaliumFileWritter.start: Starting log collection.")
-        waitInitializationJob.join()
+        gatedWriter.enable()
     }
 
-    /**
-     * Observes logcat text, writing to the [activeLoggingFile] as it reads.
-     * @return A Flow that tells the current length, in bytes, of the log file.
-     */
-    private fun CoroutineScope.observeLogCatWritingToLoggingFile(): Flow<Long> = flow<Long> {
-        Runtime.getRuntime().exec("logcat -c")
-        val process = Runtime.getRuntime().exec("logcat")
-
-        val reader = process.inputStream.bufferedReader()
-
-        appLogger.i("Starting to write log files, grabbing from logcat")
-        while (isActive) {
-            val text = reader.readLine()
-            if (!text.isNullOrBlank()) {
-                val fileSize = writeLineToFile(text)
-                emit(fileSize)
-            }
-        }
-        reader.close()
-        process.destroy()
-    }.flowOn(Dispatchers.IO)
-
-    /**
-     * Stops processing logs and writing to files
-     */
     override suspend fun stop() {
-        appLogger.i("KaliumFileWritter.stop called; Stopping log collection.")
-        writingJob?.cancel()
-        clearActiveLoggingFileContent()
+        gatedWriter.disable()
     }
 
     override suspend fun forceFlush() {
-        /* no-op */
+        gatedWriter.flushBarrier()?.let { waitForBarrier(it) }
     }
 
-    private fun clearActiveLoggingFileContent() {
-        if (activeLoggingFile.exists()) {
-            val writer = PrintWriter(activeLoggingFile)
-            writer.print("")
-            writer.close()
+    override suspend fun deleteAllLogFiles() {
+        val marker = gatedWriter.flushBarrier(disableAfterWrite = true)
+        marker?.let { waitForBarrier(it) }
+
+        withContext(Dispatchers.IO) {
+            logsDirectory.listFiles()
+                ?.filter { ROLLED_LOG_FILE_REGEX.matches(it.name) }
+                ?.forEach(File::delete)
+            ensureLogDirectoryExists()
+            activeLoggingFile.outputStream().use { }
+        }
+
+        if (marker != null) gatedWriter.enable()
+    }
+
+    private suspend fun waitForBarrier(marker: String) = withContext(Dispatchers.IO) {
+        withTimeout(config.flushTimeoutMs) {
+            while (!containsBarrier(marker)) delay(FLUSH_POLL_INTERVAL_MS)
         }
     }
 
-    /**
-     * Writes the new [text] and other log entries in logcat to the [activeLoggingFile].
-     * @return The length, in bytes, of the log file.
-     */
-    private fun writeLineToFile(text: String): Long {
-        FileWriter(activeLoggingFile, true).use { fw ->
-            fw.appendLine(text)
-            fw.flush()
-        }
-        return activeLoggingFile.length()
-    }
+    private fun containsBarrier(marker: String): Boolean = logsDirectory.listFiles()
+        ?.filter { it.name == activeLoggingFile.name || ROLLED_LOG_FILE_REGEX.matches(it.name) }
+        ?.any { file -> runCatching { file.useLines { lines -> lines.any { marker in it } } }.getOrDefault(false) }
+        ?: false
 
-    private fun ensureLogDirectoryAndFileExistence() {
+    private fun ensureLogDirectoryExists() {
         if (!logsDirectory.exists() && !logsDirectory.mkdirs()) {
-            appLogger.e("Unable to create logs directory")
-        }
-
-        if (!activeLoggingFile.exists() && !activeLoggingFile.createNewFile()) {
-            appLogger.e("KaliumFileWriter: Failure to create new file for logging", IOException("Unable to load log file"))
-        }
-        if (!activeLoggingFile.canWrite()) {
-            appLogger.e("KaliumFileWriter: Logging file is not writable", IOException("Log file not writable"))
+            throw IOException("Unable to create log directory: ${logsDirectory.absolutePath}")
         }
     }
 
-    override fun deleteAllLogFiles() {
-        clearActiveLoggingFileContent()
-        logsDirectory.listFiles()?.filter {
-            it.extension.lowercase(Locale.ROOT) == LOG_COMPRESSED_FILE_EXTENSION
-        }?.forEach { it.delete() }
-    }
+    private class GatedLogWriter(private val delegate: () -> LogWriter?) : LogWriter() {
+        private val lock = Any()
+        private var enabled = false
 
-    private fun getCompressedFilesList() = (logsDirectory.listFiles() ?: emptyArray()).filter { it != activeLoggingFile }
+        fun enable() = synchronized(lock) { enabled = true }
 
-    private fun compressedFileName(): String {
-        val currentDate = logFileTimeFormat.format(Date())
-        return "${LOG_FILE_PREFIX}_$currentDate.$LOG_COMPRESSED_FILE_EXTENSION"
-    }
+        fun disable() = synchronized(lock) { enabled = false }
 
-    private fun deleteOldCompressedFiles() = getCompressedFilesList()
-        .sortedBy { it.lastModified() }
-        .dropLast(LOG_COMPRESSED_FILES_MAX_COUNT)
-        .forEach {
-            it.delete()
+        fun flushBarrier(disableAfterWrite: Boolean = false): String? = synchronized(lock) {
+            if (!enabled) return null
+
+            val marker = "$FLUSH_MARKER_PREFIX${UUID.randomUUID()}"
+            delegate()?.log(Severity.Verbose, marker, LOG_TAG, null)
+            if (disableAfterWrite) enabled = false
+            marker
         }
 
-    private fun compress(): Boolean {
-        try {
-            val compressed = File(logsDirectory, compressedFileName())
-            val zippedOutputStream = GZIPOutputStream(compressed.outputStream())
-            val inputStream = activeLoggingFile.inputStream()
-            inputStream.copyTo(zippedOutputStream, BYTE_ARRAY_SIZE)
-            clearActiveLoggingFileContent()
-            inputStream.close()
-            zippedOutputStream.close()
-        } catch (e: IOException) {
-            appLogger.d("$e")
-            return false
+        override fun log(severity: Severity, message: String, tag: String, throwable: Throwable?) {
+            synchronized(lock) {
+                if (enabled) delegate()?.log(severity, message, tag, throwable)
+            }
         }
-
-        return true
     }
 
-    companion object {
-        private const val LOG_FILE_PREFIX = "wire"
-        private const val ACTIVE_LOGGING_FILE_NAME = "${LOG_FILE_PREFIX}_logs.txt"
-        private const val LOG_FILE_MAX_SIZE_THRESHOLD = 25 * 1024 * 1024
-        private const val BYTE_ARRAY_SIZE = 1024
-        private const val LOG_COMPRESSED_FILES_MAX_COUNT = 10
-        private const val LOG_COMPRESSED_FILE_EXTENSION = "gz"
+    private companion object {
+        const val LOG_FILE_NAME = "wire_logs"
+        const val LOG_TAG = "LogFileWriter"
+        const val FLUSH_MARKER_PREFIX = "wire-log-flush:"
+        const val FLUSH_POLL_INTERVAL_MS = 10L
+        val ROLLED_LOG_FILE_REGEX = Regex("$LOG_FILE_NAME-[0-9]+\\.log")
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Impl.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV1Impl.kt
@@ -22,6 +22,8 @@ import kotlinx.io.files.Path
 import java.io.File
 import java.io.IOException
 import java.util.UUID
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 
 /** Persists diagnostics directly from Kermit instead of reading device logcat. */
 class LogFileWriterV1Impl(
@@ -38,6 +40,7 @@ class LogFileWriterV1Impl(
 
     override suspend fun start() = withContext(Dispatchers.IO) {
         ensureLogDirectoryExists()
+        migrateLegacyLogs()
         if (rollingWriter == null) {
             rollingWriter = RollingFileLogWriter(
                 RollingFileLogWriterConfig(
@@ -67,6 +70,7 @@ class LogFileWriterV1Impl(
             logsDirectory.listFiles()
                 ?.filter { ROLLED_LOG_FILE_REGEX.matches(it.name) }
                 ?.forEach(File::delete)
+            deleteLegacyLogFiles()
             ensureLogDirectoryExists()
             activeLoggingFile.outputStream().use { }
         }
@@ -89,6 +93,66 @@ class LogFileWriterV1Impl(
         if (!logsDirectory.exists() && !logsDirectory.mkdirs()) {
             throw IOException("Unable to create log directory: ${logsDirectory.absolutePath}")
         }
+    }
+
+    /**
+     * Transfers the only legacy active log to a deterministic gzip snapshot. The active source
+     * remains untouched until the snapshot has been fully written, validated and renamed.
+     */
+    private fun migrateLegacyLogs() {
+        val legacyActiveFile = File(logsDirectory, LEGACY_ACTIVE_FILE_NAME)
+        val legacySnapshot = File(logsDirectory, LEGACY_SNAPSHOT_FILE_NAME)
+        val legacySnapshotTemp = File(logsDirectory, "$LEGACY_SNAPSHOT_FILE_NAME.tmp")
+
+        if (!legacyActiveFile.exists()) {
+            if (legacySnapshot.isFile && isReadableGzip(legacySnapshot)) {
+                deleteLegacyLogFiles(keepSnapshot = true)
+                return
+            }
+            legacySnapshotTemp.delete()
+            return
+        }
+
+        if (legacySnapshot.exists()) {
+            if (legacySnapshot.isFile && isReadableGzip(legacySnapshot)) {
+                deleteLegacyLogFiles(keepSnapshot = true)
+                return
+            }
+            if (!legacySnapshot.delete()) return
+        }
+
+        if (legacySnapshotTemp.exists() && !legacySnapshotTemp.delete()) return
+
+        if (!createLegacySnapshot(legacyActiveFile, legacySnapshotTemp, legacySnapshot)) return
+
+        deleteLegacyLogFiles(keepSnapshot = true)
+    }
+
+    private fun createLegacySnapshot(source: File, temporarySnapshot: File, finalSnapshot: File): Boolean = runCatching {
+        source.inputStream().buffered().use { input ->
+            GZIPOutputStream(temporarySnapshot.outputStream().buffered()).use { output -> input.copyTo(output) }
+        }
+        temporarySnapshot.renameTo(finalSnapshot) && isReadableGzip(finalSnapshot)
+    }.getOrDefault(false).also { created ->
+        if (!created) temporarySnapshot.delete()
+    }
+
+    private fun isReadableGzip(file: File): Boolean = runCatching {
+        GZIPInputStream(file.inputStream().buffered()).use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (input.read(buffer) != -1) Unit
+        }
+    }.isSuccess
+
+    private fun deleteLegacyLogFiles(keepSnapshot: Boolean = false) {
+        logsDirectory.listFiles()
+            ?.filter { file ->
+                file.name == LEGACY_ACTIVE_FILE_NAME ||
+                    LEGACY_ARCHIVE_FILE_REGEX.matches(file.name) ||
+                    LEGACY_TEMP_FILE_REGEX.matches(file.name) ||
+                    (!keepSnapshot && file.name == LEGACY_SNAPSHOT_FILE_NAME)
+            }
+            ?.forEach(File::delete)
     }
 
     private class GatedLogWriter(private val delegate: () -> LogWriter?) : LogWriter() {
@@ -117,9 +181,13 @@ class LogFileWriterV1Impl(
 
     private companion object {
         const val LOG_FILE_NAME = "wire_logs"
+        const val LEGACY_ACTIVE_FILE_NAME = "$LOG_FILE_NAME.txt"
+        const val LEGACY_SNAPSHOT_FILE_NAME = "wire_legacy_active.gz"
         const val LOG_TAG = "LogFileWriter"
         const val FLUSH_MARKER_PREFIX = "wire-log-flush:"
         const val FLUSH_POLL_INTERVAL_MS = 10L
         val ROLLED_LOG_FILE_REGEX = Regex("$LOG_FILE_NAME-[0-9]+\\.log")
+        val LEGACY_ARCHIVE_FILE_REGEX = Regex("wire_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.gz")
+        val LEGACY_TEMP_FILE_REGEX = Regex("(?:wire_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.gz|$LEGACY_SNAPSHOT_FILE_NAME)\\.tmp")
     }
 }

--- a/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV2Impl.kt
+++ b/app/src/main/kotlin/com/wire/android/util/logging/LogFileWriterV2Impl.kt
@@ -316,7 +316,7 @@ class LogFileWriterV2Impl(
         }
     }
 
-    override fun deleteAllLogFiles() {
+    override suspend fun deleteAllLogFiles() {
         clearActiveLoggingFileContent()
         logsDirectory.listFiles()?.filter {
             it.extension.lowercase(Locale.ROOT) == LOG_COMPRESSED_FILE_EXTENSION

--- a/app/src/test/kotlin/com/wire/android/util/logging/LogFileWriterV1ImplTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/logging/LogFileWriterV1ImplTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package com.wire.android.util.logging
+
+import com.wire.android.AppLogger
+import com.wire.android.appLogger
+import com.wire.kalium.common.logger.CoreLogger
+import com.wire.kalium.common.logger.kaliumLogger
+import com.wire.kalium.logger.KaliumLogLevel
+import com.wire.kalium.logger.KaliumLogger
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class LogFileWriterV1ImplTest {
+
+    @TempDir
+    lateinit var temporaryDirectory: File
+
+    @AfterEach
+    fun resetLoggers() {
+        AppLogger.init(KaliumLogger.Config.DISABLED)
+        CoreLogger.init(KaliumLogger.Config.DISABLED)
+    }
+
+    @Test
+    fun `given app and Kalium loggers when enabled then both events reach the active file`() = runTest {
+        val writer = writer()
+        writer.start()
+        val config = KaliumLogger.Config(KaliumLogLevel.VERBOSE, listOf(writer.logWriter))
+        AppLogger.init(config)
+        CoreLogger.init(config)
+
+        appLogger.i("app-log-event")
+        kaliumLogger.i("kalium-log-event")
+        writer.forceFlush()
+
+        val contents = writer.activeLoggingFile.readText()
+        assertTrue(contents.contains("app-log-event"))
+        assertTrue(contents.contains("kalium-log-event"))
+    }
+
+    @Test
+    fun `given stopped writer when events are logged then they are not persisted`() = runTest {
+        val writer = writer()
+        writer.start()
+        writer.stop()
+
+        writer.logWriter.log(co.touchlab.kermit.Severity.Debug, "disabled-event", "test", null)
+
+        assertFalse(writer.activeLoggingFile.exists() && writer.activeLoggingFile.readText().contains("disabled-event"))
+    }
+
+    @Test
+    fun `given small rolling limit when logging then retained files are bounded and shareable`() = runTest {
+        val writer = writer(rollOnSizeBytes = 1, maxLogFiles = 3)
+        writer.start()
+
+        repeat(10) { writer.logWriter.log(co.touchlab.kermit.Severity.Info, "event-$it", "test", null) }
+        writer.forceFlush()
+
+        val files = temporaryDirectory.listFiles().orEmpty()
+        assertTrue(files.any { it == writer.activeLoggingFile })
+        assertTrue(files.all { it.name == "wire_logs.log" || it.name.matches(Regex("wire_logs-[0-9]+\\.log")) })
+        assertTrue(files.size <= 3)
+    }
+
+    @Test
+    fun `given existing logs when deleting then active file is cleared rolls are removed and logging resumes`() = runTest {
+        val writer = writer()
+        writer.start()
+        repeat(4) { writer.logWriter.log(co.touchlab.kermit.Severity.Info, "before-delete-$it", "test", null) }
+        writer.forceFlush()
+
+        writer.deleteAllLogFiles()
+
+        assertEquals("", writer.activeLoggingFile.readText())
+        assertTrue(temporaryDirectory.listFiles().orEmpty().none { it.name.matches(Regex("wire_logs-[0-9]+\\.log")) })
+
+        writer.logWriter.log(co.touchlab.kermit.Severity.Info, "after-delete", "test", null)
+        writer.forceFlush()
+        assertTrue(writer.activeLoggingFile.readText().contains("after-delete"))
+    }
+
+    private fun writer(
+        rollOnSizeBytes: Long = 25L * 1024 * 1024,
+        maxLogFiles: Int = 11,
+    ) = LogFileWriterV1Impl(
+        logsDirectory = temporaryDirectory,
+        config = LogFileWriterV1Config(
+            rollOnSizeBytes = rollOnSizeBytes,
+            maxLogFiles = maxLogFiles,
+            flushTimeoutMs = 5_000,
+        ),
+    )
+}

--- a/app/src/test/kotlin/com/wire/android/util/logging/LogFileWriterV1ImplTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/logging/LogFileWriterV1ImplTest.kt
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 
 class LogFileWriterV1ImplTest {
 
@@ -95,6 +97,87 @@ class LogFileWriterV1ImplTest {
         assertTrue(writer.activeLoggingFile.readText().contains("after-delete"))
     }
 
+    @Test
+    fun `given legacy log when starting then it is retained in one gzip snapshot`() = runTest {
+        val legacyActive = File(temporaryDirectory, "wire_logs.txt").apply { writeText("legacy diagnostic") }
+        File(temporaryDirectory, "wire_2026-08-27_15-09-01.gz").writeText("old archive")
+        File(temporaryDirectory, "wire_2026-08-27_15-09-01.gz.tmp").writeText("old temp")
+
+        writer().start()
+
+        val snapshot = File(temporaryDirectory, "wire_legacy_active.gz")
+        assertEquals("legacy diagnostic", snapshot.gzipText())
+        assertFalse(legacyActive.exists())
+        assertTrue(temporaryDirectory.listFiles().orEmpty().none { it.name.startsWith("wire_2026-") })
+        assertTrue(File(temporaryDirectory, "wire_logs.log").exists())
+    }
+
+    @Test
+    fun `given finalized legacy snapshot and source when starting then source is removed without a duplicate`() = runTest {
+        File(temporaryDirectory, "wire_logs.txt").writeText("legacy diagnostic")
+        File(temporaryDirectory, "wire_legacy_active.gz").writeGzip("legacy diagnostic")
+        File(temporaryDirectory, "wire_legacy_active.gz.tmp").writeText("stale temp")
+        val legacyArchive = File(temporaryDirectory, "wire_2026-08-27_15-09-01.gz").apply { writeText("old archive") }
+
+        writer().start()
+
+        assertFalse(File(temporaryDirectory, "wire_logs.txt").exists())
+        assertFalse(File(temporaryDirectory, "wire_legacy_active.gz.tmp").exists())
+        assertFalse(legacyArchive.exists())
+        assertEquals(1, temporaryDirectory.listFiles().orEmpty().count { it.name == "wire_legacy_active.gz" })
+        assertEquals("legacy diagnostic", File(temporaryDirectory, "wire_legacy_active.gz").gzipText())
+    }
+
+    @Test
+    fun `given finalized snapshot without source when starting then remaining legacy archives are cleaned`() = runTest {
+        File(temporaryDirectory, "wire_legacy_active.gz").writeGzip("legacy diagnostic")
+        val legacyArchive = File(temporaryDirectory, "wire_2026-08-27_15-09-01.gz").apply { writeText("old archive") }
+
+        writer().start()
+
+        assertFalse(legacyArchive.exists())
+        assertEquals("legacy diagnostic", File(temporaryDirectory, "wire_legacy_active.gz").gzipText())
+    }
+
+    @Test
+    fun `given snapshot failure when starting then legacy files are retained and direct logging starts`() = runTest {
+        val legacyActive = File(temporaryDirectory, "wire_logs.txt").apply { writeText("legacy diagnostic") }
+        val legacyArchive = File(temporaryDirectory, "wire_2026-08-27_15-09-01.gz").apply { writeText("old archive") }
+        File(temporaryDirectory, "wire_legacy_active.gz").apply {
+            mkdir()
+            File(this, "blocker").writeText("cannot delete")
+        }
+
+        val writer = writer()
+        writer.start()
+        writer.logWriter.log(co.touchlab.kermit.Severity.Info, "direct after failed migration", "test", null)
+        writer.forceFlush()
+
+        assertTrue(legacyActive.exists())
+        assertTrue(legacyArchive.exists())
+        assertTrue(writer.activeLoggingFile.readText().contains("direct after failed migration"))
+    }
+
+    @Test
+    fun `given legacy and direct logs when deleting then recognized logs are removed and unrelated files remain`() = runTest {
+        val writer = writer()
+        writer.start()
+        writer.logWriter.log(co.touchlab.kermit.Severity.Info, "direct", "test", null)
+        writer.forceFlush()
+        File(temporaryDirectory, "wire_logs.txt").writeText("legacy active")
+        File(temporaryDirectory, "wire_2026-08-27_15-09-01.gz").writeText("legacy archive")
+        File(temporaryDirectory, "wire_legacy_active.gz").writeGzip("legacy snapshot")
+        val unrelatedFile = File(temporaryDirectory, "unrelated.gz").apply { writeText("keep") }
+
+        writer.deleteAllLogFiles()
+
+        assertEquals("", writer.activeLoggingFile.readText())
+        assertFalse(File(temporaryDirectory, "wire_logs.txt").exists())
+        assertFalse(File(temporaryDirectory, "wire_2026-08-27_15-09-01.gz").exists())
+        assertFalse(File(temporaryDirectory, "wire_legacy_active.gz").exists())
+        assertTrue(unrelatedFile.exists())
+    }
+
     private fun writer(
         rollOnSizeBytes: Long = 25L * 1024 * 1024,
         maxLogFiles: Int = 11,
@@ -106,4 +189,10 @@ class LogFileWriterV1ImplTest {
             flushTimeoutMs = 5_000,
         ),
     )
+
+    private fun File.writeGzip(contents: String) {
+        GZIPOutputStream(outputStream()).bufferedWriter().use { it.write(contents) }
+    }
+
+    private fun File.gzipText(): String = GZIPInputStream(inputStream()).bufferedReader().use { it.readText() }
 }

--- a/default.json
+++ b/default.json
@@ -71,7 +71,7 @@
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://wire.count.ly/",
             "enable_new_registration": true,
-            "use_async_flush_logging": false
+            "use_async_flush_logging": true
         },
         "internal": {
             "application_id": "com.wire.internal",

--- a/default.json
+++ b/default.json
@@ -71,7 +71,7 @@
             "analytics_app_key": "8ffae535f1836ed5f58fd5c8a11c00eca07c5438",
             "analytics_server_url": "https://wire.count.ly/",
             "enable_new_registration": true,
-            "use_async_flush_logging": true,
+            "use_async_flush_logging": false
         },
         "internal": {
             "application_id": "com.wire.internal",
@@ -86,7 +86,7 @@
             "use_strict_mls_filter": false,
             "use_async_flush_logging": true,
             "conversation_feeder_enabled": true,
-            "db_invalidation_control_enabled": false,
+            "db_invalidation_control_enabled": false
         },
         "fdroid": {
             "application_id": "com.wire",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,6 +90,7 @@ aboutLibraries = "14.0.0-b03"
 cyclonedx = "3.1.0"
 leakCanary = "2.14"
 ksp = "2.3.4"
+kermitIo = "2.0.5"
 
 # Benchmark
 benchmark-macro-junit4 = "1.3.3"
@@ -162,6 +163,7 @@ ktx-immutableCollections = { module = "org.jetbrains.kotlinx:kotlinx-collections
 
 ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
 ksp-symbol-processing-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
+kermit-io = { module = "co.touchlab:kermit-io", version.ref = "kermitIo" }
 
 allure-kotlin-model   = { module = "io.qameta.allure:allure-kotlin-model",   version.ref = "allureKotlin" }
 allure-kotlin-commons = { module = "io.qameta.allure:allure-kotlin-commons", version.ref = "allureKotlin" }


### PR DESCRIPTION

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28172
<!--jira-description-action-hidden-marker-end-->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Some devices produces zero bytes logs due to vendor oem restrictions. 

### Causes (Optional)

The current implementation of our file logger relies on spinning off a process that runs logcat and attaches this output to a file log. 

### Solutions

While in the past we dealt with this issue, since it was blocking the app startup, now this enables logs on them as well by using kermit-io and it's RollingFileWritter made for this purpose. 

### Dependencies (Optional)

We need to stick to version 2.0.5 given a datetime constraint coming from kalium, which creates conflict resolution if upgrade to latest 2.1.0


----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
