### PR TITLE
fix: parse SSO failure errorCode

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
+++ b/app/src/main/kotlin/com/wire/android/util/deeplink/DeepLinkProcessor.kt
@@ -248,7 +248,12 @@ class DeepLinkProcessor @Inject constructor(
     private fun getSSOLoginDeepLinkResult(uri: Uri): DeepLinkResult {
 
         val lastPathSegment = uri.lastPathSegment
-        val error = uri.getQueryParameter(SSO_LOGIN_ERROR_PARAM)
+        val error = if (lastPathSegment == SSO_LOGIN_FAILURE) {
+            uri.getQueryParameter(SSO_LOGIN_ERROR_PARAM)
+                ?: uri.getQueryParameter(SSO_LOGIN_LEGACY_ERROR_PARAM)
+        } else {
+            null
+        }
         val cookie = uri.getQueryParameter(SSO_LOGIN_COOKIE_PARAM)
         val location = uri.getQueryParameter(SSO_LOGIN_SERVER_CONFIG_PARAM)
 
@@ -287,7 +292,8 @@ class DeepLinkProcessor @Inject constructor(
         const val SSO_LOGIN_SUCCESS = "success"
         const val SSO_LOGIN_USERID_PARAM = "userId"
         const val SSO_LOGIN_COOKIE_PARAM = "cookie"
-        const val SSO_LOGIN_ERROR_PARAM = "error"
+        const val SSO_LOGIN_ERROR_PARAM = "errorCode"
+        const val SSO_LOGIN_LEGACY_ERROR_PARAM = "error"
         const val SSO_LOGIN_SERVER_CONFIG_PARAM = "location"
         const val CONVERSATION_DEEPLINK_HOST = "conversation"
         const val OTHER_USER_PROFILE_DEEPLINK_HOST = "other-user-profile"

--- a/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/DeepLinkProcessorTest.kt
@@ -363,6 +363,7 @@ class DeepLinkProcessorTest {
             coEvery { uri.host } returns DeepLinkProcessor.SSO_LOGIN_DEEPLINK_HOST
             coEvery { uri.lastPathSegment } returns DeepLinkProcessor.SSO_LOGIN_FAILURE
             coEvery { uri.getQueryParameter(DeepLinkProcessor.SSO_LOGIN_ERROR_PARAM) } returns error
+            coEvery { uri.getQueryParameter(DeepLinkProcessor.SSO_LOGIN_LEGACY_ERROR_PARAM) } returns null
             coEvery { uri.getQueryParameter(DeepLinkProcessor.SSO_LOGIN_COOKIE_PARAM) } returns null
             coEvery { uri.getQueryParameter(DeepLinkProcessor.SSO_LOGIN_SERVER_CONFIG_PARAM) } returns null
             coEvery { uri.getQueryParameter(DeepLinkProcessor.USER_TO_USE_QUERY_PARAM) } returns null

--- a/app/src/test/kotlin/com/wire/android/util/SSOFailureRedirectIntegrationTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/SSOFailureRedirectIntegrationTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.app.Application
+import android.net.Uri
+import com.wire.android.feature.AccountSwitchUseCase
+import com.wire.android.util.deeplink.DeepLinkProcessor
+import com.wire.android.util.deeplink.DeepLinkResult
+import com.wire.android.util.deeplink.SSOFailureCodes
+import com.wire.kalium.logic.CoreLogic
+import com.wire.kalium.logic.feature.session.CurrentSessionResult
+import com.wire.kalium.logic.feature.session.CurrentSessionUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class SSOFailureRedirectIntegrationTest {
+
+    @Test
+    fun `generated SSO failure redirect is parsed by the app`() = runTest {
+        val redirect = generatedFailureRedirect().replace("\$label", ERROR_LABEL)
+
+        val result = deepLinkProcessor()(Uri.parse(redirect))
+
+        assertEquals(DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.Forbidden), result)
+    }
+
+    @Test
+    fun `legacy SSO failure redirect is still parsed by the app`() = runTest {
+        val redirect = generatedFailureRedirect()
+            .replace("?errorCode=", "?error=")
+            .replace("\$label", ERROR_LABEL)
+
+        val result = deepLinkProcessor()(Uri.parse(redirect))
+
+        assertEquals(DeepLinkResult.SSOLogin.Failure(SSOFailureCodes.Forbidden), result)
+    }
+
+    /**
+     * SSOUtil is internal to Kalium, so invoke the production JVM generator without duplicating
+     * its callback template in this app-side integration test.
+     */
+    private fun generatedFailureRedirect(): String {
+        val ssoUtilClass = Class.forName("com.wire.kalium.logic.data.sso.SSOUtil")
+        val instance = ssoUtilClass.getDeclaredField("INSTANCE").apply { isAccessible = true }.get(null)
+        val generator = ssoUtilClass.declaredMethods.single {
+            it.name.startsWith("generateErrorRedirect") && it.parameterCount == 0
+        }.apply { isAccessible = true }
+        return generator.invoke(instance) as String
+    }
+
+    private fun deepLinkProcessor(): DeepLinkProcessor {
+        val currentSession = mockk<CurrentSessionUseCase>()
+        coEvery { currentSession() } returns CurrentSessionResult.Failure.SessionNotFound
+        return DeepLinkProcessor(
+            accountSwitch = mockk<AccountSwitchUseCase>(relaxed = true),
+            currentSession = currentSession,
+            coreLogic = mockk<CoreLogic>(relaxed = true),
+        )
+    }
+
+    private companion object {
+        const val ERROR_LABEL = "forbidden"
+    }
+}


### PR DESCRIPTION
## Goal

Fix SSO failure callbacks being mapped to an unknown error because Android and Kalium used different query parameter names.

Kalium generates the callback with errorCode in [SSOUtil.generateErrorRedirect and QUERY_ERROR](https://github.com/wireapp/kalium/blob/73efbba06fddb23b5990bc7c17c28c3d093020ce/logic/src/commonMain/kotlin/com/wire/kalium/logic/data/sso/SSOUtil.kt#L21-L33), while DeepLinkProcessor previously read error.

## Reproduction

1. Start an SSO login that uses redirect callbacks.
2. Let the SSO backend return a failure callback generated from the Kalium template: wire://sso-login/failure/?errorCode=$label.
3. Android does not find error and maps the callback to Unknown.

## Change

- Treat errorCode as the canonical Android failure parameter to match Kalium.
- Continue accepting error as a legacy fallback for existing or external callbacks.
- Cover the contract by passing the real compiled Kalium-generated failure redirect through Android Uri and DeepLinkProcessor.