### PR TITLE
feat: support cancelling backup restore (WPB-19677)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreScreen.kt
@@ -74,6 +74,7 @@ fun BackupAndRestoreScreen(
         onChooseBackupFile = viewModel::chooseBackupFileToRestore,
         onRestoreBackup = viewModel::restorePasswordProtectedBackup,
         onCancelBackupRestore = viewModel::cancelBackupRestore,
+        onDismissBackupRestore = viewModel::dismissBackupRestore,
         onCancelBackupCreation = viewModel::cancelBackupCreation,
         onOpenConversations = onOpenConversations,
         onBackPressed = onBackPressed,
@@ -90,6 +91,7 @@ fun BackupAndRestoreContent(
     onShareBackup: () -> Unit,
     onCancelBackupCreation: () -> Unit,
     onCancelBackupRestore: () -> Unit,
+    onDismissBackupRestore: () -> Unit,
     onChooseBackupFile: (Uri) -> Unit,
     onRestoreBackup: () -> Unit,
     onOpenConversations: () -> Unit,
@@ -175,10 +177,12 @@ fun BackupAndRestoreContent(
                 backupPasswordTextState = restoreBackupPasswordTextState,
                 onChooseBackupFile = onChooseBackupFile,
                 onRestoreBackup = onRestoreBackup,
-                onCancelBackupRestore = {
+                onDismissBackupRestore = {
                     backupAndRestoreStateHolder.dismissDialog()
-                    onCancelBackupRestore()
+                    onDismissBackupRestore()
                 },
+                onCancelBackupRestore = onCancelBackupRestore,
+                onRestoreCancellationCompleted = backupAndRestoreStateHolder::dismissDialog,
                 onOpenConversations = onOpenConversations,
                 onChooseFilePermissionPermanentlyDenied = {
                     permissionPermanentlyDeniedDialogState.show(
@@ -267,6 +271,7 @@ fun PreviewBackupAndRestoreScreen() = WireTheme {
         onShareBackup = {},
         onCancelBackupCreation = {},
         onCancelBackupRestore = {},
+        onDismissBackupRestore = {},
         onChooseBackupFile = {},
         onRestoreBackup = {},
         onOpenConversations = {},

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreState.kt
@@ -63,6 +63,8 @@ sealed interface BackupCreationProgress {
 sealed interface BackupRestoreProgress {
     data object Finished : BackupRestoreProgress
     data class InProgress(val value: Float = 0f) : BackupRestoreProgress
+    data object Cancelling : BackupRestoreProgress
+    data object Cancelled : BackupRestoreProgress
     data object Failed : BackupRestoreProgress
 }
 

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/BackupAndRestoreViewModel.kt
@@ -53,10 +53,12 @@ import com.wire.kalium.logic.feature.backup.VerifyBackupResult
 import com.wire.kalium.logic.feature.backup.VerifyBackupUseCase
 import com.wire.kalium.util.DateTimeUtil
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import okio.IOException
 import okio.Path
 import dev.zacsweers.metro.Inject
 @Suppress("LongParameterList", "TooManyFunctions")
@@ -86,7 +88,8 @@ class BackupAndRestoreViewModel @Inject constructor(
     @VisibleForTesting
     internal lateinit var latestImportedBackupTempPath: Path
 
-    private var createRestoreJob: Job? = null
+    private var createBackupJob: Job? = null
+    private var restoreBackupJob: Job? = null
 
     init {
         observeLastBackupDate()
@@ -107,8 +110,8 @@ class BackupAndRestoreViewModel @Inject constructor(
         }
     }
     fun createBackup() {
-        createRestoreJob?.cancel()
-        createRestoreJob = viewModelScope.launch {
+        createBackupJob?.cancel()
+        createBackupJob = viewModelScope.launch {
             val password = createBackupPasswordState.text.toString()
             val result = if (mpBackupSettings is MPBackupSettings.Enabled) {
                 createMpBackupFile(password) { progress ->
@@ -169,6 +172,11 @@ class BackupAndRestoreViewModel @Inject constructor(
         )
     }
     fun chooseBackupFileToRestore(uri: Uri) = viewModelScope.launch {
+        state = state.copy(
+            backupRestoreProgress = BackupRestoreProgress.InProgress(),
+            restoreFileValidation = RestoreFileValidation.Initial,
+            restorePasswordValidation = PasswordValidation.NotVerified,
+        )
         latestImportedBackupTempPath = kaliumFileSystem.tempFilePath(TEMP_IMPORTED_BACKUP_FILE_NAME)
         fileManager.copyToPath(uri, latestImportedBackupTempPath)
         verifyBackupFile(latestImportedBackupTempPath)
@@ -255,30 +263,65 @@ class BackupAndRestoreViewModel @Inject constructor(
         )
     }
     fun cancelBackupCreation() = viewModelScope.launch(dispatcher.main()) {
-        createRestoreJob?.cancel()
+        createBackupJob?.cancel()
         createBackupPasswordState.clearText()
         updateCreationProgress(0f)
     }
-    fun cancelBackupRestore() = viewModelScope.launch {
-        createRestoreJob?.cancel()
+
+    fun dismissBackupRestore() = viewModelScope.launch {
+        restoreBackupJob?.cancelAndJoin()
         restoreBackupPasswordState.clearText()
         state = state.copy(
             restoreFileValidation = RestoreFileValidation.Initial,
             backupRestoreProgress = BackupRestoreProgress.InProgress(),
             restorePasswordValidation = PasswordValidation.NotVerified
         )
-        withContext(dispatcher.io()) {
-            if (this@BackupAndRestoreViewModel::latestImportedBackupTempPath.isInitialized && kaliumFileSystem.exists(
-                    latestImportedBackupTempPath
-                )
-            ) {
-                kaliumFileSystem.delete(latestImportedBackupTempPath)
-            }
+        deleteImportedBackupFileSafely()
+    }
+
+    fun cancelBackupRestore() {
+        if (
+            state.backupFileFormat != BackupFileFormat.MULTIPLATFORM ||
+            state.backupRestoreProgress !is BackupRestoreProgress.InProgress
+        ) {
+            return
+        }
+
+        state = state.copy(backupRestoreProgress = BackupRestoreProgress.Cancelling)
+        val jobToCancel = restoreBackupJob
+        viewModelScope.launch {
+            jobToCancel?.cancelAndJoin()
+            deleteImportedBackupFileSafely()
+            restoreBackupPasswordState.clearText()
+            state = state.copy(
+                restoreFileValidation = RestoreFileValidation.Initial,
+                backupRestoreProgress = BackupRestoreProgress.Cancelled,
+                restorePasswordValidation = PasswordValidation.NotVerified,
+            )
         }
     }
+
+    private suspend fun deleteImportedBackupFileSafely() {
+        try {
+            deleteImportedBackupFile()
+        } catch (exception: IOException) {
+            appLogger.e("Failed to delete imported backup file", exception)
+        }
+    }
+
+    private suspend fun deleteImportedBackupFile() = withContext(dispatcher.io()) {
+        if (
+            this@BackupAndRestoreViewModel::latestImportedBackupTempPath.isInitialized &&
+            kaliumFileSystem.exists(latestImportedBackupTempPath)
+        ) {
+            kaliumFileSystem.delete(latestImportedBackupTempPath)
+        }
+    }
+
     private fun restoreBackup(backupFilePath: Path, password: String?) {
-        createRestoreJob?.cancel()
-        createRestoreJob = viewModelScope.launch {
+        restoreBackupJob?.cancel()
+        state = state.copy(backupRestoreProgress = BackupRestoreProgress.InProgress())
+        restoreBackupJob = viewModelScope.launch {
             val result = when (state.backupFileFormat) {
                 BackupFileFormat.ANDROID -> importBackup(backupFilePath, password)
                 BackupFileFormat.MULTIPLATFORM -> importMpBackup(backupFilePath, password) { progress ->
@@ -304,8 +347,11 @@ class BackupAndRestoreViewModel @Inject constructor(
     private fun updateCreationProgress(progress: Float) = viewModelScope.launch {
         state = state.copy(backupCreationProgress = BackupCreationProgress.InProgress(progress))
     }
-    private fun updateRestoreProgress(progress: Float) = viewModelScope.launch {
-        state = state.copy(backupRestoreProgress = BackupRestoreProgress.InProgress(progress))
+
+    private fun updateRestoreProgress(progress: Float) {
+        if (state.backupRestoreProgress is BackupRestoreProgress.InProgress) {
+            state = state.copy(backupRestoreProgress = BackupRestoreProgress.InProgress(progress))
+        }
     }
     internal companion object {
         const val TEMP_IMPORTED_BACKUP_FILE_NAME = "tempImportedBackup.zip"

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogFlow.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogFlow.kt
@@ -34,6 +34,7 @@ import com.wire.android.ui.home.settings.backup.BackupRestoreProgress
 import com.wire.android.ui.home.settings.backup.PasswordValidation
 import com.wire.android.ui.home.settings.backup.RestoreFileValidation
 import com.wire.android.ui.home.settings.backup.dialog.common.FailureDialog
+import com.wire.kalium.logic.feature.backup.BackupFileFormat
 
 @Composable
 fun RestoreBackupDialogFlow(
@@ -43,6 +44,8 @@ fun RestoreBackupDialogFlow(
     onRestoreBackup: () -> Unit,
     onOpenConversations: () -> Unit,
     onCancelBackupRestore: () -> Unit,
+    onDismissBackupRestore: () -> Unit,
+    onRestoreCancellationCompleted: () -> Unit,
     onChooseFilePermissionPermanentlyDenied: () -> Unit,
 ) {
     val restoreDialogStateHolder = rememberRestoreDialogState()
@@ -54,7 +57,7 @@ fun RestoreBackupDialogFlow(
                     backUpAndRestoreState = backUpAndRestoreState,
                     restoreDialogStateHolder = restoreDialogStateHolder,
                     onChooseBackupFile = onChooseBackupFile,
-                    onCancelBackupRestore = onCancelBackupRestore,
+                    onCancelBackupRestore = onDismissBackupRestore,
                     onChooseFilePermissionPermanentlyDenied = onChooseFilePermissionPermanentlyDenied,
                 )
             }
@@ -65,7 +68,7 @@ fun RestoreBackupDialogFlow(
                     backUpAndRestoreState = backUpAndRestoreState,
                     restoreDialogStateHolder = restoreDialogStateHolder,
                     onRestoreBackup = onRestoreBackup,
-                    onCancelBackupRestore = onCancelBackupRestore
+                    onCancelBackupRestore = onDismissBackupRestore
                 )
             }
 
@@ -73,7 +76,9 @@ fun RestoreBackupDialogFlow(
                 RestoreBackupStep(
                     backUpAndRestoreState = backUpAndRestoreState,
                     restoreDialogStateHolder = restoreDialogStateHolder,
-                    onOpenConversations = onOpenConversations
+                    onOpenConversations = onOpenConversations,
+                    onCancelBackupRestore = onCancelBackupRestore,
+                    onRestoreCancellationCompleted = onRestoreCancellationCompleted,
                 )
             }
 
@@ -81,14 +86,14 @@ fun RestoreBackupDialogFlow(
                 FailureDialog(
                     title = stringResource(id = restoreDialogStep.restoreFailure.title),
                     message = stringResource(id = restoreDialogStep.restoreFailure.message),
-                    onDismiss = onCancelBackupRestore
+                    onDismiss = onDismissBackupRestore
                 )
             }
         }
     }
 
     BackHandler(restoreDialogStateHolder.currentRestoreDialogStep != RestoreDialogStep.RestoreBackup) {
-        onCancelBackupRestore()
+        onDismissBackupRestore()
     }
 }
 
@@ -167,7 +172,9 @@ fun EnterPasswordStep(
 fun RestoreBackupStep(
     backUpAndRestoreState: BackupAndRestoreState,
     restoreDialogStateHolder: RestoreDialogStateHolder,
-    onOpenConversations: () -> Unit
+    onOpenConversations: () -> Unit,
+    onCancelBackupRestore: () -> Unit,
+    onRestoreCancellationCompleted: () -> Unit,
 ) {
     with(restoreDialogStateHolder) {
         LaunchedEffect(backUpAndRestoreState.backupRestoreProgress) {
@@ -185,6 +192,8 @@ fun RestoreBackupStep(
                     }
                 }
                 BackupRestoreProgress.Finished -> restoreDialogStateHolder.toFinished()
+                BackupRestoreProgress.Cancelling -> Unit
+                BackupRestoreProgress.Cancelled -> onRestoreCancellationCompleted()
                 is BackupRestoreProgress.InProgress -> {
                     restoreDialogStateHolder.restoreProgress = progress.value
                 }
@@ -194,7 +203,10 @@ fun RestoreBackupStep(
         RestoreProgressDialog(
             isRestoreCompleted = isRestoreCompleted,
             restoreProgress = restoreProgress,
-            onOpenConversation = onOpenConversations
+            onOpenConversation = onOpenConversations,
+            canCancel = backUpAndRestoreState.backupFileFormat == BackupFileFormat.MULTIPLATFORM,
+            isCancelling = backUpAndRestoreState.backupRestoreProgress == BackupRestoreProgress.Cancelling,
+            onCancelBackupRestore = onCancelBackupRestore,
         )
     }
 }

--- a/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/settings/backup/dialog/restore/RestoreBackupDialogs.kt
@@ -125,6 +125,9 @@ fun RestoreProgressDialog(
     isRestoreCompleted: Boolean,
     restoreProgress: Float,
     onOpenConversation: () -> Unit,
+    canCancel: Boolean,
+    isCancelling: Boolean,
+    onCancelBackupRestore: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val progress by animateFloatAsState(targetValue = restoreProgress)
@@ -135,11 +138,20 @@ fun RestoreProgressDialog(
             // User is not able to dismiss the dialog
         },
         optionButton1Properties = WireDialogButtonProperties(
-            onClick = onOpenConversation,
-            text = if (isRestoreCompleted) stringResource(R.string.label_ok) else "",
-            type = WireDialogButtonType.Primary,
-            state = if (isRestoreCompleted) WireButtonState.Default else WireButtonState.Disabled,
-            loading = !isRestoreCompleted,
+            onClick = if (isRestoreCompleted) onOpenConversation else onCancelBackupRestore,
+            text = when {
+                isRestoreCompleted -> stringResource(R.string.label_ok)
+                isCancelling -> stringResource(R.string.backup_label_cancelling)
+                canCancel -> stringResource(R.string.label_cancel)
+                else -> ""
+            },
+            type = if (isRestoreCompleted) WireDialogButtonType.Primary else WireDialogButtonType.Secondary,
+            state = if (isRestoreCompleted || (canCancel && !isCancelling)) {
+                WireButtonState.Default
+            } else {
+                WireButtonState.Disabled
+            },
+            loading = !isRestoreCompleted && (!canCancel || isCancelling),
             loadingIndicatorAlignment = IconAlignment.Center
         ),
     ) {
@@ -171,6 +183,9 @@ fun PreviewRestoreProgressDialog() = WireTheme {
     RestoreProgressDialog(
         isRestoreCompleted = false,
         restoreProgress = 0.5f,
-        onOpenConversation = {}
+        onOpenConversation = {},
+        canCancel = true,
+        isCancelling = false,
+        onCancelBackupRestore = {},
     )
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1389,6 +1389,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="backup_dialog_restoring_backup_title">Restoring backup...</string>
     <string name="backup_label_conversation_restored">Conversations have been restored</string>
     <string name="backup_label_loading_conversations">Loading conversations</string>
+    <string name="backup_label_cancelling">Cancelling...</string>
     <string name="backup_dialog_restore_backup_title">Restore from backup </string>
     <string name="backup_dialog_restore_backup_message">The existing history on this device remains and will be completed by the new backup. You can restore history from all your devices and different platforms but not from another account.</string>
     <string name="backup_dialog_choose_backup_file_option">Choose Backup File</string>

--- a/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/settings/home/BackupAndRestoreViewModelTest.kt
@@ -59,12 +59,18 @@ import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Instant
@@ -366,7 +372,7 @@ class BackupAndRestoreViewModelTest {
         // When
         backupAndRestoreViewModel.chooseBackupFileToRestore(backupUri)
         advanceUntilIdle()
-        backupAndRestoreViewModel.cancelBackupRestore()
+        backupAndRestoreViewModel.dismissBackupRestore()
         advanceUntilIdle()
 
         // Then
@@ -377,6 +383,51 @@ class BackupAndRestoreViewModelTest {
         coVerify(exactly = 1) {
             arrangement.fileManager.copyToPath(backupUri, backupAndRestoreViewModel.latestImportedBackupTempPath, any())
         }
+    }
+
+    @Test
+    fun givenMultiplatformRestoreInProgress_whenCancelling_thenWaitsForCurrentPageBeforeCleanup() = runTest(dispatcher.default()) {
+        val pageStarted = CompletableDeferred<Unit>()
+        val finishPage = CompletableDeferred<Unit>()
+        val progressCallback = slot<(Float) -> Unit>()
+        val (arrangement, backupAndRestoreViewModel) = Arrangement()
+            .withCancellableMultiplatformRestore(pageStarted, finishPage, progressCallback)
+            .arrange()
+
+        backupAndRestoreViewModel.restorePasswordProtectedBackup()
+        advanceTimeBy(BackupAndRestoreViewModel.SMALL_DELAY + 1)
+        runCurrent()
+        pageStarted.await()
+
+        backupAndRestoreViewModel.cancelBackupRestore()
+        backupAndRestoreViewModel.cancelBackupRestore()
+        runCurrent()
+
+        assertEquals(BackupRestoreProgress.Cancelling, backupAndRestoreViewModel.state.backupRestoreProgress)
+        assertTrue(arrangement.fakeKaliumFileSystem.exists(backupAndRestoreViewModel.latestImportedBackupTempPath))
+
+        progressCallback.captured(0.75f)
+        assertEquals(BackupRestoreProgress.Cancelling, backupAndRestoreViewModel.state.backupRestoreProgress)
+
+        finishPage.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(BackupRestoreProgress.Cancelled, backupAndRestoreViewModel.state.backupRestoreProgress)
+        assertFalse(arrangement.fakeKaliumFileSystem.exists(backupAndRestoreViewModel.latestImportedBackupTempPath))
+    }
+
+    @Test
+    fun givenLegacyRestoreInProgress_whenCancelling_thenCancellationIsIgnored() = runTest(dispatcher.default()) {
+        val (_, backupAndRestoreViewModel) = Arrangement().arrange()
+        backupAndRestoreViewModel.state = backupAndRestoreViewModel.state.copy(
+            backupFileFormat = BackupFileFormat.ANDROID,
+            backupRestoreProgress = BackupRestoreProgress.InProgress(0.5f),
+        )
+
+        backupAndRestoreViewModel.cancelBackupRestore()
+        advanceUntilIdle()
+
+        assertEquals(BackupRestoreProgress.InProgress(0.5f), backupAndRestoreViewModel.state.backupRestoreProgress)
     }
 
     @Test
@@ -576,6 +627,29 @@ class BackupAndRestoreViewModelTest {
             viewModel.latestImportedBackupTempPath =
                 fakeKaliumFileSystem.tempFilePath(BackupAndRestoreViewModel.TEMP_IMPORTED_BACKUP_FILE_NAME)
             coEvery { importBackup(any(), any()) } returns RestoreBackupResult.Success
+        }
+
+        fun withCancellableMultiplatformRestore(
+            pageStarted: CompletableDeferred<Unit>,
+            finishPage: CompletableDeferred<Unit>,
+            progressCallback: io.mockk.CapturingSlot<(Float) -> Unit>,
+        ) = apply {
+            viewModel.latestImportedBackupTempPath =
+                fakeKaliumFileSystem.tempFilePath(BackupAndRestoreViewModel.TEMP_IMPORTED_BACKUP_FILE_NAME)
+            fakeKaliumFileSystem.sink(viewModel.latestImportedBackupTempPath).buffer().use {
+                it.write("someBackupData".toByteArray())
+            }
+            viewModel.state = viewModel.state.copy(
+                backupFileFormat = BackupFileFormat.MULTIPLATFORM,
+                restoreFileValidation = RestoreFileValidation.PasswordRequired,
+            )
+            coEvery { importMpBackup(any(), any(), capture(progressCallback)) } coAnswers {
+                pageStarted.complete(Unit)
+                withContext(NonCancellable) {
+                    finishPage.await()
+                }
+                RestoreBackupResult.Success
+            }
         }
 
         fun withRequestedPasswordDialog() = apply {

--- a/app/stability/app-devDebug.stability
+++ b/app/stability/app-devDebug.stability
@@ -3267,7 +3267,7 @@ public fun com.wire.android.ui.debug.DebugDataOptions(appVersion: kotlin.String,
     - viewModel: RUNTIME (requires runtime check)
 
 @Composable
-public fun com.wire.android.ui.debug.DebugDataOptionsContent(state: com.wire.android.ui.debug.DebugDataOptionsState, appVersion: kotlin.String, buildVariant: kotlin.String, onCopyText: kotlin.Function1<kotlin.String, kotlin.Unit>, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, enrollE2EICertificate: kotlin.Function0<kotlin.Unit>, e2eiCertificateExpirationInputState: androidx.compose.foundation.text.input.TextFieldState, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult, kotlin.Unit>, dismissCertificateDialog: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onResendFCMToken: kotlin.Function0<kotlin.Unit>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>, onShowSecurityProviders: kotlin.Function0<kotlin.Unit>, onRepairFaultyRemovalKeys: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.debug.DebugDataOptionsContent(state: com.wire.android.ui.debug.DebugDataOptionsState, appVersion: kotlin.String, buildVariant: kotlin.String, onCopyText: kotlin.Function1<kotlin.String, kotlin.Unit>, onDisableEventProcessingChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onRestartSlowSyncForRecovery: kotlin.Function0<kotlin.Unit>, onForceUpdateApiVersions: kotlin.Function0<kotlin.Unit>, enrollE2EICertificate: kotlin.Function0<kotlin.Unit>, e2eiCertificateExpirationInputState: androidx.compose.foundation.text.input.TextFieldState, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIResult, kotlin.Unit>, dismissCertificateDialog: kotlin.Function0<kotlin.Unit>, checkCrlRevocationList: kotlin.Function0<kotlin.Unit>, forceCRLExpirationAfterOneMinute: kotlin.Boolean, onForceCRLExpirationAfterOneMinuteChange: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onResendFCMToken: kotlin.Function0<kotlin.Unit>, onShowFeatureFlags: kotlin.Function0<kotlin.Unit>, onShowCryptoStats: kotlin.Function0<kotlin.Unit>, onShowSecurityProviders: kotlin.Function0<kotlin.Unit>, onRepairFaultyRemovalKeys: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -3647,6 +3647,14 @@ public fun com.wire.android.ui.debug.securityProvidersViewModel(): com.wire.andr
   params:
 
 @Composable
+public fun com.wire.android.ui.debug.securityproviders.CryptoServiceListItem(row: com.wire.android.ui.debug.securityproviders.CryptoServiceRow, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+  skippable: true
+  restartable: true
+  params:
+    - row: STABLE (class with no mutable properties)
+    - modifier: STABLE (marked @Stable or @Immutable)
+
+@Composable
 private fun com.wire.android.ui.debug.securityproviders.NetworkSection(network: com.wire.android.ui.debug.securityproviders.NetworkDiagnostics): kotlin.Unit
   skippable: false
   restartable: true
@@ -3700,7 +3708,7 @@ internal fun com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentRouteScreen(viewMo
     - onOpenCertificateDetails: STABLE (function type)
 
 @Composable
-private fun com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentScreenContent(state: com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentState, clearSessionState: com.wire.android.ui.authentication.devices.common.ClearSessionState, dismissSuccess: kotlin.Function0<kotlin.Unit>, dismissErrorDialog: kotlin.Function0<kotlin.Unit>, enrollE2EICertificate: kotlin.Function0<kotlin.Unit>, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult, kotlin.Unit>, openCertificateDetails: kotlin.Function0<kotlin.Unit>, onBackButtonClicked: kotlin.Function0<kotlin.Unit>, onCancelEnrollmentClicked: kotlin.Function0<kotlin.Unit>, onProceedEnrollmentClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+private fun com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentScreenContent(state: com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentState, clearSessionState: com.wire.android.ui.authentication.devices.common.ClearSessionState, dismissSuccess: kotlin.Function0<kotlin.Unit>, dismissErrorDialog: kotlin.Function0<kotlin.Unit>, enrollE2EICertificate: kotlin.Function0<kotlin.Unit>, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIResult, kotlin.Unit>, openCertificateDetails: kotlin.Function0<kotlin.Unit>, onBackButtonClicked: kotlin.Function0<kotlin.Unit>, onCancelEnrollmentClicked: kotlin.Function0<kotlin.Unit>, onProceedEnrollmentClicked: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: true
   restartable: true
   params:
@@ -3716,7 +3724,7 @@ private fun com.wire.android.ui.e2eiEnrollment.E2EIEnrollmentScreenContent(state
     - onProceedEnrollmentClicked: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.e2eiEnrollment.GetE2EICertificateUI(enrollmentResultHandler: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult, kotlin.Unit>, isNewClient: kotlin.Boolean, viewModel: com.wire.android.ui.e2eiEnrollment.GetE2EICertificateViewModel): kotlin.Unit
+public fun com.wire.android.ui.e2eiEnrollment.GetE2EICertificateUI(enrollmentResultHandler: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIResult, kotlin.Unit>, isNewClient: kotlin.Boolean, viewModel: com.wire.android.ui.e2eiEnrollment.GetE2EICertificateViewModel): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -9795,7 +9803,7 @@ public fun com.wire.android.ui.home.settings.avatarPickerViewModel(): com.wire.a
   params:
 
 @Composable
-public fun com.wire.android.ui.home.settings.backup.BackupAndRestoreContent(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, createBackupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, restoreBackupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, onCreateBackup: kotlin.Function0<kotlin.Unit>, onSaveBackup: kotlin.Function1<android.net.Uri, kotlin.Unit>, onShareBackup: kotlin.Function0<kotlin.Unit>, onCancelBackupCreation: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, onChooseBackupFile: kotlin.Function1<android.net.Uri, kotlin.Unit>, onRestoreBackup: kotlin.Function0<kotlin.Unit>, onOpenConversations: kotlin.Function0<kotlin.Unit>, onBackPressed: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.home.settings.backup.BackupAndRestoreContent(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, createBackupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, restoreBackupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, onCreateBackup: kotlin.Function0<kotlin.Unit>, onSaveBackup: kotlin.Function1<android.net.Uri, kotlin.Unit>, onShareBackup: kotlin.Function0<kotlin.Unit>, onCancelBackupCreation: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, onDismissBackupRestore: kotlin.Function0<kotlin.Unit>, onChooseBackupFile: kotlin.Function1<android.net.Uri, kotlin.Unit>, onRestoreBackup: kotlin.Function0<kotlin.Unit>, onOpenConversations: kotlin.Function0<kotlin.Unit>, onBackPressed: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -9807,6 +9815,7 @@ public fun com.wire.android.ui.home.settings.backup.BackupAndRestoreContent(back
     - onShareBackup: STABLE (function type)
     - onCancelBackupCreation: STABLE (function type)
     - onCancelBackupRestore: STABLE (function type)
+    - onDismissBackupRestore: STABLE (function type)
     - onChooseBackupFile: STABLE (function type)
     - onRestoreBackup: STABLE (function type)
     - onOpenConversations: STABLE (function type)
@@ -9940,7 +9949,7 @@ public fun com.wire.android.ui.home.settings.backup.dialog.restore.PickRestoreFi
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
-public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackupDialogFlow(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, backupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, onChooseBackupFile: kotlin.Function1<android.net.Uri, kotlin.Unit>, onRestoreBackup: kotlin.Function0<kotlin.Unit>, onOpenConversations: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, onChooseFilePermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackupDialogFlow(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, backupPasswordTextState: androidx.compose.foundation.text.input.TextFieldState, onChooseBackupFile: kotlin.Function1<android.net.Uri, kotlin.Unit>, onRestoreBackup: kotlin.Function0<kotlin.Unit>, onOpenConversations: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, onDismissBackupRestore: kotlin.Function0<kotlin.Unit>, onRestoreCancellationCompleted: kotlin.Function0<kotlin.Unit>, onChooseFilePermissionPermanentlyDenied: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
@@ -9950,25 +9959,32 @@ public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackup
     - onRestoreBackup: STABLE (function type)
     - onOpenConversations: STABLE (function type)
     - onCancelBackupRestore: STABLE (function type)
+    - onDismissBackupRestore: STABLE (function type)
+    - onRestoreCancellationCompleted: STABLE (function type)
     - onChooseFilePermissionPermanentlyDenied: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackupStep(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, restoreDialogStateHolder: com.wire.android.ui.home.settings.backup.dialog.restore.RestoreDialogStateHolder, onOpenConversations: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreBackupStep(backUpAndRestoreState: com.wire.android.ui.home.settings.backup.BackupAndRestoreState, restoreDialogStateHolder: com.wire.android.ui.home.settings.backup.dialog.restore.RestoreDialogStateHolder, onOpenConversations: kotlin.Function0<kotlin.Unit>, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, onRestoreCancellationCompleted: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:
     - backUpAndRestoreState: UNSTABLE (has mutable properties or unstable members)
     - restoreDialogStateHolder: STABLE (marked @Stable or @Immutable)
     - onOpenConversations: STABLE (function type)
+    - onCancelBackupRestore: STABLE (function type)
+    - onRestoreCancellationCompleted: STABLE (function type)
 
 @Composable
-public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreProgressDialog(isRestoreCompleted: kotlin.Boolean, restoreProgress: kotlin.Float, onOpenConversation: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
+public fun com.wire.android.ui.home.settings.backup.dialog.restore.RestoreProgressDialog(isRestoreCompleted: kotlin.Boolean, restoreProgress: kotlin.Float, onOpenConversation: kotlin.Function0<kotlin.Unit>, canCancel: kotlin.Boolean, isCancelling: kotlin.Boolean, onCancelBackupRestore: kotlin.Function0<kotlin.Unit>, modifier: androidx.compose.ui.Modifier): kotlin.Unit
   skippable: true
   restartable: true
   params:
     - isRestoreCompleted: STABLE (primitive type)
     - restoreProgress: STABLE (primitive type)
     - onOpenConversation: STABLE (function type)
+    - canCancel: STABLE (primitive type)
+    - isCancelling: STABLE (primitive type)
+    - onCancelBackupRestore: STABLE (function type)
     - modifier: STABLE (marked @Stable or @Immutable)
 
 @Composable
@@ -10959,7 +10975,7 @@ private fun com.wire.android.ui.settings.devices.DeviceDetailSectionContent(sect
     - titleTrailingItem: STABLE (composable function type)
 
 @Composable
-public fun com.wire.android.ui.settings.devices.DeviceDetailsContent(state: com.wire.android.ui.settings.devices.model.DeviceDetailsState, passwordTextState: androidx.compose.foundation.text.input.TextFieldState, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.FinalizeEnrollmentResult, kotlin.Unit>, modifier: androidx.compose.ui.Modifier, onDeleteDevice: kotlin.Function0<kotlin.Unit>, onNavigateBack: kotlin.Function0<kotlin.Unit>, onNavigateToE2eiCertificateDetailsScreen: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.MLSClientIdentity, kotlin.Unit>, onRemoveConfirm: kotlin.Function0<kotlin.Unit>, onDialogDismiss: kotlin.Function0<kotlin.Unit>, onErrorDialogDismiss: kotlin.Function0<kotlin.Unit>, enrollE2eiCertificate: kotlin.Function0<kotlin.Unit>, onUpdateClientVerification: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onEnrollE2EIErrorDismiss: kotlin.Function0<kotlin.Unit>, onEnrollE2EISuccessDismiss: kotlin.Function0<kotlin.Unit>, onBreakSession: kotlin.Function0<kotlin.Unit>): kotlin.Unit
+public fun com.wire.android.ui.settings.devices.DeviceDetailsContent(state: com.wire.android.ui.settings.devices.model.DeviceDetailsState, passwordTextState: androidx.compose.foundation.text.input.TextFieldState, handleE2EIEnrollmentResult: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.usecase.EnrollE2EIResult, kotlin.Unit>, modifier: androidx.compose.ui.Modifier, onDeleteDevice: kotlin.Function0<kotlin.Unit>, onNavigateBack: kotlin.Function0<kotlin.Unit>, onNavigateToE2eiCertificateDetailsScreen: kotlin.Function1<com.wire.kalium.logic.feature.e2ei.MLSClientIdentity, kotlin.Unit>, onRemoveConfirm: kotlin.Function0<kotlin.Unit>, onDialogDismiss: kotlin.Function0<kotlin.Unit>, onErrorDialogDismiss: kotlin.Function0<kotlin.Unit>, enrollE2eiCertificate: kotlin.Function0<kotlin.Unit>, onUpdateClientVerification: kotlin.Function1<kotlin.Boolean, kotlin.Unit>, onEnrollE2EIErrorDismiss: kotlin.Function0<kotlin.Unit>, onEnrollE2EISuccessDismiss: kotlin.Function0<kotlin.Unit>, onBreakSession: kotlin.Function0<kotlin.Unit>): kotlin.Unit
   skippable: false
   restartable: true
   params:


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-19677
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-19677
----

# What's new in this PR?

### Issues

The Cancel button did not stop an in-progress multiplatform backup restore.

### Causes (Optional)

Restore and backup jobs were not separated, and the UI had no cancellation lifecycle that waited for persistence and temporary-file cleanup.

### Solutions

- Enable Cancel only for multiplatform restores.
- Add Cancelling and Cancelled states.
- Wait for the active persistence page and cleanup to finish before dismissing.
- Prevent late progress updates and analytics from reporting cancellation as success or failure.
- Keep legacy restores non-cancellable.