### PR TITLE
feat(drive): Restrict external file opening for Viewer users (WPB-28476)

### DIFF
--- a/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
+++ b/features/cells/src/main/java/com/wire/android/feature/cells/ui/CellViewModel.kt
@@ -124,7 +124,7 @@ class CellViewModel @AssistedInject constructor(
     @Named("offlineFilesEnabled") val offlineFilesEnabled: Boolean,
     @Named("inAppImageViewerEnabled") private val inAppImageViewerEnabled: Boolean,
     @Named("drivePermissionsEnabled") val drivePermissionsEnabled: Boolean,
-    ) : ActionsViewModel<CellViewAction>() {
+) : ActionsViewModel<CellViewAction>() {
 
     @AssistedFactory
     interface Factory {
@@ -454,14 +454,21 @@ class CellViewModel @AssistedInject constructor(
 
             else -> Unit
         }
-        file.contentUrl?.let { url ->
-            fileHelper.openAssetUrlWithExternalApp(
-                url = url,
-                mimeType = file.mimeType,
-                onError = {
-                    sendAction(ShowError(CellError.NO_APP_FOUND))
-                }
-            )
+
+        val isViewerWithDrivePermissions = isViewerOnly.value && drivePermissionsEnabled
+
+        if (!isViewerWithDrivePermissions) {
+            file.contentUrl?.let { url ->
+                fileHelper.openAssetUrlWithExternalApp(
+                    url = url,
+                    mimeType = file.mimeType,
+                    onError = {
+                        sendAction(ShowError(CellError.NO_APP_FOUND))
+                    }
+                )
+            }
+        } else {
+            sendAction(ShowError(CellError.FILE_NOT_SUPPORTED))
         }
     }
 
@@ -487,15 +494,21 @@ class CellViewModel @AssistedInject constructor(
 
             else -> Unit
         }
-        file.localPath?.let { path ->
-            fileHelper.openAssetFileWithExternalApp(
-                localPath = path.toPath(),
-                assetName = file.name,
-                mimeType = file.mimeType,
-                onError = {
-                    sendAction(ShowError(CellError.NO_APP_FOUND))
-                }
-            )
+        val isViewerWithDrivePermissions = isViewerOnly.value && drivePermissionsEnabled
+
+        if (!isViewerWithDrivePermissions) {
+            file.localPath?.let { path ->
+                fileHelper.openAssetFileWithExternalApp(
+                    localPath = path.toPath(),
+                    assetName = file.name,
+                    mimeType = file.mimeType,
+                    onError = {
+                        sendAction(ShowError(CellError.NO_APP_FOUND))
+                    }
+                )
+            }
+        } else {
+            sendAction(ShowError(CellError.FILE_NOT_SUPPORTED))
         }
     }
 
@@ -741,6 +754,7 @@ internal data class OpenVideoViewer(val file: CellNodeUi.File) : CellViewAction
 internal data class OpenAudioPlayer(val file: CellNodeUi.File) : CellViewAction
 
 internal enum class CellError(val message: Int) {
+    FILE_NOT_SUPPORTED(R.string.file_not_supported),
     NO_APP_FOUND(R.string.no_app_found),
     OTHER_ERROR(R.string.action_failed),
     DOWNLOAD_FAILED(R.string.action_failed),

--- a/features/cells/src/main/res/values/strings.xml
+++ b/features/cells/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="share_file_via_link">Share file via link</string>
     <string name="share_folder_via_link">Share folder via link</string>
     <string name="no_app_found">No application found to open the file.</string>
+    <string name="file_not_supported">Can\'t open this file. File type isn\'t supported.</string>
     <string name="cell_files_load_failure_message">Unable to load. Please try again later.</string>
     <string name="action_failed">Action failed.</string>
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28476
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [ ] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [ ] contains a reference JIRA issue number like `SQPIT-764`
    - [ ] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [ ] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Prevent users with the Viewer role from opening files using external apps when Drive permissions are enabled.

### Dependencies (Optional)

_If there are some other pull requests related to this one (e.g. new releases of frameworks), specify them here._

Needs releases with:

- [ ] GitHub link to other pull request

### Testing

#### Test Coverage (Optional)

- [ ] I have added automated test to this contribution

#### How to Test

_Briefly describe how this change was tested and if applicable the exact steps taken to verify that it works as expected._

### Notes (Optional)

_Specify here any other facts that you think are important for this issue._

### Attachments (Optional)

_Attachments like images, videos, etc. (drag and drop in the text box)_ 
<!-- Uncomment the brackets and place your screenshots on the table below. -->
<!--
| Before | After |
| ----------- | ------------ |
|   |   |
-->

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
