### PR TITLE
fix: backport mls federation conflict 4.22 (WPB-26348)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModel.kt
@@ -40,6 +40,7 @@ import com.wire.android.ui.home.newconversation.model.Contact
 import com.wire.android.util.debug.FeatureVisibilityFlags
 import com.wire.kalium.logic.data.conversation.Conversation
 import com.wire.kalium.logic.data.conversation.CreateConversationParam
+import com.wire.kalium.logic.data.id.ConversationId
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.isExternal
 import com.wire.kalium.logic.feature.channels.ChannelCreationPermission
@@ -69,6 +70,8 @@ class NewConversationViewModel @Inject constructor(
     private val isWireCellsFeatureEnabled: IsWireCellsEnabledUseCase,
     private val observeIsAppsAllowedForUsage: ObserveIsAppsAllowedForUsageUseCase
 ) : ViewModel() {
+
+    private var failedMLSGroupCreationId: ConversationId? = null
 
     var newGroupNameTextState: TextFieldState = TextFieldState()
     var newGroupState: GroupMetadataState by mutableStateOf(GroupMetadataState())
@@ -122,6 +125,7 @@ class NewConversationViewModel @Inject constructor(
     }
 
     fun resetState() {
+        failedMLSGroupCreationId = null
         newGroupNameTextState.clearText()
         newGroupState = GroupMetadataState()
         loadDefaultProtocol()
@@ -196,7 +200,27 @@ class NewConversationViewModel @Inject constructor(
         }
     }
 
+    fun discardGroupCreation() {
+        if (createGroupState == CreateGroupState.Discarding) return
+        val conversationId = failedMLSGroupCreationId
+        if (conversationId == null) {
+            createGroupState = CreateGroupState.Discarded
+            return
+        }
+
+        createGroupState = CreateGroupState.Discarding
+        viewModelScope.launch {
+            if (createRegularGroup.discardPendingMLSGroupCreation(conversationId)) {
+                failedMLSGroupCreationId = null
+                createGroupState = CreateGroupState.Discarded
+            } else {
+                createGroupState = CreateGroupState.Error.DiscardFailed
+            }
+        }
+    }
+
     fun onCreateGroupErrorDismiss() {
+        if (createGroupState == CreateGroupState.Error.DiscardFailed) return
         createGroupState = CreateGroupState.Default
     }
 
@@ -334,6 +358,7 @@ class NewConversationViewModel @Inject constructor(
     private fun handleNewGroupCreationResult(result: ConversationCreationResult) {
         return when (result) {
             is ConversationCreationResult.Success -> {
+                failedMLSGroupCreationId = null
                 newGroupState = newGroupState.copy(isLoading = false)
                 createGroupState = CreateGroupState.Created(result.conversation.id)
             }
@@ -360,6 +385,7 @@ class NewConversationViewModel @Inject constructor(
             }
 
             is ConversationCreationResult.BackendConflictFailure -> {
+                failedMLSGroupCreationId = result.conversationId
                 groupOptionsState = groupOptionsState.copy(isLoading = false)
                 newGroupState = newGroupState.copy(isLoading = false)
                 createGroupState = CreateGroupState.Error.ConflictedBackends(result.domains)

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupErrorDialog.kt
@@ -47,6 +47,7 @@ fun CreateGroupErrorDialog(
             message = stringResource(R.string.error_no_network_message),
         ) to null
 
+        CreateGroupState.Error.DiscardFailed,
         is CreateGroupState.Error.Unknown -> DialogErrorStrings(
             title = stringResource(R.string.error_unknown_title),
             message = stringResource(R.string.error_unknown_message),
@@ -80,12 +81,16 @@ fun CreateGroupErrorDialog(
         onDismiss = onDismiss,
         buttonsHorizontalAlignment = false,
         optionButton1Properties = WireDialogButtonProperties(
-            onClick = if (error.isConflictedBackends) onEditParticipantsList else onDismiss,
+            onClick = when (error) {
+                is CreateGroupState.Error.ConflictedBackends -> onEditParticipantsList
+                CreateGroupState.Error.DiscardFailed -> onCancel
+                else -> onDismiss
+            },
             text = stringResource(
-                id = if (error.isConflictedBackends) {
-                    R.string.conversation_can_not_be_created_edit_participant_list
-                } else {
-                    R.string.label_ok
+                id = when (error) {
+                    is CreateGroupState.Error.ConflictedBackends -> R.string.conversation_can_not_be_created_edit_participant_list
+                    CreateGroupState.Error.DiscardFailed -> R.string.label_try_again
+                    else -> R.string.label_ok
                 }
             ),
             type = WireDialogButtonType.Primary,

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupState.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/common/CreateGroupState.kt
@@ -22,9 +22,12 @@ import com.wire.kalium.logic.data.id.ConversationId
 sealed interface CreateGroupState {
 
     data object Default : CreateGroupState
+    data object Discarding : CreateGroupState
+    data object Discarded : CreateGroupState
 
     sealed interface Error : CreateGroupState {
         data object Unknown : Error
+        data object DiscardFailed : Error
         data object Forbidden : Error
         data object LackingConnection : Error
         data class ConflictedBackends(val domains: List<String>) : Error

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupOptions/GroupOptionsScreen.kt
@@ -89,8 +89,10 @@ fun GroupOptionScreen(
         navigator.navigate(NavigationCommand(ConversationScreenDestination(conversationId), BackStackMode.REMOVE_CURRENT_NESTED_GRAPH))
 
     LaunchedEffect(newConversationViewModel.createGroupState) {
-        (newConversationViewModel.createGroupState as? CreateGroupState.Created)?.let {
-            navigateToGroup(it.conversationId)
+        when (val state = newConversationViewModel.createGroupState) {
+            is CreateGroupState.Created -> navigateToGroup(state.conversationId)
+            CreateGroupState.Discarded -> navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+            else -> Unit
         }
     }
 
@@ -121,10 +123,7 @@ fun GroupOptionScreen(
             newConversationViewModel.onCreateGroupErrorDismiss()
             navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination, BackStackMode.UPDATE_EXISTED))
         },
-        onDiscardGroupCreationClick = {
-            newConversationViewModel.onCreateGroupErrorDismiss()
-            navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
-        },
+        onDiscardGroupCreationClick = newConversationViewModel::discardGroupCreation,
         onErrorDismissed = newConversationViewModel::onCreateGroupErrorDismiss,
         onEnableWireCellChanged = newConversationViewModel::onEnableWireCellChanged
     )

--- a/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
+++ b/app/src/main/kotlin/com/wire/android/ui/home/newconversation/groupname/NewGroupNameScreen.kt
@@ -52,8 +52,10 @@ fun NewGroupNameScreen(
         newConversationViewModel.observeGroupNameChanges()
     }
     LaunchedEffect(newConversationViewModel.createGroupState) {
-        (newConversationViewModel.createGroupState as? CreateGroupState.Created)?.let {
-            navigateToGroup(it.conversationId)
+        when (val state = newConversationViewModel.createGroupState) {
+            is CreateGroupState.Created -> navigateToGroup(state.conversationId)
+            CreateGroupState.Discarded -> navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
+            else -> Unit
         }
     }
     GroupNameScreen(
@@ -77,10 +79,7 @@ fun NewGroupNameScreen(
                 newConversationViewModel.onCreateGroupErrorDismiss()
                 navigator.navigate(NavigationCommand(NewGroupConversationSearchPeopleScreenDestination, BackStackMode.UPDATE_EXISTED))
             },
-            onCancel = {
-                newConversationViewModel.onCreateGroupErrorDismiss()
-                navigator.navigate(NavigationCommand(HomeScreenDestination, BackStackMode.CLEAR_WHOLE))
-            },
+            onCancel = newConversationViewModel::discardGroupCreation,
         )
     }
 }

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelArrangement.kt
@@ -59,6 +59,7 @@ internal class NewConversationViewModelArrangement {
         // Default empty values
         coEvery { isMLSEnabledUseCase() } returns true
         coEvery { createRegularGroup(any(), any(), any()) } returns ConversationCreationResult.Success(CONVERSATION)
+        coEvery { createRegularGroup.discardPendingMLSGroupCreation(any()) } returns true
         coEvery { observeChannelsCreationPermissionUseCase() } returns flowOf(ChannelCreationPermission.Forbidden)
         coEvery { getDefaultProtocol() } returns SupportedProtocol.PROTEUS
         coEvery { isWireCellsEnabled() } returns false
@@ -190,6 +191,11 @@ internal class NewConversationViewModelArrangement {
 
     fun withConflictingBackendsFailure() = apply {
         createGroupState = CreateGroupState.Error.ConflictedBackends(listOf("bella.wire.link", "foma.wire.link"))
+    }
+
+    fun withBackendConflict(domains: List<String>, conversationId: ConversationId? = null) = apply {
+        coEvery { createRegularGroup(any(), any(), any()) } returns
+            ConversationCreationResult.BackendConflictFailure(domains, conversationId)
     }
 
     fun withGetSelfUser(isTeamMember: Boolean, userType: UserType = UserType.INTERNAL) = apply {

--- a/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
+++ b/app/src/test/kotlin/com/wire/android/ui/home/newconversation/NewConversationViewModelTest.kt
@@ -43,8 +43,10 @@ import com.wire.kalium.logic.data.user.SupportedProtocol
 import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.data.user.type.UserType
 import com.wire.kalium.logic.feature.channels.ChannelCreationPermission
+import io.mockk.coEvery
 import io.mockk.coVerify
 import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -59,6 +61,73 @@ import org.junit.jupiter.api.extension.ExtendWith
 @OptIn(ExperimentalCoroutinesApi::class)
 @ExtendWith(CoroutineTestExtension::class, SnapshotExtension::class)
 class NewConversationViewModelTest {
+
+    @Test
+    fun `given conflict without fallback, when discarding, then closes without cleanup`() = runTest {
+        val domains = listOf("a.example", "b.example")
+        val (arrangement, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withDefaultProtocol(SupportedProtocol.MLS)
+            .withBackendConflict(domains)
+            .arrange()
+
+        viewModel.createGroup()
+        advanceUntilIdle()
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Error.ConflictedBackends(domains)
+        viewModel.discardGroupCreation()
+        advanceUntilIdle()
+
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Discarded
+        coVerify(exactly = 0) { arrangement.createRegularGroup.discardPendingMLSGroupCreation(any()) }
+    }
+
+    @Test
+    fun `given cleanup fallback, when discarding, then waits for successful cleanup`() = runTest {
+        val conversationId = NewConversationViewModelArrangement.CONVERSATION_ID
+        val completion = CompletableDeferred<Boolean>()
+        val (arrangement, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withBackendConflict(listOf("a.example"), conversationId)
+            .arrange()
+        coEvery { arrangement.createRegularGroup.discardPendingMLSGroupCreation(conversationId) } coAnswers { completion.await() }
+        viewModel.createGroup()
+        advanceUntilIdle()
+
+        viewModel.discardGroupCreation()
+        advanceUntilIdle()
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Discarding
+        viewModel.discardGroupCreation()
+        completion.complete(true)
+        advanceUntilIdle()
+
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Discarded
+        coVerify(exactly = 1) { arrangement.createRegularGroup.discardPendingMLSGroupCreation(conversationId) }
+        viewModel.discardGroupCreation()
+        coVerify(exactly = 1) { arrangement.createRegularGroup.discardPendingMLSGroupCreation(conversationId) }
+    }
+
+    @Test
+    fun `given failed discard, when tried again, then retains fallback and closes only on success`() = runTest {
+        val conversationId = NewConversationViewModelArrangement.CONVERSATION_ID
+        val (arrangement, viewModel) = NewConversationViewModelArrangement()
+            .withGetSelfUser(isTeamMember = true)
+            .withBackendConflict(listOf("a.example"), conversationId)
+            .arrange()
+        coEvery { arrangement.createRegularGroup.discardPendingMLSGroupCreation(conversationId) } returnsMany listOf(false, true)
+        viewModel.createGroup()
+        advanceUntilIdle()
+
+        viewModel.discardGroupCreation()
+        advanceUntilIdle()
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Error.DiscardFailed
+        viewModel.onCreateGroupErrorDismiss()
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Error.DiscardFailed
+        viewModel.discardGroupCreation()
+        advanceUntilIdle()
+
+        viewModel.createGroupState shouldBeEqualTo CreateGroupState.Discarded
+        coVerify(exactly = 2) { arrangement.createRegularGroup.discardPendingMLSGroupCreation(conversationId) }
+    }
 
     @Test
     fun `given sync failure, when creating group, then should update options state with connectivity error`() = runTest {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-26348
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-26348
----

# What's new in this PR?

### Issues

Backporting https://github.com/wireapp/wire-android/pull/5239 to 4.22 for next Bund release.