### PR TITLE
fix: meeting members only from self-team self-domain [WPB-28245]

### DIFF
--- a/core/search/src/main/kotlin/com/wire/android/search/SearchUsersAndAppsScreen.kt
+++ b/core/search/src/main/kotlin/com/wire/android/search/SearchUsersAndAppsScreen.kt
@@ -89,7 +89,7 @@ fun SearchUsersAndAppsScreen(
     itemActionType: ItemActionType,
     modifier: Modifier = Modifier,
     conversationId: ConversationId? = null,
-    onlyConnectedContacts: Boolean = false,
+    onlySelfTeamAndDomain: Boolean = false,
     shouldHideBottomActionForSearch: Boolean = false,
     shouldHideBottomActionForServices: Boolean = false,
     isAppsTabVisible: Boolean = false,
@@ -215,7 +215,7 @@ fun SearchUsersAndAppsScreen(
                         SearchPeopleTabItem.PEOPLE -> {
                             SearchAllPeopleOrContactsScreen(
                                 conversationId = conversationId,
-                                onlyConnectedContacts = onlyConnectedContacts,
+                                onlySelfTeamAndDomain = onlySelfTeamAndDomain,
                                 searchQuery = searchBarState.searchQueryTextState.text.toString(),
                                 contactsSelected = selectedContacts,
                                 onOpenUserProfile = onOpenUserProfile,
@@ -274,8 +274,8 @@ private fun SearchAllPeopleOrContactsScreen(
     onOpenUserProfile: (Contact) -> Unit,
     onContactChecked: (Boolean, Contact) -> Unit,
     conversationId: ConversationId? = null,
-    onlyConnectedContacts: Boolean = false,
-    searchUserViewModel: SearchUserViewModel = searchUserViewModel(conversationId, onlyConnectedContacts),
+    onlySelfTeamAndDomain: Boolean = false,
+    searchUserViewModel: SearchUserViewModel = searchUserViewModel(conversationId, onlySelfTeamAndDomain),
     lazyListState: LazyListState = rememberLazyListState(),
     firstContactFocusRequester: FocusRequester? = null,
     nextFocusRequester: FocusRequester? = null,

--- a/core/search/src/main/kotlin/com/wire/android/search/SearchViewModelGraph.kt
+++ b/core/search/src/main/kotlin/com/wire/android/search/SearchViewModelGraph.kt
@@ -33,16 +33,16 @@ object SearchManualViewModelFactoryGroup
 @Composable
 fun searchUserViewModel(
     conversationId: ConversationId? = null,
-    onlyConnectedContacts: Boolean = false,
+    onlySelfTeamAndDomain: Boolean = false,
 ): SearchUserViewModel =
     wireAssistedMetroViewModel<SearchUserViewModel, SearchManualViewModelFactory>(
         instanceKey = listOfNotNull(
             "search_user",
-            if (onlyConnectedContacts) "only_connected_contacts" else null,
+            if (onlySelfTeamAndDomain) "only_self_team_and_domain" else null,
             conversationId?.let { "conversation_id_${it.value}@${it.domain}" },
         ).joinToString("_")
     ) {
-        searchUserViewModel(conversationId, onlyConnectedContacts)
+        searchUserViewModel(conversationId, onlySelfTeamAndDomain)
     }
 
 @Composable

--- a/core/search/src/main/kotlin/com/wire/android/search/users/SearchUserViewModel.kt
+++ b/core/search/src/main/kotlin/com/wire/android/search/users/SearchUserViewModel.kt
@@ -56,7 +56,7 @@ import com.wire.android.search.SearchManualViewModelFactoryGroup
 @WireAssistedViewModelBinding(SearchManualViewModelFactoryGroup::class)
 class SearchUserViewModel @AssistedInject constructor(
     @Assisted private val conversationId: ConversationId?,
-    @Assisted private val onlyConnectedContacts: Boolean,
+    @Assisted private val onlySelfTeamAndDomain: Boolean,
     private val searchUsersByName: SearchUsersByNameUseCase,
     private val searchUsersByHandle: SearchUsersByHandleUseCase,
     private val contactMapper: ContactMapper,
@@ -66,7 +66,7 @@ class SearchUserViewModel @AssistedInject constructor(
 ) : ViewModel() {
     @AssistedFactory
     interface Factory {
-        fun create(conversationId: ConversationId?, onlyConnectedContacts: Boolean): SearchUserViewModel
+        fun create(conversationId: ConversationId?, onlySelfTeamAndDomain: Boolean): SearchUserViewModel
     }
 
     private val searchQueryTextFlow = MutableStateFlow(String.EMPTY)
@@ -152,8 +152,8 @@ class SearchUserViewModel @AssistedInject constructor(
     private suspend fun searchByHandle(searchTerm: String, domain: String?): SearchUserResult =
         searchUsersByHandle(
             searchTerm,
-            excludingConversation = conversationId,
-            skipRemoteSearch = onlyConnectedContacts,
+            excludingMembersOfConversation = conversationId,
+            onlySelfTeamAndDomain = onlySelfTeamAndDomain,
             customDomain = domain
         )
 
@@ -161,7 +161,7 @@ class SearchUserViewModel @AssistedInject constructor(
         searchUsersByName(
             searchTerm,
             excludingMembersOfConversation = conversationId,
-            skipRemoteSearch = onlyConnectedContacts,
+            onlySelfTeamAndDomain = onlySelfTeamAndDomain,
             customDomain = domain
         )
 }

--- a/core/search/src/test/kotlin/com/wire/android/search/SearchAssistedFactorySourceTest.kt
+++ b/core/search/src/test/kotlin/com/wire/android/search/SearchAssistedFactorySourceTest.kt
@@ -28,7 +28,7 @@ internal class SearchAssistedFactorySourceTest {
         assertTrue(searchUserViewModel.contains("@WireAssistedViewModelBinding(SearchManualViewModelFactoryGroup::class)"))
         assertTrue(
             searchUserViewModel.contains(
-                "fun create(conversationId: ConversationId?, onlyConnectedContacts: Boolean): SearchUserViewModel"
+                "fun create(conversationId: ConversationId?, onlySelfTeamAndDomain: Boolean): SearchUserViewModel"
             )
         )
         assertFalse(File("src/main/kotlin/com/wire/android/search/SearchMetroViewModelBindings.kt").exists())

--- a/core/search/src/test/kotlin/com/wire/android/search/users/SearchUserViewModelTest.kt
+++ b/core/search/src/test/kotlin/com/wire/android/search/users/SearchUserViewModelTest.kt
@@ -286,7 +286,7 @@ class SearchUserViewModelTest {
         coVerify(exactly = 1) {
             arrangement.searchUsersByHandleUseCase.invoke(
                 query,
-                excludingConversation = null,
+                excludingMembersOfConversation = null,
                 customDomain = "domain"
             )
         }
@@ -329,10 +329,10 @@ class SearchUserViewModelTest {
     }
 
     @Test
-    fun `given only connected contacts is false, when searching by handle, then do not exclude remote`() = runTest {
+    fun `given only self team and domain is false, when searching by handle, then search for all users`() = runTest {
         val query = "handle"
         val (arrangement, viewModel) = Arrangement()
-            .withOnlyConnectedContacts(false)
+            .withOnlySelfTeamAndDomain(false)
             .withSearchByHandleResult(SearchUserResult(connected = listOf(), notConnected = listOf()))
             .withFederatedSearchParserResult(FederatedSearchParser.Result(searchTerm = query, domain = "domain"))
             .withIsValidHandleResult(ValidateUserHandleResult.Valid(""))
@@ -342,18 +342,18 @@ class SearchUserViewModelTest {
         coVerify(exactly = 1) {
             arrangement.searchUsersByHandleUseCase.invoke(
                 searchHandle = query,
-                excludingConversation = null,
-                skipRemoteSearch = false,
+                excludingMembersOfConversation = null,
+                onlySelfTeamAndDomain = false,
                 customDomain = "domain"
             )
         }
     }
 
     @Test
-    fun `given only connected contacts is true, when searching by handle, then exclude remote`() = runTest {
+    fun `given only self team and domain is true, when searching by handle, then only search for self team and domain users`() = runTest {
         val query = "handle"
         val (arrangement, viewModel) = Arrangement()
-            .withOnlyConnectedContacts(true)
+            .withOnlySelfTeamAndDomain(true)
             .withSearchByHandleResult(SearchUserResult(connected = listOf(), notConnected = listOf()))
             .withFederatedSearchParserResult(FederatedSearchParser.Result(searchTerm = query, domain = "domain"))
             .withIsValidHandleResult(ValidateUserHandleResult.Valid(""))
@@ -363,18 +363,18 @@ class SearchUserViewModelTest {
         coVerify(exactly = 1) {
             arrangement.searchUsersByHandleUseCase.invoke(
                 searchHandle = query,
-                excludingConversation = null,
-                skipRemoteSearch = true,
+                excludingMembersOfConversation = null,
+                onlySelfTeamAndDomain = true,
                 customDomain = "domain"
             )
         }
     }
 
     @Test
-    fun `given only connected contacts is false, when searching by name, then do not exclude remote`() = runTest {
+    fun `given only self team and domain is false, when searching by name, then search for all users`() = runTest {
         val query = "Name"
         val (arrangement, viewModel) = Arrangement()
-            .withOnlyConnectedContacts(false)
+            .withOnlySelfTeamAndDomain(false)
             .withSearchResult(SearchUserResult(connected = listOf(), notConnected = listOf()))
             .withFederatedSearchParserResult(FederatedSearchParser.Result(searchTerm = query, domain = "domain"))
             .withIsValidHandleResult(ValidateUserHandleResult.Invalid.InvalidCharacters("ame", listOf('N')))
@@ -385,17 +385,17 @@ class SearchUserViewModelTest {
             arrangement.searchUsersByNameUseCase.invoke(
                 searchQuery = query,
                 excludingMembersOfConversation = null,
-                skipRemoteSearch = false,
+                onlySelfTeamAndDomain = false,
                 customDomain = "domain"
             )
         }
     }
 
     @Test
-    fun `given only connected contacts is true, when searching by name, then exclude remote`() = runTest {
+    fun `given only self team and domain is true, when searching by name, then only search for self team and domain users`() = runTest {
         val query = "Name"
         val (arrangement, viewModel) = Arrangement()
-            .withOnlyConnectedContacts(true)
+            .withOnlySelfTeamAndDomain(true)
             .withSearchResult(SearchUserResult(connected = listOf(), notConnected = listOf()))
             .withFederatedSearchParserResult(FederatedSearchParser.Result(searchTerm = query, domain = "domain"))
             .withIsValidHandleResult(ValidateUserHandleResult.Invalid.InvalidCharacters("ame", listOf('N')))
@@ -406,7 +406,7 @@ class SearchUserViewModelTest {
             arrangement.searchUsersByNameUseCase.invoke(
                 searchQuery = query,
                 excludingMembersOfConversation = null,
-                skipRemoteSearch = true,
+                onlySelfTeamAndDomain = true,
                 customDomain = "domain"
             )
         }
@@ -434,7 +434,7 @@ class SearchUserViewModelTest {
 
         private var conversationId: ConversationId? = null
 
-        private var onlyConnectedContacts: Boolean = false
+        private var onlySelfTeamAndDomain: Boolean = false
 
         init {
             MockKAnnotations.init(this, relaxUnitFun = true)
@@ -479,8 +479,8 @@ class SearchUserViewModelTest {
             this.conversationId = conversationId
         }
 
-        fun withOnlyConnectedContacts(onlyConnectedContacts: Boolean) = apply {
-            this.onlyConnectedContacts = onlyConnectedContacts
+        fun withOnlySelfTeamAndDomain(onlySelfTeamAndDomain: Boolean) = apply {
+            this.onlySelfTeamAndDomain = onlySelfTeamAndDomain
         }
 
         fun withSearchResult(result: SearchUserResult) = apply {
@@ -508,7 +508,7 @@ class SearchUserViewModelTest {
         fun arrange() = apply {
             searchUserViewModel = SearchUserViewModel(
                 conversationId = conversationId,
-                onlyConnectedContacts = onlyConnectedContacts,
+                onlySelfTeamAndDomain = onlySelfTeamAndDomain,
                 searchUsersByName = searchUsersByNameUseCase,
                 searchUsersByHandle = searchUsersByHandleUseCase,
                 contactMapper = contactMapper,

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingParticipantsScreen.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/create/NewMeetingParticipantsScreen.kt
@@ -48,7 +48,7 @@ internal fun NewMeetingParticipantsRouteContent(
     onOpenUserProfile: (UserId) -> Unit,
 ) {
     SearchUsersAndAppsScreen(
-        onlyConnectedContacts = true,
+        onlySelfTeamAndDomain = true,
         searchTitle = stringResource(R.string.new_meeting_participants_title),
         selectedContacts = newMeetingViewModel.state.selectedContacts,
         onContactChecked = newMeetingViewModel::updateSelectedContact,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28245
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

Currently, Wire Meetings should allow adding only people from same team and same domain to the meeting, instead of all contacts. In this PR, the flag allowing to filter only locally known contacts is replaced with a flag allowing to return only people from the same team and domain.

### Dependencies (Optional)

Needs releases with:

- https://github.com/wireapp/kalium/pull/4452

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Create a meeting and try to add some participants - there should be no guests nor federated, only team members.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
