### PR TITLE
feat: refresh meetings list when day, system time or timezone changes [WPB-28223]

### DIFF
--- a/features/meetings/build.gradle.kts
+++ b/features/meetings/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     testImplementation(libs.mockk.core)
     testImplementation(libs.turbine)
     testImplementation(libs.androidx.paging.testing)
+    testImplementation(libs.androidx.lifecycle.viewModelTesting)
     testRuntimeOnly(libs.junit5.engine)
     androidTestImplementation(libs.androidx.test.extJunit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
@@ -35,25 +35,25 @@ import com.wire.android.feature.meetings.ui.MeetingsTabItem
 import com.wire.android.feature.meetings.ui.MeetingsManualViewModelFactoryGroup
 import com.wire.android.feature.meetings.ui.mock.MeetingMocksProvider
 import com.wire.android.feature.meetings.ui.usecase.GetPaginatedFlowOfMeetingsUseCase
+import com.wire.android.feature.meetings.ui.util.SystemTimeObserver
 import com.wire.android.util.CurrentTimeProvider
 import com.wire.android.util.dispatchers.DispatcherProvider
+import com.wire.android.util.time.CurrentTimeZoneProvider
 import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.isActive
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atTime
@@ -77,6 +77,8 @@ class MeetingListViewModelPreview(type: MeetingsTabItem) : MeetingListViewModel 
 class MeetingListViewModelImpl @AssistedInject constructor(
     @Assisted val type: MeetingsTabItem,
     override val currentTimeProvider: CurrentTimeProvider,
+    currentTimeZoneProvider: CurrentTimeZoneProvider,
+    systemTimeObserver: SystemTimeObserver,
     getMeetingsPaginated: GetPaginatedFlowOfMeetingsUseCase,
     observeActiveCalls: ObserveActiveCallsUseCase,
     dispatcher: DispatcherProvider,
@@ -87,16 +89,18 @@ class MeetingListViewModelImpl @AssistedInject constructor(
         fun create(type: MeetingsTabItem): MeetingListViewModelImpl
     }
 
-    private val alignedTickerFlow = flow {
-        while (currentCoroutineContext().isActive) {
-            val currentTime = currentTimeProvider()
-            emit(currentTime)
-            delay(currentTime.millisToNextFullMinute())
-        }
-    }
+    private val currentTimeFlow = systemTimeObserver()
+        .map { currentTimeProvider() }
+        .onStart { emit(currentTimeProvider()) }
+        .shareIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
 
-    private val pagingDataFlow = flowOf(type)
-        .flatMapLatest { type ->
+    private val pagingDataFlow = currentTimeFlow
+        .map { currentTime ->
+            val currentTimeZone = currentTimeZoneProvider()
+            currentTime.toLocalDateTime(currentTimeZone).date to currentTimeZone // refresh whole list when local date or time zone changes
+        }
+        .distinctUntilChanged()
+        .flatMapLatest {
             getMeetingsPaginated(type = type)
         }
         .flowOn(dispatcher.io())
@@ -104,8 +108,8 @@ class MeetingListViewModelImpl @AssistedInject constructor(
 
     override val meetings: Flow<PagingData<MeetingListItem>> = combine(
         pagingDataFlow,
-        observeActiveCalls(),
-        alignedTickerFlow
+        observeActiveCalls(), // update item statuses when active calls change
+        currentTimeFlow // update item statuses on every minute tick or when system date/time/timezone changes
     ) { pagingData, activeCalls, currentTime ->
         pagingData
             .map { item ->
@@ -152,9 +156,6 @@ private fun generateHeader(
         else -> null
     }
 }
-
-@Suppress("MagicNumber")
-private fun Instant.millisToNextFullMinute(): Long = 60_000L - (this.toEpochMilliseconds() % 60_000L)
 
 /** Extension function to create a header time at the start of the hour of the meeting's start time. */
 private fun LocalDateTime.headerDayHourTime() = date.atTime(hour, 0, 0).toInstant(TimeZone.currentSystemDefault())

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
@@ -47,11 +47,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.datetime.LocalDateTime
@@ -89,17 +89,22 @@ class MeetingListViewModelImpl @AssistedInject constructor(
         fun create(type: MeetingsTabItem): MeetingListViewModelImpl
     }
 
+    // The paging cache observes this key without keeping the system time observer subscribed.
+    private val pagingDateAndTimeZone = MutableStateFlow(
+        currentTimeZoneProvider().let { timeZone ->
+            currentTimeProvider().toLocalDateTime(timeZone).date to timeZone
+        }
+    )
+
     private val currentTimeFlow = systemTimeObserver()
         .map { currentTimeProvider() }
         .onStart { emit(currentTimeProvider()) }
-        .shareIn(scope = viewModelScope, started = SharingStarted.WhileSubscribed(), replay = 1)
-
-    private val pagingDataFlow = currentTimeFlow
-        .map { currentTime ->
+        .onEach { currentTime ->
             val currentTimeZone = currentTimeZoneProvider()
-            currentTime.toLocalDateTime(currentTimeZone).date to currentTimeZone // refresh whole list when local date or time zone changes
+            pagingDateAndTimeZone.value = currentTime.toLocalDateTime(currentTimeZone).date to currentTimeZone
         }
-        .distinctUntilChanged()
+
+    private val pagingDataFlow = pagingDateAndTimeZone  // refresh whole list when local date or time zone changes
         .flatMapLatest {
             getMeetingsPaginated(type = type)
         }

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/list/MeetingListViewModel.kt
@@ -104,7 +104,7 @@ class MeetingListViewModelImpl @AssistedInject constructor(
             pagingDateAndTimeZone.value = currentTime.toLocalDateTime(currentTimeZone).date to currentTimeZone
         }
 
-    private val pagingDataFlow = pagingDateAndTimeZone  // refresh whole list when local date or time zone changes
+    private val pagingDataFlow = pagingDateAndTimeZone // refresh whole list when local date or time zone changes
         .flatMapLatest {
             getMeetingsPaginated(type = type)
         }

--- a/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/util/SystemTimeObserver.kt
+++ b/features/meetings/src/main/java/com/wire/android/feature/meetings/ui/util/SystemTimeObserver.kt
@@ -1,0 +1,53 @@
+/*
+ * Wire
+ * Copyright (C) 2025 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.meetings.ui.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import com.wire.android.di.ApplicationContext
+import dev.zacsweers.metro.Inject
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+class SystemTimeObserver @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    /** Emits on system's minute ticks, and when the system date, clock, time zone, or time zone offset changes. */
+    operator fun invoke(): Flow<Unit> = callbackFlow {
+        val actions = listOf(
+            Intent.ACTION_TIME_TICK,
+            Intent.ACTION_DATE_CHANGED,
+            Intent.ACTION_TIME_CHANGED,
+            Intent.ACTION_TIMEZONE_CHANGED,
+            Intent.ACTION_TIMEZONE_OFFSET_CHANGED,
+        )
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (intent?.action in actions) trySend(Unit)
+            }
+        }
+        val intentFilter = IntentFilter().apply {
+            actions.forEach { addAction(it) }
+        }
+        context.registerReceiver(receiver, intentFilter)
+        awaitClose { context.unregisterReceiver(receiver) }
+    }
+}

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
@@ -294,6 +294,64 @@ class MeetingListViewModelTest {
         }
     }
 
+    @Test
+    fun givenCachedPaging_whenUiUnsubscribes_thenTimeObservationStopsAndCacheIsReusedOnReturn() = runTest(dispatcher) {
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
+            .withCurrentTimeProvider { Instant.parse("2026-01-01T12:00:00Z") }
+            .withGetMeetingsPaginated(emptyList())
+            .arrange()
+
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                awaitItem()
+                runCurrent()
+                assertEquals(1, arrangement.minuteTicks.subscriptionCount.value)
+                assertEquals(1, arrangement.systemTimeChanges.subscriptionCount.value)
+                cancelAndIgnoreRemainingEvents()
+            }
+            runCurrent()
+            assertEquals(0, arrangement.minuteTicks.subscriptionCount.value)
+            assertEquals(0, arrangement.systemTimeChanges.subscriptionCount.value)
+
+            scenario.viewModel.meetings.test {
+                awaitItem()
+                runCurrent()
+                assertEquals(1, arrangement.minuteTicks.subscriptionCount.value)
+                assertEquals(1, arrangement.systemTimeChanges.subscriptionCount.value)
+                coVerify(exactly = 1) { arrangement.getMeetingsPaginated(arrangement.type) }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun givenUiUnsubscribed_whenMidnightPasses_thenPagingRefreshesOnlyWhenUiReturns() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T23:59:30Z")
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
+            .withCurrentTimeProvider { currentTime + testScheduler.currentTime.milliseconds }
+            .withGetMeetingsPaginated(emptyList())
+            .arrange()
+
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                awaitItem()
+                cancelAndIgnoreRemainingEvents()
+            }
+            runCurrent()
+            advanceTimeBy(30_000)
+            arrangement.minuteTicks.emit(Unit)
+            runCurrent()
+            coVerify(exactly = 1) { arrangement.getMeetingsPaginated(arrangement.type) }
+
+            scenario.viewModel.meetings.test {
+                awaitItem()
+                runCurrent()
+                coVerify(exactly = 2) { arrangement.getMeetingsPaginated(arrangement.type) }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
     private fun List<MeetingListItem>.meetingItem() = meetingItems().single()
     private fun List<MeetingListItem>.meetingItems() = filterIsInstance<MeetingItem>()
     private fun MeetingItem.ongoingStatus() = status as MeetingItem.Status.Ongoing

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/list/MeetingListViewModelTest.kt
@@ -15,8 +15,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see http://www.gnu.org/licenses/.
  */
+@file:Suppress("UnusedFlow")
+
 package com.wire.android.feature.meetings.ui.list
 
+import androidx.lifecycle.viewmodel.testing.viewModelScenario
 import androidx.paging.PagingData
 import androidx.paging.testing.asSnapshot
 import app.cash.turbine.test
@@ -25,7 +28,9 @@ import com.wire.android.feature.meetings.model.MeetingItem
 import com.wire.android.feature.meetings.model.MeetingListItem
 import com.wire.android.feature.meetings.ui.MeetingsTabItem
 import com.wire.android.feature.meetings.ui.usecase.GetPaginatedFlowOfMeetingsUseCase
+import com.wire.android.feature.meetings.ui.util.SystemTimeObserver
 import com.wire.android.util.CurrentTimeProvider
+import com.wire.android.util.time.CurrentTimeZoneProvider
 import com.wire.kalium.logic.data.call.Call
 import com.wire.kalium.logic.data.call.CallStatus
 import com.wire.kalium.logic.data.conversation.Conversation
@@ -38,12 +43,15 @@ import com.wire.kalium.logic.data.user.UserId
 import com.wire.kalium.logic.feature.call.usecase.ObserveActiveCallsUseCase
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -52,6 +60,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -74,48 +83,74 @@ class MeetingListViewModelTest {
     }
 
     @Test
-    fun givenCurrentTimeBetweenFullMinutes_whenMeetingsAreCollected_thenNextEmissionIsAlignedToNextFullMinute() = runTest(dispatcher) {
-        val currentTime = Instant.parse("2026-01-01T12:00:30.500Z")
-        val meetingStartTime = Instant.parse("2026-01-01T12:01:00Z")
-        val (_, viewModel) = Arrangement(dispatcher)
-            .withCurrentTimeProvider { currentTime + testScheduler.currentTime.milliseconds }
-            .withGetMeetingsPaginated(meetings = listOf(meeting(startTime = meetingStartTime)))
+    fun givenNoTimeBroadcast_whenMeetingsAreCollected_thenPagingLoadsImmediately() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T12:00:30Z")
+        val initialMeeting = meeting(startTime = currentTime + 30.minutes)
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
+            .withCurrentTimeProvider { currentTime }
+            .withGetMeetingsPaginated(listOf(initialMeeting))
             .arrange()
 
-        viewModel.meetings.test {
-            awaitItem()
-
-            advanceTimeBy(29_499)
-            expectNoEvents()
-
-            advanceTimeBy(1)
-            runCurrent()
-            awaitItem()
-
-            cancelAndConsumeRemainingEvents()
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                val pagingData = awaitItem()
+                assertEquals(0L, testScheduler.currentTime)
+                assertEquals(initialMeeting.meeting.meetingId, pagingData.items().meetingItem().meetingId)
+                coVerify(exactly = 1) { arrangement.getMeetingsPaginated(arrangement.type) }
+                cancelAndIgnoreRemainingEvents()
+            }
         }
     }
 
     @Test
-    fun givenCurrentTimeBetweenFullMinutes_whenMeetingsAreCollected_thenNextEmissionUpdatesTheStatusesOfMeetings() = runTest(dispatcher) {
+    fun givenMeetingsAreCollected_whenMinuteTickArrives_thenCurrentTimeIsUpdated() = runTest(dispatcher) {
         val currentTime = Instant.parse("2026-01-01T12:00:30.500Z")
         val meetingStartTime = Instant.parse("2026-01-01T12:01:00Z")
-        val (_, viewModel) = Arrangement(dispatcher)
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
             .withCurrentTimeProvider { currentTime + testScheduler.currentTime.milliseconds }
             .withGetMeetingsPaginated(meetings = listOf(meeting(startTime = meetingStartTime)))
             .arrange()
 
-        viewModel.meetings.test {
-            val first = awaitItem()
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                awaitItem()
 
-            advanceTimeBy(29_500)
-            runCurrent()
-            val second = expectMostRecentItem()
+                advanceTimeBy(29_499)
+                expectNoEvents()
 
-            assertEquals(MeetingItem.Status.Scheduled::class, first.items().meetingItem().status::class)
-            assertEquals(MeetingItem.Status.Ongoing::class, second.items().meetingItem().status::class)
+                advanceTimeBy(1)
+                arrangement.minuteTicks.emit(Unit)
+                runCurrent()
+                awaitItem()
 
-            cancelAndConsumeRemainingEvents()
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun givenScheduledMeeting_whenMinuteTickArrives_thenMeetingBecomesOngoing() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T12:00:30.500Z")
+        val meetingStartTime = Instant.parse("2026-01-01T12:01:00Z")
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
+            .withCurrentTimeProvider { currentTime + testScheduler.currentTime.milliseconds }
+            .withGetMeetingsPaginated(meetings = listOf(meeting(startTime = meetingStartTime)))
+            .arrange()
+
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                val first = awaitItem()
+
+                advanceTimeBy(29_500)
+                arrangement.minuteTicks.emit(Unit)
+                runCurrent()
+                val second = expectMostRecentItem()
+
+                assertEquals(MeetingItem.Status.Scheduled::class, first.items().meetingItem().status::class)
+                assertEquals(MeetingItem.Status.Ongoing::class, second.items().meetingItem().status::class)
+
+                cancelAndConsumeRemainingEvents()
+            }
         }
     }
 
@@ -136,25 +171,27 @@ class MeetingListViewModelTest {
             conversationId = meetingWithActiveCall.meeting.conversationId,
             establishedTime = Instant.parse("2026-01-01T11:55:00Z")
         )
-        val (_, viewModel) = Arrangement(dispatcher)
+        val (_, viewModelScenario) = Arrangement(dispatcher)
             .withCurrentTimeProvider { currentTime }
             .withGetMeetingsPaginated(meetings = listOf(meetingWithActiveCall, meetingWithoutActiveCall))
             .withObserveActiveCalls(listOf(activeCall))
             .arrange()
 
-        val meetingItems = viewModel.meetings.first().items().meetingItems()
+        viewModelScenario.use { scenario ->
+            val meetingItems = scenario.viewModel.meetings.first().items().meetingItems()
 
-        assertEquals(
-            MeetingItem.OngoingCallStatus(
-                currentCallEstablishedTime = Instant.parse("2026-01-01T11:55:00Z"),
-                isSelfUserAttending = true
-            ),
-            meetingItems.single { it.meetingId == meetingWithActiveCall.meeting.meetingId }.ongoingStatus().ongoingCallStatus
-        )
-        assertEquals(
-            null,
-            meetingItems.single { it.meetingId == meetingWithoutActiveCall.meeting.meetingId }.ongoingStatus().ongoingCallStatus
-        )
+            assertEquals(
+                MeetingItem.OngoingCallStatus(
+                    currentCallEstablishedTime = Instant.parse("2026-01-01T11:55:00Z"),
+                    isSelfUserAttending = true
+                ),
+                meetingItems.single { it.meetingId == meetingWithActiveCall.meeting.meetingId }.ongoingStatus().ongoingCallStatus
+            )
+            assertEquals(
+                null,
+                meetingItems.single { it.meetingId == meetingWithoutActiveCall.meeting.meetingId }.ongoingStatus().ongoingCallStatus
+            )
+        }
     }
 
     @Test
@@ -164,18 +201,97 @@ class MeetingListViewModelTest {
             meeting(meetingId = MeetingId("first-meeting", "domain"), startTime = currentTime - 10.minutes),
             meeting(meetingId = MeetingId("second-meeting", "domain"), startTime = currentTime - 5.minutes)
         )
-        val (_, viewModel) = Arrangement(dispatcher)
+        val (_, viewModelScenario) = Arrangement(dispatcher)
             .withCurrentTimeProvider { currentTime }
             .withGetMeetingsPaginated(meetings = meetings)
             .withObserveActiveCalls(emptyList())
             .arrange()
 
-        val meetingItems = viewModel.meetings.first().items().meetingItems()
+        viewModelScenario.use { scenario ->
+            val meetingItems = scenario.viewModel.meetings.first().items().meetingItems()
 
-        assertEquals(
-            listOf(null, null),
-            meetingItems.map { it.ongoingStatus().ongoingCallStatus }
-        )
+            assertEquals(
+                listOf(null, null),
+                meetingItems.map { it.ongoingStatus().ongoingCallStatus }
+            )
+        }
+    }
+
+    @Test
+    fun givenSameDayAndTimeZone_whenMinuteChanges_thenPagingIsNotReloaded() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T12:00:30Z")
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
+            .withCurrentTimeProvider { currentTime + testScheduler.currentTime.milliseconds }
+            .withGetMeetingsPaginated(emptyList())
+            .arrange()
+
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                awaitItem()
+                advanceTimeBy(90_000)
+                arrangement.minuteTicks.emit(Unit)
+                runCurrent()
+                coVerify(exactly = 1) { arrangement.getMeetingsPaginated(arrangement.type) }
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun givenLocalMidnight_whenDayChanges_thenPagingIsReloadedAndPreviousDayIsRemoved() = runTest(dispatcher) {
+        // Midnight in Berlin occurs before the UTC date changes.
+        val currentTime = Instant.parse("2026-01-01T22:59:30Z")
+        val previousDayMeeting = meeting(startTime = currentTime - 30.minutes)
+        val nextDayMeeting = meeting(meetingId = MeetingId("next-day", "domain"), startTime = currentTime + 30.minutes)
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
+            .withTimeZoneProvider { TimeZone.of("Europe/Berlin") }
+            .withCurrentTimeProvider { currentTime + testScheduler.currentTime.milliseconds }
+            .withGetMeetingsPaginated(listOf(previousDayMeeting, nextDayMeeting))
+            .arrange()
+
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                assertEquals(2, awaitItem().items().meetingItems().size)
+                arrangement.withGetMeetingsPaginated(listOf(nextDayMeeting))
+
+                advanceTimeBy(30_000)
+                arrangement.minuteTicks.emit(Unit)
+                runCurrent()
+
+                assertEquals(nextDayMeeting.meeting.meetingId, expectMostRecentItem().items().meetingItem().meetingId)
+                coVerify(exactly = 2) { arrangement.getMeetingsPaginated(arrangement.type) }
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+    }
+
+    @Test
+    fun givenSameLocalDate_whenTimeZoneChanges_thenPagingIsReloadedImmediately() = runTest(dispatcher) {
+        val currentTime = Instant.parse("2026-01-01T12:00:30Z")
+        var timeZone: TimeZone = TimeZone.UTC
+        val (arrangement, viewModelScenario) = Arrangement(dispatcher)
+            .withTimeZoneProvider { timeZone }
+            .withCurrentTimeProvider { currentTime + testScheduler.currentTime.milliseconds }
+            .withGetMeetingsPaginated(emptyList())
+            .arrange()
+
+        viewModelScenario.use { scenario ->
+            scenario.viewModel.meetings.test {
+                awaitItem()
+                timeZone = TimeZone.of("Europe/Berlin")
+                arrangement.systemTimeChanges.emit(Unit)
+                runCurrent()
+                coVerify(exactly = 2) { arrangement.getMeetingsPaginated(arrangement.type) }
+                assertEquals(0L, testScheduler.currentTime)
+
+                arrangement.systemTimeChanges.emit(Unit)
+                advanceTimeBy(60_000)
+                arrangement.minuteTicks.emit(Unit)
+                runCurrent()
+                coVerify(exactly = 2) { arrangement.getMeetingsPaginated(arrangement.type) }
+                cancelAndConsumeRemainingEvents()
+            }
+        }
     }
 
     private fun List<MeetingListItem>.meetingItem() = meetingItems().single()
@@ -222,8 +338,16 @@ class MeetingListViewModelTest {
         establishedTime = establishedTime,
     )
 
-    private class Arrangement(private val dispatcher: TestDispatcher) {
+    private class Arrangement(
+        private val dispatcher: TestDispatcher,
+    ) {
         val type = MeetingsTabItem.NEXT
+        val systemTimeChanges = MutableSharedFlow<Unit>()
+        val minuteTicks = MutableSharedFlow<Unit>()
+
+        @MockK
+        lateinit var systemTimeObserver: SystemTimeObserver
+        var currentTimeZoneProvider = CurrentTimeZoneProvider { TimeZone.UTC }
         var currentTimeProvider = CurrentTimeProvider {
             Instant.fromEpochMilliseconds(dispatcher.scheduler.currentTime)
         }
@@ -237,6 +361,10 @@ class MeetingListViewModelTest {
         init {
             MockKAnnotations.init(this)
             every { observeActiveCalls() } returns flowOf(emptyList())
+            every { systemTimeObserver() } returns merge(systemTimeChanges, minuteTicks)
+        }
+        fun withTimeZoneProvider(timeZone: () -> TimeZone) = apply {
+            currentTimeZoneProvider = CurrentTimeZoneProvider(timeZone)
         }
         fun withCurrentTimeProvider(currentTime: () -> Instant) = apply {
             currentTimeProvider = CurrentTimeProvider(currentTime)
@@ -249,12 +377,16 @@ class MeetingListViewModelTest {
         fun withObserveActiveCalls(activeCalls: List<Call>) = apply {
             every { observeActiveCalls() } returns flowOf(activeCalls)
         }
-        fun arrange() = this to MeetingListViewModelImpl(
-            type = type,
-            dispatcher = TestDispatcherProvider(dispatcher),
-            currentTimeProvider = currentTimeProvider,
-            getMeetingsPaginated = getMeetingsPaginated,
-            observeActiveCalls = observeActiveCalls,
-        )
+        fun arrange() = this to viewModelScenario {
+            MeetingListViewModelImpl(
+                type = type,
+                dispatcher = TestDispatcherProvider(dispatcher),
+                currentTimeProvider = currentTimeProvider,
+                currentTimeZoneProvider = currentTimeZoneProvider,
+                systemTimeObserver = systemTimeObserver,
+                getMeetingsPaginated = getMeetingsPaginated,
+                observeActiveCalls = observeActiveCalls,
+            )
+        }
     }
 }

--- a/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/util/SystemTimeObserverTest.kt
+++ b/features/meetings/src/test/kotlin/com/wire/android/feature/meetings/ui/util/SystemTimeObserverTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.feature.meetings.ui.util
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import app.cash.turbine.test
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SystemTimeObserverTest {
+
+    @Test
+    fun givenSystemTimeObserver_whenCollected_thenRegistersWithoutEmittingAndUnregistersOnCancellation() = runTest {
+        val arrangement = Arrangement()
+        arrangement.observer().test {
+            runCurrent()
+            verify(exactly = 1) { arrangement.context.registerReceiver(any(), any()) }
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(exactly = 1) { arrangement.context.unregisterReceiver(arrangement.receiver.captured) }
+    }
+
+    @Test
+    fun givenSystemTimeObserver_whenSupportedBroadcastsArrive_thenEmitsImmediately() = runTest {
+        val arrangement = Arrangement()
+        arrangement.observer().test {
+            runCurrent()
+            listOf(
+                Intent.ACTION_TIME_TICK,
+                Intent.ACTION_DATE_CHANGED,
+                Intent.ACTION_TIME_CHANGED,
+                Intent.ACTION_TIMEZONE_CHANGED,
+                Intent.ACTION_TIMEZONE_OFFSET_CHANGED,
+            ).forEach { action ->
+                arrangement.broadcast(action)
+                assertEquals(Unit, awaitItem())
+            }
+            assertEquals(0L, testScheduler.currentTime)
+        }
+    }
+
+    @Test
+    fun givenSystemTimeObserver_whenUnrelatedOrNullBroadcastArrives_thenDoesNotEmit() = runTest {
+        val arrangement = Arrangement()
+        arrangement.observer().test {
+            runCurrent()
+            arrangement.broadcast(Intent.ACTION_SCREEN_ON)
+            arrangement.receiver.captured.onReceive(arrangement.context, null)
+            runCurrent()
+            expectNoEvents()
+        }
+    }
+
+    private class Arrangement {
+        val context = mockk<Context>(relaxed = true)
+        val receiver = slot<BroadcastReceiver>()
+        val observer = SystemTimeObserver(context)
+
+        init {
+            every { context.registerReceiver(capture(receiver), any()) } returns null
+        }
+
+        fun broadcast(action: String) {
+            val intent = mockk<Intent>()
+            every { intent.action } returns action
+            receiver.captured.onReceive(context, intent)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -200,6 +200,7 @@ androidx-lifecycle-liveData = { module = "androidx.lifecycle:lifecycle-livedata-
 androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtime = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewModel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewModelTesting = { module = "androidx.lifecycle:lifecycle-viewmodel-testing", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewModelCompose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewModelSavedState = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-viewModelNavigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "androidx-lifecycle" }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28223
<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
    - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
    - [x] contains a reference JIRA issue number like `SQPIT-764`
    - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
    - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Past meetings stay on the list after the local end of the day or when user changes system date, time or timezone.

### Solutions

Update the list after the local end of the day or when system date, time or timezone.
Use BroadcastReceiver to get informed when system date, time or timezone changes, also use system's minute ticker instead of having custom one that uses delays.
Add `viewModelTesting` and use `viewModelScenario` in tests to clean-up and cancel `viewModelScope` safely after each test.

### Testing

#### Test Coverage (Optional)

- [x] I have added automated test to this contribution

#### How to Test

Open meetings list, have some meetings today and change the day in the device settings to tomorrow or wait until the end of the day.

----
#### PR Post Submission Checklist for internal contributors (Optional)

- [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

- [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
