### PR TITLE
fix(navigation): prevent navigation crashes on Android below 15 [WPB-28606] 🍒 

### DIFF
--- a/core/navigation-kmp/build.gradle.kts
+++ b/core/navigation-kmp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 kotlin {
     android {
         namespace = "com.wire.navigation"
+        withHostTest {}
     }
 
     @OptIn(org.jetbrains.kotlin.gradle.ExperimentalWasmDsl::class)

--- a/core/navigation-kmp/src/commonMain/kotlin/com/wire/navigation/WireBackStackReducer.kt
+++ b/core/navigation-kmp/src/commonMain/kotlin/com/wire/navigation/WireBackStackReducer.kt
@@ -57,7 +57,7 @@ fun reduceBackStack(
 private fun MutableList<WireRoute>.removeCurrentFlow() {
     val currentFlowId = lastOrNull()?.flowId ?: return
     while (lastOrNull()?.flowId == currentFlowId) {
-        removeLast()
+        removeAt(lastIndex)
     }
 }
 
@@ -71,7 +71,7 @@ private fun MutableList<WireRoute>.removeFromFirst(routeId: String) {
 private fun MutableList<WireRoute>.removeConsecutiveRoutesFromTop() {
     val currentRouteId = lastOrNull()?.routeId ?: return
     while (lastOrNull()?.routeId == currentRouteId) {
-        removeLast()
+        removeAt(lastIndex)
     }
 }
 

--- a/core/navigation-kmp/src/commonMain/kotlin/com/wire/navigation/WireNavigationController.kt
+++ b/core/navigation-kmp/src/commonMain/kotlin/com/wire/navigation/WireNavigationController.kt
@@ -69,7 +69,8 @@ class WireNavigationController(
     fun goBack(allowEmpty: Boolean = false): Boolean {
         if (backStack.isEmpty() || (!allowEmpty && backStack.size == 1)) return false
         val previous = routes
-        backStack.removeLast()
+        // List.removeLast() is only available on Android API 35 and newer.
+        backStack.removeAt(backStack.lastIndex)
         onBackStackChanged(previous, routes, WireBackStackChange.BACK)
         return true
     }

--- a/core/navigation-kmp/src/commonTest/kotlin/com/wire/navigation/WireNavigationControllerTest.kt
+++ b/core/navigation-kmp/src/commonTest/kotlin/com/wire/navigation/WireNavigationControllerTest.kt
@@ -50,6 +50,37 @@ class WireNavigationControllerTest {
     }
 
     @Test
+    fun givenConversationStack_whenGoingBack_thenLastRouteIsRemovedAndChangeIsReported() {
+        val home = route("home")
+        val conversation = route("conversation")
+        val backStack = mutableListOf<NavKey>(home, conversation)
+        val changes = mutableListOf<Triple<List<WireRoute>, List<WireRoute>, WireBackStackChange>>()
+        val controller = WireNavigationController(
+            backStack,
+            onBackStackChanged = { previous, current, change -> changes.add(Triple(previous, current, change)) },
+        )
+
+        assertTrue(controller.goBack())
+
+        assertEquals(listOf<NavKey>(home), backStack)
+        assertEquals(home, controller.currentRoute)
+        assertEquals(
+            listOf(Triple(listOf<WireRoute>(home, conversation), listOf<WireRoute>(home), WireBackStackChange.BACK)),
+            changes,
+        )
+    }
+
+    @Test
+    fun givenOnlyStartRoute_whenGoingBackAllowingEmpty_thenStackIsEmpty() {
+        val controller = WireNavigationController(mutableListOf<NavKey>(route("home")))
+
+        assertTrue(controller.goBack(allowEmpty = true))
+        assertTrue(controller.routes.isEmpty())
+        assertFalse(controller.goBack())
+        assertFalse(controller.goBack(allowEmpty = true))
+    }
+
+    @Test
     fun givenOnlyStartRoute_whenGoingBack_thenStartRouteIsRetained() {
         val controller = WireNavigationController(mutableListOf<NavKey>(route("home")))
 


### PR DESCRIPTION
This PR was manually cherry-picked based on the following PR:
 - #5267

Original PR description:

-----

<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28606
<!--jira-description-action-hidden-marker-end-->


### Issues

Navigation crashes on Android below 15 with `NoSuchMethodError` in `WireNavigationController.goBack()`. To reproduce, open a conversation and navigate back.

### Causes

Three back stack operations compile to `java.util.List.removeLast()`, which is only available from Android 15 (API 35): ordinary back navigation, removing the current flow, and removing consecutive entries of the same route.

### Solutions

Replace all three calls with `removeAt(lastIndex)` to preserve the existing back stack behavior on older Android versions. Enable Android host tests for the navigation module and add coverage for popping a conversation, reporting the stack change, and allowing an empty stack.

### Testing

All 51 navigation module tests pass, including the existing reducer tests for removing a flow and consecutive routes. Compiled Android bytecode confirms that all three affected calls now use `List.remove(int)`.

#### How to Test

Device verification is pending. Run the following scenarios on Android 14 and one older supported Android version, then perform a regression smoke test on Android 15 or newer.

- [ ] **Conversation back navigation:** Open a conversation and return using both the toolbar back arrow and the system back gesture/button. The conversation list should appear without a crash.
- [ ] **Multiple back stack entries:** Navigate through conversation details, a user profile, and settings as applicable. Go back through each screen. Each action should return to the preceding screen without crashing or skipping entries.
- [ ] **Group creation:** Complete the new-group flow and confirm that the created conversation opens without crashing. Navigate back and verify that the completed creation steps are no longer on the back stack.
- [ ] **Team migration:** Complete the account-to-team migration flow. Verify that the completion screen appears without crashing and the completed migration steps are removed from the back stack.
- [ ] **Cells recycle bin:** Open a deleted folder in the recycle bin and restore an item through the flow that requires restoring its parent folder. Verify that navigation returns to the recycle bin root without crashing. Going back should not reopen folder screens removed from the back stack.



[WPB-28606]: https://wearezeta.atlassian.net/browse/WPB-28606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ