### PR TITLE
fix: crash when showing location (WPB-28203)

### DIFF
--- a/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
+++ b/app/src/main/kotlin/com/wire/android/util/CommonIntentUtil.kt
@@ -21,8 +21,10 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.core.net.toUri
 import com.wire.android.BuildConfig
+import com.wire.android.R
 import com.wire.android.appLogger
 
 // geo intent url scheme
@@ -31,6 +33,7 @@ internal const val GEO_INTENT_URL = "geo:0,0?q=%f,%f"
 /**
  * Launches a geo intent with the given latitude and longitude.
  * If no app/activity can be found to handle the [GEO_INTENT_URL], a [fallbackUrl] is used.
+ * Shows a toast if neither intent can be handled.
  */
 fun launchGeoIntent(
     latitude: Float,
@@ -45,7 +48,12 @@ fun launchGeoIntent(
         context.startActivity(Intent(Intent.ACTION_VIEW, geoStringUrl.toString().toUri()))
     } catch (e: ActivityNotFoundException) {
         appLogger.e("No activity found to handle geo intent, fallback to url", e)
-        context.startActivity(Intent(Intent.ACTION_VIEW, fallbackUrl.toUri()))
+        try {
+            context.startActivity(Intent(Intent.ACTION_VIEW, fallbackUrl.toUri()))
+        } catch (fallbackException: ActivityNotFoundException) {
+            appLogger.e("No activity found to handle location fallback url", fallbackException)
+            Toast.makeText(context, R.string.label_no_application_found_open_location, Toast.LENGTH_SHORT).show()
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1761,6 +1761,7 @@ In group conversations, the group admin can overwrite this setting.</string>
     <string name="location_app_permission_dialog_body">Allow Wire to access your device location to send your location.</string>
     <string name="location_loading_label">Please wait...</string>
     <string name="location_could_not_be_shared">Location could not be shared</string>
+    <string name="label_no_application_found_open_location">No application found to open location</string>
     <!-- Asset Preview -->
     <string name="remove_asset_description">Remove asset</string>
     <string name="asset_attention_description">Asset attention</string>

--- a/app/src/test/kotlin/com/wire/android/util/CommonIntentUtilTest.kt
+++ b/app/src/test/kotlin/com/wire/android/util/CommonIntentUtilTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Wire
+ * Copyright (C) 2026 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ */
+package com.wire.android.util
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.widget.Toast
+import androidx.test.core.app.ApplicationProvider
+import com.wire.android.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = Application::class)
+class CommonIntentUtilTest {
+
+    @Test
+    fun `given a geo handler when opening location then no fallback or toast is used`() {
+        val context = LocationIntentContext(failedLaunches = 0)
+
+        openLocation(context)
+
+        assertEquals(1, context.launchedIntents.size)
+        assertEquals(Intent.ACTION_VIEW, context.launchedIntents.single().action)
+        assertEquals("geo", context.launchedIntents.single().data?.scheme)
+        assertNull(ShadowToast.getLatestToast())
+    }
+
+    @Test
+    fun `given only a browser handler when opening location then fallback opens without a toast`() {
+        val context = LocationIntentContext(failedLaunches = 1)
+
+        openLocation(context)
+
+        assertLocationLaunchOrder(context)
+        assertNull(ShadowToast.getLatestToast())
+    }
+
+    @Test
+    fun `given no handlers when opening location then a short toast is shown without crashing`() {
+        val context = LocationIntentContext(failedLaunches = 2)
+
+        openLocation(context)
+
+        assertLocationLaunchOrder(context)
+        assertEquals(1, ShadowToast.shownToastCount())
+        assertEquals(
+            context.getString(R.string.label_no_application_found_open_location),
+            ShadowToast.getTextOfLatestToast()
+        )
+        assertEquals(Toast.LENGTH_SHORT, ShadowToast.getLatestToast().duration)
+    }
+
+    private fun openLocation(context: Context) {
+        launchGeoIntent(52.5f, 13.4f, "Berlin", FALLBACK_URL, context)
+    }
+
+    private fun assertLocationLaunchOrder(context: LocationIntentContext) {
+        assertEquals(listOf(Intent.ACTION_VIEW, Intent.ACTION_VIEW), context.launchedIntents.map { it.action })
+        assertEquals("geo", context.launchedIntents.first().data?.scheme)
+        assertEquals(FALLBACK_URL, context.launchedIntents.last().data.toString())
+    }
+
+    private class LocationIntentContext(
+        private val failedLaunches: Int
+    ) : ContextWrapper(ApplicationProvider.getApplicationContext<Application>()) {
+        val launchedIntents = mutableListOf<Intent>()
+
+        override fun startActivity(intent: Intent) {
+            launchedIntents.add(intent)
+            if (launchedIntents.size <= failedLaunches) {
+                throw ActivityNotFoundException()
+            }
+        }
+    }
+
+    private companion object {
+        const val FALLBACK_URL = "https://maps.google.com/maps?z=16&q=loc:52.5+13.4"
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->
https://wearezeta.atlassian.net/browse/WPB-28203
<!--jira-description-action-hidden-marker-end-->
https://wearezeta.atlassian.net/browse/WPB-28203
----

# What's new in this PR?

### Issues

Crash when trying to open location viewer when no applications can handle it.

### Causes (Optional)

ActivityNotFoundException not handled on the last startActivity call.

### Solutions

Handle ActivityNotFound exception on all startActivity calls.